### PR TITLE
fix: get correct mime types on windows for cdn proxy.

### DIFF
--- a/solara/server/cdn_helper.py
+++ b/solara/server/cdn_helper.py
@@ -52,9 +52,9 @@ def get_data(base_cache_dir: pathlib.Path, path):
         raise Exception(f"Could not load URL: {url}")
 
 
-def get_path(base_cache_dir: pathlib.Path, path):
+def get_path(base_cache_dir: pathlib.Path, path) -> pathlib.Path:
 
-    parts = path.split("/")
+    parts = path.replace("\\", "/").split("/")
     store_path = path if len(parts) != 1 else pathlib.Path(path) / "__main"
     cache_path = base_cache_dir / store_path
 

--- a/solara/server/cdn_helper.py
+++ b/solara/server/cdn_helper.py
@@ -36,7 +36,7 @@ def get_cdn_url(path):
 
 def get_data(base_cache_dir: pathlib.Path, path):
     parts = path.replace("\\", "/").split("/")
-    store_path = path if len(parts) != 1 else pathlib.Path(path) / "__main"
+    store_path = path if len(parts) != 1 else pathlib.Path(path) / "__main.js"
 
     content = get_from_cache(base_cache_dir, store_path)
     if content:
@@ -55,7 +55,7 @@ def get_data(base_cache_dir: pathlib.Path, path):
 def get_path(base_cache_dir: pathlib.Path, path) -> pathlib.Path:
 
     parts = path.replace("\\", "/").split("/")
-    store_path = path if len(parts) != 1 else pathlib.Path(path) / "__main"
+    store_path = path if len(parts) != 1 else pathlib.Path(path) / "__main.js"
     cache_path = base_cache_dir / store_path
 
     if cache_path.exists():

--- a/solara/server/starlette.py
+++ b/solara/server/starlette.py
@@ -6,11 +6,9 @@ from typing import List, Union, cast
 from uuid import uuid4
 
 import anyio
-import solara
 import starlette.websockets
 import uvicorn.server
 import websockets.legacy.http
-from solara.server.threaded import ServerBase
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.gzip import GZipMiddleware
@@ -18,6 +16,9 @@ from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse
 from starlette.routing import Mount, Route, WebSocketRoute
 from starlette.staticfiles import StaticFiles
+
+import solara
+from solara.server.threaded import ServerBase
 
 from . import app as appmod
 from . import server, settings, telemetry, websocket
@@ -257,7 +258,7 @@ class StaticAssets(StaticFiles):
 
 class StaticCdn(StaticFiles):
     def lookup_path(self, path: str) -> typing.Tuple[str, typing.Optional[os.stat_result]]:
-        full_path = get_path(settings.assets.proxy_cache_dir, path)
+        full_path = str(get_path(settings.assets.proxy_cache_dir, path))
         return full_path, os.stat(full_path)
 
 

--- a/tests/unit/cdn_helper_test.py
+++ b/tests/unit/cdn_helper_test.py
@@ -1,7 +1,8 @@
 import hashlib
 import os
+from pathlib import Path
 
-from solara.server.cdn_helper import get_cdn_url, get_data, get_from_cache, put_in_cache
+from solara.server.cdn_helper import get_cdn_url, get_data, get_from_cache, put_in_cache, get_path
 
 
 def norm(path):
@@ -32,6 +33,11 @@ def test_cache(tmp_path_factory):
 def test_cdn_url():
     assert get_cdn_url(path1) == f"https://cdn.jsdelivr.net/npm/{path1}".replace("\\", "/")
     assert get_cdn_url(path2) == f"https://cdn.jsdelivr.net/npm/{path2}".replace("\\", "/")
+
+
+def test_get_path(tmpdir):
+    full_path = get_path(Path(tmpdir), path1)
+    assert str(full_path).endswith("vue-grid-layout.min.js")
 
 
 def test_get_data(tmp_path_factory):


### PR DESCRIPTION
Because on windows we cached to a file ending in /path.css/__main The mime type was not guessed correctly.

Fixes https://github.com/widgetti/solara/issues/36