### PR TITLE
add support for index.html customization

### DIFF
--- a/solara/server/server.py
+++ b/solara/server/server.py
@@ -36,6 +36,7 @@ cache_memory = solara.cache.Memory(max_items=128)
 def get_jinja_env(app_name: str) -> jinja2.Environment:
     jinja_loader = jinja2.FileSystemLoader(
         [
+            os.getenv('SOLARA_TEMPLATES_DIR') or 'templates',
             app.apps["__default__"].directory.parent / "templates",
             str(directory / "templates"),
         ]

--- a/solara/server/server.py
+++ b/solara/server/server.py
@@ -39,8 +39,8 @@ def get_jinja_env(app_name: str) -> jinja2.Environment:
     jinja_loader = jinja2.FileSystemLoader(
         template_dirs_from_env +
         [
-            '../templates',
             'templates',
+            '../templates',
             app.apps["__default__"].directory.parent / "templates",
             str(directory / "templates"),
         ]

--- a/solara/server/server.py
+++ b/solara/server/server.py
@@ -29,14 +29,18 @@ template_name = "index.html.j2"
 ipykernel_major = int(ipykernel.__version__.split(".")[0])
 ipywidgets_major = int(ipywidgets.__version__.split(".")[0])
 cache_memory = solara.cache.Memory(max_items=128)
-
+template_dir_env_name = 'SOLARA_TEMPLATES_DIR'
 # first look at the project directory, then the builtin solara directory
 
 
 def get_jinja_env(app_name: str) -> jinja2.Environment:
+    template_dir_from_env = os.getenv(template_dir_env_name)
+    template_dirs_from_env =  [template_dir_from_env] if template_dir_from_env else []
     jinja_loader = jinja2.FileSystemLoader(
+        template_dirs_from_env +
         [
-            os.getenv('SOLARA_TEMPLATES_DIR') or 'templates',
+            '../templates',
+            'templates',
             app.apps["__default__"].directory.parent / "templates",
             str(directory / "templates"),
         ]


### PR DESCRIPTION
It's very common that we would want to customize the index.html especially the <head> section since we actually can't actually customize it from application layer.

This PR would enable the developer to customize the index.html by providing their own `index.html.j2` in `os.getenv('SOLARA_TEMPLATES_DIR') or 'templates'`. The framework might not want to allow user to do all the customizations since there seems a lot of vue initiating logic in the template, if developer rewrote that, it will simply not work. But I feel it's still beneficial to have this, since this is the only way to resolve a real problem.

For my self, I am also imaging to use Solara as a mechnisim to render Python side components and handle the interaction between frondend/backend and one day I might really want to build the UI system entirely with my own React UI library wrapper (Matine for example), further work needed to make it possible but in concept seems the need is just to define the interface between the template and solara render function (to render things under an element in the template).