### PR TITLE
ci: fix support for anyio 4 typing

### DIFF
--- a/solara/server/starlette.py
+++ b/solara/server/starlette.py
@@ -89,7 +89,7 @@ class WebsocketWrapper(websocket.WebsocketWrapper):
             # version 3+
             fut = self.portal.start_task_soon(self.ws.receive)
         else:
-            fut = self.portal.spawn_task(self.ws.receive)
+            fut = self.portal.spawn_task(self.ws.receive)  # type: ignore
 
         message = await asyncio.wrap_future(fut)
         if "text" in message:


### PR DESCRIPTION
The function `spawn_task` was renamed to `start_task_soon` and
was deprecated. We added forward/backward compatibility for this.
However, now the deprecated function is removed in version 4, which
breaks the type checking.