### PR TITLE
ci: fix lint failure of mypy due to modern typed libraries

### DIFF
--- a/.github/workflows/codequality.yaml
+++ b/.github/workflows/codequality.yaml
@@ -23,7 +23,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          pip install ".[dev]" mypy==0.991 black==22.12.0 codespell==2.2.4 "click<8.1.4"
+          pip install ".[dev]" mypy==0.991 black==22.12.0 codespell==2.2.4 "click<8.1.4" "traitlets<5.10.0" "matplotlib<3.8.0"
           mypy --install-types --non-interactive solara
       - name: Run codespell
         run: codespell


### PR DESCRIPTION
Introduced in traitlets 5.10 due to
 * https://github.com/ipython/traitlets/pull/868
 * https://github.com/ipython/traitlets/pull/818

The correct way would be to fix the errors, but we don't want CI to fail randomly. This also supports our idea of having lockfiles for CI.