### PR TITLE
fix: module namespace when running as script was not set to __main__

### DIFF
--- a/solara/autorouting.py
+++ b/solara/autorouting.py
@@ -470,7 +470,7 @@ def generate_routes_directory(path: Path) -> List[solara.Route]:
     return routes
 
 
-def _generate_route_path(subpath: Path, layout=None, first=False, has_index=False) -> solara.Route:
+def _generate_route_path(subpath: Path, layout=None, first=False, has_index=False, initial_namespace={}) -> solara.Route:
     from .server import reload
 
     name = subpath.stem
@@ -496,7 +496,7 @@ def _generate_route_path(subpath: Path, layout=None, first=False, has_index=Fals
         children = generate_routes_directory(subpath)
     else:
         reload.reloader.watcher.add_file(subpath)
-        module = source_to_module(subpath)
+        module = source_to_module(subpath, initial_namespace=initial_namespace)
         children = getattr(module, "routes", children)
         children = fix_routes(children, subpath)
         module_layout = getattr(module, "Layout", module_layout)

--- a/solara/server/app.py
+++ b/solara/server/app.py
@@ -10,7 +10,6 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, cast
 
-import IPython.display
 import ipywidgets as widgets
 import reacton
 from ipywidgets import DOMWidget, Widget
@@ -85,11 +84,6 @@ class AppScript:
     def _execute(self):
         logger.info("Executing %s", self.name)
         app = None
-        local_scope = {
-            "display": IPython.display.display,
-            "__name__": "__main__",
-            "__file__": str(self.path),
-        }
         routes: Optional[List[solara.Route]] = None
 
         def add_path():
@@ -107,13 +101,14 @@ class AppScript:
         elif self.name.endswith(".py"):
             self.type = AppType.SCRIPT
             add_path()
-            local_scope["__name__"] = "__main__"
             # manually add the script to the watcher
             reload.reloader.watcher.add_file(self.path)
             self.directory = self.path.parent.resolve()
+            initial_namespace = {
+                "__name__": "__main__",
+            }
             with reload.reloader.watch():
-                routes = [solara.autorouting._generate_route_path(self.path, first=True)]
-
+                routes = [solara.autorouting._generate_route_path(self.path, first=True, initial_namespace=initial_namespace)]
         elif self.name.endswith(".ipynb"):
             self.type = AppType.NOTEBOOK
             add_path()


### PR DESCRIPTION
Fixes https://github.com/widgetti/solara/issues/208

We should only have to do this for a .py script run, and set `__name__`. I don't think we should do this for a notebook.