### PR TITLE
feat: use_reactive as alternative for use_state

### DIFF
--- a/solara/__init__.py
+++ b/solara/__init__.py
@@ -14,6 +14,10 @@ def _using_solara_server():
     return False
 
 
+from typing import TypeVar, Union
+from solara.lab import Reactive
+
+
 # isort: skip_file
 from reacton import (
     component,
@@ -40,6 +44,8 @@ from . import util
 
 # flake8: noqa: F402
 from .datatypes import *
+
+Value = Union[T, Reactive[T]]
 from .hooks import *
 from .cache import memoize
 from . import cache
@@ -48,6 +54,31 @@ from .components import *
 from .routing import use_route, use_router, use_route_level, find_route, use_pathname, resolve_path
 from .autorouting import generate_routes, generate_routes_directory, RenderPage, RoutingProvider, DefaultLayout
 from .checks import check_jupyter
+
+
+def get(v: Value[T]) -> T:
+    """Get the value of a `Reactive` or return the value if it is a normal value"""
+    if isinstance(v, Reactive):
+        return v.value
+    return v
+
+
+def set(v: Value[T], value: T) -> None:
+    """Set the value of a `Reactive` value or do nothing if it is a normal value"""
+    if isinstance(v, Reactive):
+        v.value = value
+
+
+def use_reactive(initial_value: T) -> Reactive[T]:
+    """A reactive variable that can be used in a component."""
+
+    def create():
+        return Reactive(initial_value)
+
+    reactive_value = use_memo(create, dependencies=[])
+    reactive_value.use()
+
+    return reactive_value
 
 
 def display(*objs, **kwargs):

--- a/solara/components/input.py
+++ b/solara/components/input.py
@@ -35,7 +35,7 @@ def use_change(el: reacton.core.Element, on_value: Callable[[Any], Any], enabled
 @solara.component
 def InputText(
     label: str,
-    value: str = "",
+    value: solara.Value[str] = "",
     on_value: Callable[[str], None] = None,
     disabled: bool = False,
     password: bool = False,
@@ -53,16 +53,18 @@ def InputText(
     * `continuous_update`: Whether to call the `on_value` callback on every change or only when the input loses focus or the enter key is pressed.
     """
 
-    def set_value_cast(value):
+    def set_value_cast(new_value):
+        solara.set(value, str(new_value))
         if on_value is None:
             return
-        on_value(str(value))
+        on_value(str(new_value))
 
-    def on_v_model(value):
+    def on_v_model(new_value):
         if continuous_update:
             set_value_cast(value)
+            solara.set(value, str(new_value))
 
-    text_field = v.TextField(v_model=value, on_v_model=on_v_model, label=label, disabled=disabled, type="password" if password else None)
+    text_field = v.TextField(v_model=solara.get(value), on_v_model=on_v_model, label=label, disabled=disabled, type="password" if password else None)
     use_change(text_field, set_value_cast, enabled=not continuous_update)
     return text_field
 

--- a/solara/components/slider.py
+++ b/solara/components/slider.py
@@ -16,7 +16,7 @@ T = TypeVar("T")
 @solara.value_component(int)
 def SliderInt(
     label: str,
-    value: int = 0,
+    value: solara.Value[int] = 0,
     min: int = 0,
     max: int = 10,
     step: int = 1,
@@ -38,13 +38,14 @@ def SliderInt(
     * `disabled`: Whether the slider is disabled.
     """
 
-    def set_value_cast(value):
+    def set_value_cast(new_value):
+        solara.set(value, int(new_value))
         if on_value is None:
             return
-        on_value(int(value))
+        on_value(int(new_value))
 
     return rv.Slider(
-        v_model=value,
+        v_model=solara.get(value),
         on_v_model=set_value_cast,
         label=label,
         min=min,

--- a/solara/website/pages/docs/content/03-quickstart.md
+++ b/solara/website/pages/docs/content/03-quickstart.md
@@ -25,20 +25,20 @@ import solara
 
 @solara.component
 def Page():
-    sentence, set_sentence = solara.use_state("Solara makes our team more productive.")
-    word_limit, set_word_limit = solara.use_state(10)
-    word_count = len(sentence.split())
+    sentence = solara.use_reactive("Solara makes our team more productive.")
+    word_limit = solara.use_reactive(10)
+    word_count = len(sentence.value.split())
 
-    solara.SliderInt("Word limit", value=word_limit, on_value=set_word_limit, min=2, max=20)
-    solara.InputText(label="Your sentence", value=sentence, on_value=set_sentence,
-                        continuous_update=True)
+    solara.SliderInt("Word limit", value=word_limit, min=2, max=20)
+    solara.InputText(label="Your sentence", value=sentence, continuous_update=True)
 
-    if word_count >= int(word_limit):
-        solara.Error(f"With {word_count} words, you passed the word limit of {word_limit}.")
-    elif word_count >= int(0.8 * word_limit):
-        solara.Warning(f"With {word_count} words, you are close to the word limit of {word_limit}.")
+    if word_count >= int(word_limit.value):
+        solara.Error(f"With {word_count} words, you passed the word limit of {word_limit.value}.")
+    elif word_count >= int(0.8 * word_limit.value):
+        solara.Warning(f"With {word_count} words, you are close to the word limit of {word_limit.value}.")
     else:
         solara.Success("Great short writing!")
+
 
 # In a Jupyter notebook, put this at the end of your cell:
 # Page()


### PR DESCRIPTION
Many people have trouble digesting `use_state`. This could be an alternative way of using state in solara. Needs user testing.