### PR TITLE
feat: Allow FileBrowser to show folders first

### DIFF
--- a/solara/components/file_browser.py
+++ b/solara/components/file_browser.py
@@ -18,7 +18,7 @@ def list_dir(path, filter: Callable[[Path], bool] = lambda x: True, folders_firs
         return {"name": n, "is_file": is_file, "size": humanize.naturalsize(os.stat(full_path).st_size) if is_file else None}
 
     def keyfunc(item):
-        if item['is_file']:
+        if item["is_file"]:
             return str(int(folders_first)) + item["name"].lower()
         else:
             return str(int(not folders_first)) + item["name"].lower()

--- a/solara/components/file_browser.py
+++ b/solara/components/file_browser.py
@@ -11,14 +11,21 @@ import solara
 from solara.components import Div
 
 
-def list_dir(path, filter: Callable[[Path], bool] = lambda x: True):
+def list_dir(path, filter: Callable[[Path], bool] = lambda x: True, folders_first: bool = False) -> List[dict]:
     def mk_item(n):
         full_path = join(path, n)
         is_file = isfile(full_path)
         return {"name": n, "is_file": is_file, "size": humanize.naturalsize(os.stat(full_path).st_size) if is_file else None}
 
+    def keyfunc(item):
+        if item['is_file']:
+            return str(int(folders_first)) + item["name"].lower()
+        else:
+            return str(int(not folders_first)) + item["name"].lower()
+
     files = [mk_item(k) for k in os.listdir(path) if not k.startswith(".") if filter(Path(path) / k)]
-    sorted_files = sorted(files, key=lambda item: ("0" if item["is_file"] else "1") + item["name"].lower())
+    sorted_files = sorted(files, key=keyfunc)
+
     return sorted_files
 
 
@@ -54,6 +61,7 @@ def FileBrowser(
     on_path_select: Callable[[Optional[Path]], None] = None,
     on_file_open: Callable[[Path], None] = None,
     filter: Callable[[Path], bool] = lambda x: True,
+    folders_first: bool = False,
     on_file_name: Callable[[str], None] = None,
     start_directory=None,
     can_select=False,
@@ -78,6 +86,7 @@ def FileBrowser(
      * `on_path_select`: Depends on mode, see above.
      * `on_file_open`: Depends on mode, see above.
      * `filter`: A function that takes a `Path` and returns `True` if the file/directory should be shown.
+     * `folders_first`: If `True` folders are shown before files. Default: `False`.
      * `on_file_name`: (deprecated) Use on_file_open instead.
      * `start_directory`: (deprecated) Use directory instead.
     """
@@ -160,7 +169,7 @@ def FileBrowser(
     with Div(class_="solara-file-browser") as main:
         Div(children=[current_dir])
         FileListWidget.element(
-            files=[{"name": "..", "is_file": False}] + list_dir(current_dir, filter=filter),
+            files=[{"name": "..", "is_file": False}] + list_dir(current_dir, filter=filter, folders_first=folders_first),
             selected=selected,
             clicked=selected,
             on_clicked=on_click,

--- a/solara/components/file_browser.py
+++ b/solara/components/file_browser.py
@@ -11,7 +11,7 @@ import solara
 from solara.components import Div
 
 
-def list_dir(path, filter=filter):
+def list_dir(path, filter: Callable[[Path], bool] = lambda x: True):
     def mk_item(n):
         full_path = join(path, n)
         is_file = isfile(full_path)

--- a/solara/components/file_browser.py
+++ b/solara/components/file_browser.py
@@ -11,20 +11,14 @@ import solara
 from solara.components import Div
 
 
-def list_dir(path, filter: Callable[[Path], bool] = lambda x: True, folders_first: bool = False) -> List[dict]:
+def list_dir(path, filter: Callable[[Path], bool] = lambda x: True, directory_first: bool = False) -> List[dict]:
     def mk_item(n):
         full_path = join(path, n)
         is_file = isfile(full_path)
         return {"name": n, "is_file": is_file, "size": humanize.naturalsize(os.stat(full_path).st_size) if is_file else None}
 
-    def keyfunc(item):
-        if item["is_file"]:
-            return str(int(folders_first)) + item["name"].lower()
-        else:
-            return str(int(not folders_first)) + item["name"].lower()
-
     files = [mk_item(k) for k in os.listdir(path) if not k.startswith(".") if filter(Path(path) / k)]
-    sorted_files = sorted(files, key=keyfunc)
+    sorted_files = sorted(files, key=lambda item: (item["is_file"] == directory_first, item["name"].lower()))
 
     return sorted_files
 
@@ -61,7 +55,7 @@ def FileBrowser(
     on_path_select: Callable[[Optional[Path]], None] = None,
     on_file_open: Callable[[Path], None] = None,
     filter: Callable[[Path], bool] = lambda x: True,
-    folders_first: bool = False,
+    directory_first: bool = False,
     on_file_name: Callable[[str], None] = None,
     start_directory=None,
     can_select=False,
@@ -86,7 +80,7 @@ def FileBrowser(
      * `on_path_select`: Depends on mode, see above.
      * `on_file_open`: Depends on mode, see above.
      * `filter`: A function that takes a `Path` and returns `True` if the file/directory should be shown.
-     * `folders_first`: If `True` folders are shown before files. Default: `False`.
+     * `directory_first`: If `True` directories are shown before files. Default: `False`.
      * `on_file_name`: (deprecated) Use on_file_open instead.
      * `start_directory`: (deprecated) Use directory instead.
     """
@@ -169,7 +163,7 @@ def FileBrowser(
     with Div(class_="solara-file-browser") as main:
         Div(children=[current_dir])
         FileListWidget.element(
-            files=[{"name": "..", "is_file": False}] + list_dir(current_dir, filter=filter, folders_first=folders_first),
+            files=[{"name": "..", "is_file": False}] + list_dir(current_dir, filter=filter, directory_first=directory_first),
             selected=selected,
             clicked=selected,
             on_clicked=on_click,


### PR DESCRIPTION
This PR adds a boolean `folders_first` to the `FileBrowser`, which makes folders appear first in the sorting.

Also fixes a bug where the default filter for `list_dir` was the default built-in `filter`