### PR TITLE
feat: when the proxy cache dir cannot be written to, disable the proxy

### DIFF
--- a/solara/server/flask.py
+++ b/solara/server/flask.py
@@ -187,14 +187,16 @@ def serve_static(path):
     return send_from_directory(server.solara_static, path)
 
 
-@blueprint.route(f"/{cdn_helper.cdn_url_path}/<path:path>")
-def cdn(path):
-    if not allowed():
-        abort(401)
-    cache_directory = settings.assets.proxy_cache_dir
-    content = cdn_helper.get_data(Path(cache_directory), path)
-    mime = mimetypes.guess_type(path)
-    return flask.Response(content, mimetype=mime[0])
+if settings.assets:
+
+    @blueprint.route(f"/{cdn_helper.cdn_url_path}/<path:path>")
+    def cdn(path):
+        if not allowed():
+            abort(401)
+        cache_directory = settings.assets.proxy_cache_dir
+        content = cdn_helper.get_data(Path(cache_directory), path)
+        mime = mimetypes.guess_type(path)
+        return flask.Response(content, mimetype=mime[0])
 
 
 @blueprint.route("/", defaults={"path": ""})

--- a/solara/server/settings.py
+++ b/solara/server/settings.py
@@ -1,10 +1,11 @@
 import os
+import re
 import site
 import sys
 import uuid
+import warnings
 from enum import Enum
 from pathlib import Path
-import re
 from typing import Optional
 
 import pydantic
@@ -152,7 +153,18 @@ assets = Assets()
 oauth = OAuth()
 session = Session()
 
-assets.proxy_cache_dir.mkdir(exist_ok=True, parents=True)
+if assets.proxy:
+    try:
+        assets.proxy_cache_dir.mkdir(exist_ok=True, parents=True)
+    except Exception as e:
+        assets.proxy = False
+        warnings.warn(
+            f"Could not create {assets.proxy_cache_dir} due to {e}. We will automatically disable the assets proxy for you. "
+            "If you want to disable this warning, set SOLARA_ASSETS_PROXY to False (e.g. export SOLARA_ASSETS_PROXY=false)."
+        )
+        # that's ok, the user probably doesn't have permission to create the directory
+        # in this case, we would need to install solara-assets?
+        pass
 
 if telemetry.server_user_id == "not_set":
     home = get_solara_home()

--- a/solara/server/starlette.py
+++ b/solara/server/starlette.py
@@ -381,7 +381,8 @@ routes = [
     Route("/", endpoint=root),
     Route("/{fullpath}", endpoint=root),
     Route("/_solara/api/close/{connection_id}", endpoint=close, methods=["POST"]),
-    Mount(f"/{cdn_url_path}", app=StaticCdn(directory=settings.assets.proxy_cache_dir)),
+    # only enable when the proxy is turned on, otherwise if the directory does not exists we will get an exception
+    *([Mount(f"/{cdn_url_path}", app=StaticCdn(directory=settings.assets.proxy_cache_dir))] if settings.assets.proxy else []),
     Mount(f"{prefix}/static/public", app=StaticPublic()),
     Mount(f"{prefix}/static/assets", app=StaticAssets()),
     Mount(f"{prefix}/static/nbextensions", app=StaticNbFiles()),


### PR DESCRIPTION
This will let solara work out of the box when the proxy cache dir is not writable, and will not require the user to manually disable the proxy. If the proxy is disabled, the cache dir will not be created and the no endpoint will be registered.

We also notify the user with a warning what happened and how to avoid it.
```
$ solara run sol.py
/Users/maartenbreddels/github/widgetti/solara-copy/solara/server/settings.py:162: UserWarning: Could not create /..../share/solara/cdn due to ..... We will automatically disable the assets proxy for you. If you want to disable this warning, set SOLARA_ASSETS_PROXY to False (e.g. export SOLARA_ASSETS_PROXY=false).
  warnings.warn(
```