### PR TITLE
fix: a hot reload could mix reactive variables from solara internal ones

### DIFF
--- a/packages/solara-enterprise/solara_enterprise/auth/__init__.py
+++ b/packages/solara-enterprise/solara_enterprise/auth/__init__.py
@@ -7,4 +7,7 @@ from .utils import get_login_url, get_logout_url
 
 __all__ = ["user", "get_login_url", "get_logout_url", "Avatar", "AvatarMenu"]
 
-user = Reactive(cast(Optional[Dict], None))
+# the current way of generating a key is based in the default value
+# which may collide after a hot reload, since solara itself is not reloaded
+# if we give a fixed key, we can avoid this
+user = Reactive(cast(Optional[Dict], None), key="solara-enterprise.auth.user")


### PR DESCRIPTION
This happens with the user reactive variable, which got a key like 'None:0'. After a hot reload, the counter for this type was reset, and a different reactive variable got the same key. The value for the user reactive variable was then a dict with the user values.