### PR TITLE
fix dev cookie on Safari

### DIFF
--- a/solara/server/server.py
+++ b/solara/server/server.py
@@ -36,6 +36,7 @@ cache_memory = solara.cache.Memory(max_items=128)
 def get_jinja_env(app_name: str) -> jinja2.Environment:
     jinja_loader = jinja2.FileSystemLoader(
         [
+            os.getenv('SOLARA_TEMPLATES_DIR') or 'templates',
             app.apps["__default__"].directory.parent / "templates",
             str(directory / "templates"),
         ]

--- a/solara/server/starlette.py
+++ b/solara/server/starlette.py
@@ -163,7 +163,6 @@ async def kernel_connection(ws: starlette.websockets.WebSocket):
         user = None
 
     if not session_id:
-        logger.error("not work for Safari")
         logger.error("no session cookie")
         await ws.close()
         return

--- a/solara/server/starlette.py
+++ b/solara/server/starlette.py
@@ -163,6 +163,7 @@ async def kernel_connection(ws: starlette.websockets.WebSocket):
         user = None
 
     if not session_id:
+        logger.error("not work for Safari")
         logger.error("no session cookie")
         await ws.close()
         return
@@ -259,7 +260,7 @@ async def root(request: Request, fullpath: str = ""):
     # however, samesite=none requires Secure https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
     # when hosted on the localhost domain we can always set the Secure flag
     # to allow samesite https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#restrict_access_to_cookies
-    if request.headers.get("x-forwarded-proto", "http") == "https" or request.base_url.hostname == "localhost":
+    if request.headers.get("x-forwarded-proto", "http") == "https":
         samesite = "none"
         secure = True
     response.set_cookie(


### PR DESCRIPTION
The behavior to set Secure=True when serving from localhost would cause failure to set cookie on Safari (tested on 17.0) and thus cause it hang on loading animation.

This could be an issue of Safari but pretty amount of developer who work on Mac would be prevented when they first try Solara on Mac if Safari was set as default browser.