### PR TITLE
fix: pass settings to the jinja template. 

### DIFF
--- a/solara/minisettings.py
+++ b/solara/minisettings.py
@@ -56,6 +56,9 @@ class _Field:
             return self
         return instance._values[self.name]
 
+    def __set__(self, instance, value):
+        instance._values[self.name] = value
+
 
 def convert(annotation, value: str) -> Any:
     check_optional_types = [str, int, float, bool, Path]

--- a/tests/unit/settings_test.py
+++ b/tests/unit/settings_test.py
@@ -42,3 +42,10 @@ def test_settings():
     assert settings.value_no_field_other == 50
     assert settings.path == Path("/tmp/test")
     assert settings.path_optional == Path("/tmp/test/optional")
+
+
+def test_dict():
+    settings = MySettings()
+    test_value = "some-other-value"
+    settings.value = test_value
+    assert settings.dict()["value"] == test_value


### PR DESCRIPTION
Because we did not implement a setter for the settings, command
line arguments were not passed to the jinja template.
Values were set, but .dict() used the _values dict which was
not updated by the setter.

Note that environment variables did work, so although
SOLARA_THEME_VARIANT=dark HOST=localhost solara run ...
Did work, the following did not:
HOST=localhost solara run ... --theme-variant=dark