### PR TITLE
Allow test host to be customized

### DIFF
--- a/solara/__main__.py
+++ b/solara/__main__.py
@@ -27,9 +27,6 @@ except ImportError:
 
 
 HERE = Path(__file__).parent
-HOST_DEFAULT = os.environ.get("HOST", "localhost")
-if "arm64-apple-darwin" in HOST_DEFAULT:  # conda activate script
-    HOST_DEFAULT = "localhost"
 
 LOGGING_CONFIG: dict = {
     "version": 1,
@@ -121,7 +118,11 @@ def cli():
 
 @cli.command()
 @click.option("--port", default=int(os.environ.get("PORT", 8765)))
-@click.option("--host", default=HOST_DEFAULT)
+@click.option(
+    "--host",
+    default=settings.main.host,
+    help="Host to listen on. Defaults to the $HOST environment or $SOLARA_HOST when available or localhost when not given.",
+)
 @click.option(
     "--dev/--no-dev",
     default=False,
@@ -419,7 +420,7 @@ def run(
 @cli.command()
 @click.argument("app")
 @click.option("--port", default=int(os.environ.get("PORT", 8765)))
-@click.option("--host", default=HOST_DEFAULT)
+@click.option("--host", default=settings.main.host)
 @click.option(
     "--headed/--no-headed",
     is_flag=True,

--- a/solara/server/settings.py
+++ b/solara/server/settings.py
@@ -1,3 +1,4 @@
+import os
 import site
 import sys
 import uuid
@@ -118,6 +119,11 @@ class OAuth(pydantic.BaseSettings):
         env_file = ".env"
 
 
+HOST_DEFAULT = os.environ.get("HOST", "localhost")
+if "arm64-apple-darwin" in HOST_DEFAULT:  # conda activate script
+    HOST_DEFAULT = "localhost"
+
+
 class MainSettings(pydantic.BaseSettings):
     use_pdb: bool = False
     mode: str = "production"
@@ -126,6 +132,7 @@ class MainSettings(pydantic.BaseSettings):
     root_path: Optional[str] = None  # e.g. /myapp/
     base_url: str = ""  # e.g. https://myapp.solara.run/myapp/
     platform: str = sys.platform
+    host = HOST_DEFAULT
 
     class Config:
         env_prefix = "solara_"

--- a/solara/test/pytest_plugin.py
+++ b/solara/test/pytest_plugin.py
@@ -32,13 +32,14 @@ if typing.TYPE_CHECKING:
 logger = logging.getLogger("solara.pytest_plugin")
 
 TEST_PORT = int(os.environ.get("PORT", "18765")) + 100  # do not interfere with the solara integration tests
+TEST_HOST = os.environ.get("SOLARA_TEST_HOST", "localhost")
 TIMEOUT = float(os.environ.get("SOLARA_PW_TIMEOUT", "18"))
 
 
 @pytest.fixture(scope="session")
 def solara_server(request):
     global TEST_PORT
-    webserver = ServerStarlette(TEST_PORT)
+    webserver = ServerStarlette(TEST_PORT, TEST_HOST)
     TEST_PORT += 1
 
     try:
@@ -265,7 +266,7 @@ def voila_server(notebook_path):
     port = TEST_PORT
     TEST_PORT += 1
     write_notebook(["print('hello')"], notebook_path)
-    server = ServerVoila(notebook_path, port)
+    server = ServerVoila(notebook_path, port, TEST_HOST)
     try:
         server.serve_threaded()
         server.wait_until_serving()
@@ -280,7 +281,7 @@ def jupyter_server(notebook_path):
     port = TEST_PORT
     TEST_PORT += 1
     write_notebook(["print('hello')"], notebook_path)
-    server = ServerJupyter(notebook_path, port)
+    server = ServerJupyter(notebook_path, port, TEST_HOST)
     try:
         server.serve_threaded()
         server.wait_until_serving()

--- a/solara/website/pages/docs/content/10-howto/50-testing.md
+++ b/solara/website/pages/docs/content/10-howto/50-testing.md
@@ -131,3 +131,13 @@ After inspecting and approving the screenshots, you can copy them to the `solara
 Visual testing with solara is based on [Playwright for Python](https://playwright.dev/python/), which provides a `page` fixture. However, this fixture will make a new page for each test, which is not what we want. Therefore, we provide a `page_session` fixture that will reuse the same page for all tests. This is important because it will make the tests faster.
 
 By following these recommendations and guidelines, you can efficiently test your Solara applications and ensure a smooth developer experience.
+
+# Configuration
+
+## Changing the Hostname
+
+To configure the hostname the socket is bound to when starting the test server, use the `HOST` or `SOLARA_HOST` environment variable (e.g. `SOLARA_HOST=0.0.0.0`). This hostname is also used for the jupyter server and voila. Alternatively the `--solara-host` argument can be passed on the command line for pytest.
+
+## Changing the Port
+
+To configure the ports the socket is bound to when starting the test servers, use the `PORT` environment variable (e.g. `PORT=18865`). This port and subsequent port will be used for solara-server, jupyter-server and voila. Alternatively the `--solara-port` argument can be passed on the command line for pytest for the solara server, and `--jupyter-port` and `--voila-port` for the ports of jupyter server and voila respectively.


### PR DESCRIPTION
I ran into the same issue as https://github.com/widgetti/solara/issues/112 but when running solara though the pytest framework which means I wasn't able to set the host to 0.0.0.0. This PR adds a way to customize the host with a new environment variable. I thought HOST would be too generic so made it SOLARA_TEST_HOST. I wonder if PORT should be SOLARA_TEST_PORT too?