### PR TITLE
feat: warn user when modules can be loaded twice.

### DIFF
--- a/solara/server/app.py
+++ b/solara/server/app.py
@@ -98,6 +98,14 @@ class AppScript:
             # resolve the directory, because Path("file").parent.parent == "." != ".."
             self.directory = self.path.resolve()
             routes = solara.generate_routes_directory(self.path)
+
+            if any(name for name in sys.modules.keys() if name.startswith(self.name)):
+                logger.warn(
+                    f"Directory {self.name} is also used as a package. This can cause modules to be loaded twice, and might "
+                    "cause unexpected behavior. If you run solara from a different directory (e.g. the parent directory) you "
+                    "can avoid this ambiguity."
+                )
+
         elif self.name.endswith(".py"):
             self.type = AppType.SCRIPT
             add_path()


### PR DESCRIPTION
Solara by default assumes the name for `solara run <name>` is a directory. However, when the name is also a package, which imports module from the package, the package modules can be loaded twice. Solara will execute the python files in the directory, while Python will load the python files as modules from the package. This can leads to unexpected behavior, such as reactive variables existing twice.