### PR TITLE
fix proplot import

### DIFF
--- a/solara/server/patch.py
+++ b/solara/server/patch.py
@@ -64,6 +64,9 @@ class FakeIPython:
                 # TODO: should we remove it from the list?
                 pass
 
+    def magic(self, *args):
+        # proplot requires this
+        pass
 
 def kernel_instance_dispatch(cls, *args, **kwargs):
     context = app.get_current_context()


### PR DESCRIPTION
`proplot` configures in inline plotting backend on import with ipython magic.
https://github.com/proplot-dev/proplot/blob/d44b25b39f3065d9f603d13416fa5b6c22feb1dd/proplot/config.py#L361


AFAIK the configuration settings does not affect anything when using proplot with solara, but solara's  `FakeIPython` needs to have a fake `magic` method for proplot to be imported. 

Meanwhile, users can monkey patch `FakeIPython`

```python
from solara.server.patch import FakeIPython
FakeIPython.magic = lambda *args: None
```