### PR TITLE
docs: fix modify script code suggestion

### DIFF
--- a/solara/website/pages/docs/content/04-tutorial/20-web-app.md
+++ b/solara/website/pages/docs/content/04-tutorial/20-web-app.md
@@ -62,9 +62,9 @@ you do not share the number of clicks with other people.
 Lets modify the script a little bit, possibly in this way:
 
 ```diff
--    return solara.Button(label=f"Clicked: {clicks}", on_click=on_click, color=color)
-+    label = "Not clicked yet" if clicks == 0 else f"Clicked: {clicks}"
-+    return solara.Button(label=label, on_click=on_click, color=color)
+-    solara.Button(label=f"Clicked: {clicks}", on_click=increment, color=color)
++    label = "Not clicked yet" if clicks.value == 0 else f"Clicked: {clicks}"
++    solara.Button(label=label, on_click=increment, color=color)
 ```
 
 If we save the script, Solara will automatically reload your script and update


### PR DESCRIPTION
Currently, the code suggestion for the modify script is incorrect. The initial `sol.py` does not use a return a statement. It also use `increment` instead of `on_click` as the event handler. Also, to check for `clicks == 0`, we need to use the state value `clicks.value == 0` instead. Otherwise, nothing happens. I assume this is just a mismatch due to a recent API change.