### PR TITLE
feat: FileDownload filename as callable

### DIFF
--- a/solara/components/file_download.py
+++ b/solara/components/file_download.py
@@ -20,7 +20,7 @@ class FileDownloadWidget(vy.VuetifyTemplate):
 @solara.component
 def FileDownload(
     data: Union[str, bytes, BinaryIO, Callable[[], Union[str, bytes, BinaryIO]]],
-    filename: Optional[str] = None,
+    filename: Union[str, Callable[[], str], None] = None,
     label: Optional[str] = None,
     icon_name: Optional[str] = "mdi-cloud-download-outline",
     close_file: bool = True,
@@ -180,11 +180,15 @@ def FileDownload(
         return None
 
     bytes_result: solara.Result[Optional[bytes]] = solara.use_thread(get_data, dependencies=[request_download, data])
+
+    if callable(filename):
+        filename = filename()
     if filename is None and hasattr(data, "name"):
         try:
             filename = Path(data.name).name  # type: ignore
         except Exception:
             pass
+
     filename = filename or "solara-download.dat"
     label = label or ("Download: " + filename)
     FileDownloadWidget.element(


### PR DESCRIPTION
I find myself doing something like this a lot: 

```python
import solara
import pandas as pd
import numpy as np

columns = list("abcdefghij")
df = pd.DataFrame({k: np.random.rand(25) for k in columns})

@solara.component
def Page():
    col, set_col = solara.use_state(columns[0])
    col_fname, set_col_fame = solara.use_state(f"mydata_{columns[0]}.csv")

    def select_cb(value):
        set_col(value)
        set_col_fame(f"mydata_{value}.csv")

    solara.Select(label="choose column", values=columns, value=col, on_value=select_cb)

    def download_cb():
        return df[col].to_csv()

    solara.FileDownload(download_cb, label="download column", filename=col_fname)
```

if `filename` would accept a callable, this use case could be shortened to:

```python
@solara.component
def Page():
    col, set_col = solara.use_state(columns[0])

    solara.Select(label="choose column", values=columns, value=col, on_value=set_col)

    def download_cb():
        return df[col].to_csv()

    solara.FileDownload(download_cb, label="download column", filename=lambda: f"mydata_{col}.csv")
```
