### PR TITLE
POC: fix: make altair and vega work in colab

### DIFF
--- a/solara/widgets/vue/vegalite.vue
+++ b/solara/widgets/vue/vegalite.vue
@@ -54,6 +54,13 @@ module.exports = {
             });
         },
         async loadVega() {
+            // we need to remove the define function to avoid conflicts with requirejs
+            // which will do an early exit:
+            //   https://github.com/requirejs/requirejs/blob/898ff9e60eb6897500720151c0b488b8749fbe8d/require.js#L177
+            // the define function is added by on colab when widgets are loaded:
+            //   https://github.com/googlecolab/colab-cdn-widget-manager/blob/664b13da3289597966bfb5b7dd5e347233d48524/src/amd.ts#L81
+            const previousDefine = window.define;
+            delete window.define;
             await this.loadRequire();
             requirejs.undef("vega")
             requirejs.undef("vega-lite")
@@ -70,6 +77,8 @@ module.exports = {
             // pre load
             await new Promise((resolve, reject) => {
                 require(['vega', 'vega-lite', 'vega-embed'], () => {
+                    // should we restore the define function?
+                    window.define = previousDefine;
                     resolve()
                 }, reject)
             });


### PR DESCRIPTION
This might break classic notebook where requirejs is already available. Proof of concept fix.


The following code on colab works:
```python
import altair as alt
import pandas as pd
from vega_datasets import data

import IPython.display
# make solara use a real cdn, since the solara cdn proxy is not available
display(IPython.display.Javascript("solara_cdn = 'https://cdn.jsdelivr.net/npm/'"))

import solara

# title = "Altair visualization"
source = data.seattle_weather()

selected_datum = solara.reactive(None)


@solara.component
def Page():
    def on_click(datum):
        selected_datum.value = datum

    chart = (
        alt.Chart(source, title="Daily Max Temperatures (C) in Seattle, WA")
        .mark_rect()
        .encode(
            alt.X("date(date):O"),
            alt.Y("month(date):O"),
            alt.Color("max(temp_max)"),
            tooltip=[
                alt.Tooltip("monthdate(date)", title="Date"),
                alt.Tooltip("max(temp_max)", title="Max Temp"),
            ],
        )
        .configure_view(step=13, strokeWidth=0)
        .configure_axis(domain=False)
    )
    with solara.Card("Annual Weather Heatmap for Seattle, WA"):
        solara.AltairChart(chart, on_click=on_click)
        df = source
        if selected_datum.value:
            month_date = selected_datum.value["monthdate_date_end"]
            dt = pd.to_datetime(month_date)
            df = df[(df["date"].dt.month == dt.month) & (df["date"].dt.day == dt.day)]
            solara.Markdown(f"Day of year: {dt.month_name()} - {dt.day}")
            solara.Button("Clear selection", on_click=lambda: selected_datum.set(None))
            solara.display(df)

            with solara.Details("Click data"):
                solara.Markdown(
                    f"""
                Click data:

                ```
                {selected_datum.value}
                ```
                """
                )
        else:
            solara.Markdown("Click on the chart to see data for a specific day")
Page()
```