### PR TITLE
refactor: use kernel_id instead of session_id

### DIFF
--- a/packages/solara-widget-manager/src/kernel.ts
+++ b/packages/solara-widget-manager/src/kernel.ts
@@ -27,7 +27,7 @@ export async function connectKernel(
   // if (!model) {
   //   return;
   // }
-  const model = { 'id': 'solara-id', 'name': 'solara-name' }
+  const model = { 'id': kernelId, 'name': 'solara-name' }
   const kernel = new KernelConnection({ model, serverSettings });
   return kernel;
 }

--- a/solara/scope/__init__.py
+++ b/solara/scope/__init__.py
@@ -18,9 +18,9 @@ class ConnectionScope(ObservableMutableMapping):
 
     def _get_dict(self) -> MutableMapping:
         if _in_solara_server():
-            import solara.server.app
+            import solara.server.kernel_context
 
-            context = solara.server.app.get_current_context()
+            context = solara.server.kernel_context.get_current_context()
             if self.name not in context.user_dicts:
                 with self.lock:
                     if self.name not in context.user_dicts:

--- a/solara/server/kernel.py
+++ b/solara/server/kernel.py
@@ -97,7 +97,7 @@ if ipykernel_version >= (6, 18, 0):
     comm.create_comm = Comm
 
     def get_comm_manager():
-        from .app import get_current_context, has_current_context
+        from .kernel_context import get_current_context, has_current_context
 
         if has_current_context():
             return get_current_context().kernel.comm_manager

--- a/solara/server/kernel_context.py
+++ b/solara/server/kernel_context.py
@@ -1,0 +1,170 @@
+import dataclasses
+import logging
+import os
+import pickle
+import threading
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, cast
+
+import ipywidgets as widgets
+import reacton
+from ipywidgets import DOMWidget, Widget
+
+from . import kernel, kernel_context, websocket
+from .kernel import Kernel, WebsocketStreamWrapper
+
+WebSocket = Any
+logger = logging.getLogger("solara.server.app")
+
+
+class Local(threading.local):
+    kernel_context_stack: Optional[List[Optional["kernel_context.VirtualKernelContext"]]] = None
+
+
+local = Local()
+
+
+@dataclasses.dataclass
+class VirtualKernelContext:
+    id: str
+    kernel: kernel.Kernel
+    control_sockets: List[WebSocket] = dataclasses.field(default_factory=list)
+    # this is the 'private' version of the normally global ipywidgets.Widgets.widget dict
+    # see patch.py
+    widgets: Dict[str, Widget] = dataclasses.field(default_factory=dict)
+    # same, for ipyvue templates
+    # see patch.py
+    templates: Dict[str, Widget] = dataclasses.field(default_factory=dict)
+    user_dicts: Dict[str, Dict] = dataclasses.field(default_factory=dict)
+    # anything we need to attach to the context
+    # e.g. for a react app the render context, so that we can store/restore the state
+    app_object: Optional[Any] = None
+    reload: Callable = lambda: None
+    state: Any = None
+    container: Optional[DOMWidget] = None
+
+    def display(self, *args):
+        print(args)  # noqa
+
+    def __enter__(self):
+        if local.kernel_context_stack is None:
+            local.kernel_context_stack = []
+        key = get_current_thread_key()
+        local.kernel_context_stack.append(current_context.get(key, None))
+        current_context[key] = self
+
+    def __exit__(self, *args):
+        key = get_current_thread_key()
+        assert local.kernel_context_stack is not None
+        current_context[key] = local.kernel_context_stack.pop()
+
+    def close(self):
+        with self:
+            if self.app_object is not None:
+                if isinstance(self.app_object, reacton.core._RenderContext):
+                    try:
+                        self.app_object.close()
+                    except Exception as e:
+                        logger.exception("Could not close render context: %s", e)
+                        # we want to continue, so we at least close all widgets
+            widgets.Widget.close_all()
+            # what if we reference each other
+            # import gc
+            # gc.collect()
+        if self.id in contexts:
+            del contexts[self.id]
+
+    def _state_reset(self):
+        state_directory = Path(".") / "states"
+        state_directory.mkdir(exist_ok=True)
+        path = state_directory / f"{self.id}.pickle"
+        path = path.absolute()
+        try:
+            path.unlink()
+        except:  # noqa
+            pass
+        del contexts[self.id]
+        key = get_current_thread_key()
+        del current_context[key]
+
+    def state_save(self, state_directory: os.PathLike):
+        path = Path(state_directory) / f"{self.id}.pickle"
+        render_context = self.app_object
+        if render_context is not None:
+            render_context = cast(reacton.core._RenderContext, render_context)
+            state = render_context.state_get()
+            with path.open("wb") as f:
+                logger.debug("State: %r", state)
+                pickle.dump(state, f)
+
+
+contexts: Dict[str, VirtualKernelContext] = {}
+# maps from thread key to VirtualKernelContext, if VirtualKernelContext is None, it exists, but is not set as current
+current_context: Dict[str, Optional[VirtualKernelContext]] = {}
+
+
+def create_dummy_context():
+    from . import kernel
+
+    kernel_context = VirtualKernelContext(
+        id="dummy",
+        kernel=kernel.Kernel(),
+    )
+    return kernel_context
+
+
+def get_current_thread_key() -> str:
+    thread = threading.current_thread()
+    return get_thread_key(thread)
+
+
+def get_thread_key(thread: threading.Thread) -> str:
+    thread_key = thread._name + str(thread._ident)  # type: ignore
+    return thread_key
+
+
+def set_context_for_thread(context: VirtualKernelContext, thread: threading.Thread):
+    key = get_thread_key(thread)
+    current_context[key] = context
+
+
+def has_current_context() -> bool:
+    thread_key = get_current_thread_key()
+    return (thread_key in current_context) and (current_context[thread_key] is not None)
+
+
+def get_current_context() -> VirtualKernelContext:
+    thread_key = get_current_thread_key()
+    if thread_key not in current_context:
+        raise RuntimeError(
+            f"Tried to get the current context for thread {thread_key}, but no known context found. This might be a bug in Solara. "
+            f"(known contexts: {list(current_context.keys())}"
+        )
+    context = current_context[thread_key]
+    if context is None:
+        raise RuntimeError(
+            f"Tried to get the current context for thread {thread_key!r}, although the context is know, it was not set for this thread. "
+            + "This might be a bug in Solara."
+        )
+    return context
+
+
+def set_current_context(context: Optional[VirtualKernelContext]):
+    thread_key = get_current_thread_key()
+    current_context[thread_key] = context
+
+
+def initialize_virtual_kernel(kernel_id: str, websocket: websocket.WebsocketWrapper):
+    import solara.server.app
+
+    kernel = Kernel()
+    logger.info("new virtual kernel: %s", kernel_id)
+    context = contexts[kernel_id] = VirtualKernelContext(id=kernel_id, kernel=kernel, control_sockets=[], widgets={}, templates={})
+    with context:
+        widgets.register_comm_target(kernel)
+        solara.server.app.register_solara_comm_target(kernel)
+        assert kernel is Kernel.instance()
+        kernel.shell_stream = WebsocketStreamWrapper(websocket, "shell")
+        kernel.control_stream = WebsocketStreamWrapper(websocket, "control")
+        kernel.session.websockets.add(websocket)
+    return context

--- a/solara/server/starlette.py
+++ b/solara/server/starlette.py
@@ -46,7 +46,7 @@ import solara
 from solara.server.threaded import ServerBase
 
 from . import app as appmod
-from . import server, settings, telemetry, websocket
+from . import kernel_context, server, settings, telemetry, websocket
 from .cdn_helper import cdn_url_path, get_path
 
 os.environ["SERVER_SOFTWARE"] = "solara/" + str(solara.__version__)
@@ -166,12 +166,17 @@ async def kernel_connection(ws: starlette.websockets.WebSocket):
         logger.error("no session cookie")
         await ws.close()
         return
-    connection_id = ws.query_params["session_id"]
-    if not connection_id:
-        logger.error("no session_id/connection_id")
+    # we use the jupyter session_id query parameter as the key/id
+    # for a page scope.
+    page_id = ws.query_params["session_id"]
+    if not page_id:
+        logger.error("no page_id")
+    kernel_id = ws.path_params["kernel_id"]
+    if not kernel_id:
+        logger.error("no kernel_id")
         await ws.close()
         return
-    logger.info("Solara kernel requested for session_id=%s connection_id=%s", session_id, connection_id)
+    logger.info("Solara kernel requested for session_id=%s kernel_id=%s", session_id, kernel_id)
     await ws.accept()
 
     def websocket_thread_runner(ws: starlette.websockets.WebSocket, portal: anyio.from_thread.BlockingPortal):
@@ -180,14 +185,14 @@ async def kernel_connection(ws: starlette.websockets.WebSocket):
         async def run():
             try:
                 assert session_id is not None
-                assert connection_id is not None
-                telemetry.connection_open(session_id, connection_id)
-                await server.app_loop(ws_wrapper, session_id, connection_id, user)
+                assert kernel_id is not None
+                telemetry.connection_open(session_id)
+                await server.app_loop(ws_wrapper, session_id, kernel_id, page_id, user)
             except:  # noqa
                 await portal.stop(cancel_remaining=True)
                 raise
             finally:
-                telemetry.connection_close(session_id, connection_id)
+                telemetry.connection_close(session_id)
 
         # sometimes throws: RuntimeError: Already running asyncio in this thread
         anyio.run(run)
@@ -206,9 +211,9 @@ async def kernel_connection(ws: starlette.websockets.WebSocket):
 
 
 def close(request: Request):
-    connection_id = request.path_params["connection_id"]
-    if connection_id in appmod.contexts:
-        context = appmod.contexts[connection_id]
+    kernel_id = request.path_params["kernel_id"]
+    if kernel_id in kernel_context.contexts:
+        context = kernel_context.contexts[kernel_id]
         context.close()
     response = HTMLResponse(content="", status_code=200)
     return response
@@ -381,10 +386,10 @@ routes = [
     Route("/readyz", endpoint=readyz),
     *routes_auth,
     Route("/jupyter/api/kernels/{id}", endpoint=kernels),
-    WebSocketRoute("/jupyter/api/kernels/{id}/{name}", endpoint=kernel_connection),
+    WebSocketRoute("/jupyter/api/kernels/{kernel_id}/{name}", endpoint=kernel_connection),
     Route("/", endpoint=root),
     Route("/{fullpath}", endpoint=root),
-    Route("/_solara/api/close/{connection_id}", endpoint=close, methods=["POST"]),
+    Route("/_solara/api/close/{kernel_id}", endpoint=close, methods=["POST"]),
     # only enable when the proxy is turned on, otherwise if the directory does not exists we will get an exception
     *([Mount(f"/{cdn_url_path}", app=StaticCdn(directory=settings.assets.proxy_cache_dir))] if settings.assets.proxy else []),
     Mount(f"{prefix}/static/public", app=StaticPublic()),

--- a/solara/server/telemetry.py
+++ b/solara/server/telemetry.py
@@ -146,12 +146,12 @@ def server_stop():
     track("Solara server stop", {"duration_seconds": duration, **_usage_stats()})
 
 
-def connection_open(session_id, connection_id):
+def connection_open(session_id):
     _connections_per_session_daily[session_id] += 1
     _connections_per_session_cumulative[session_id] += 1
 
 
-def connection_close(session_id, connection_id):
+def connection_close(session_id):
     pass
 
 

--- a/solara/test/pytest_plugin.py
+++ b/solara/test/pytest_plugin.py
@@ -173,14 +173,14 @@ def SyncWrapper():
 def _solara_test(solara_server, solara_app, page_session: "playwright.sync_api.Page"):
     global run_calls
     with solara_app("solara.test.pytest_plugin:SyncWrapper"):
-        assert len(solara.server.app.contexts) == 0
+        assert len(solara.server.kernel_context.contexts) == 0
         page_session.goto(solara_server.base_url)
         try:
             run_event.wait()
             assert run_calls == 1
-            keys = list(solara.server.app.contexts)
+            keys = list(solara.server.kernel_context.contexts)
             assert len(keys) == 1, "expected only one context, got %s" % keys
-            context = solara.server.app.contexts[keys[-1]]
+            context = solara.server.kernel_context.contexts[keys[-1]]
             with context:
                 test_output_warmup = widgets.Output()
                 test_output = widgets.Output()

--- a/solara/toestand.py
+++ b/solara/toestand.py
@@ -217,11 +217,11 @@ class ConnectionStore(ValueBase[S]):
         scope_dict = self._global_dict
         scope_id = "global"
         if _using_solara_server():
-            import solara.server.app
+            import solara.server.kernel_context
 
             try:
-                context = solara.server.app.get_current_context()
-            except:  # noqa
+                context = solara.server.kernel_context.get_current_context()
+            except RuntimeError:  # noqa
                 pass  # do we need to be more strict?
             else:
                 scope_dict = cast(Dict[str, S], context.user_dicts)

--- a/tests/integration/ssg_test.py
+++ b/tests/integration/ssg_test.py
@@ -7,14 +7,14 @@ from solara_enterprise import ssg
 
 import solara
 from solara.server import settings
-from solara.server.app import AppContext, get_current_context
+from solara.server.kernel_context import VirtualKernelContext, get_current_context
 
 HERE = Path(__file__).parent
 
 
 text_ssg = "# SSG Test"
 text_live = "# Live render"
-context: Optional[AppContext] = None
+context: Optional[VirtualKernelContext] = None
 
 
 def set_value(x: str):

--- a/tests/unit/app_test.py
+++ b/tests/unit/app_test.py
@@ -20,11 +20,11 @@ HERE = Path(__file__).parent
 reload.reloader.start()
 
 
-def test_notebook_element(app_context, no_app_context):
+def test_notebook_element(kernel_context, no_kernel_context):
     name = str(HERE / "solara_test_apps" / "notebookapp_element.ipynb")
     app = AppScript(name)
     try:
-        with app_context:
+        with kernel_context:
             el = app.run()
             assert isinstance(el, reacton.core.Element)
             el2 = app.run()
@@ -33,11 +33,11 @@ def test_notebook_element(app_context, no_app_context):
         app.close()
 
 
-def test_notebook_component(app_context, no_app_context):
+def test_notebook_component(kernel_context, no_kernel_context):
     name = str(HERE / "solara_test_apps" / "notebookapp_component.ipynb")
     app = AppScript(name)
     try:
-        with app_context:
+        with kernel_context:
             el = app.run()
             assert isinstance(el, reacton.core.Element)
             el2 = app.run()
@@ -46,11 +46,11 @@ def test_notebook_component(app_context, no_app_context):
         app.close()
 
 
-def test_notebook_widget(app_context, no_app_context):
+def test_notebook_widget(kernel_context, no_kernel_context):
     name = str(HERE / "solara_test_apps" / "notebookapp_widget.ipynb")
     app = AppScript(name)
     try:
-        with app_context:
+        with kernel_context:
             el = app.run()
             root = solara.RoutingProvider(children=[el], routes=app.routes, pathname="/")
             _box, rc = solara.render(root, handle_error=False)
@@ -63,11 +63,11 @@ def test_notebook_widget(app_context, no_app_context):
         app.close()
 
 
-def test_sidebar_single_file_multiple_routes(app_context, no_app_context):
+def test_sidebar_single_file_multiple_routes(kernel_context, no_kernel_context):
     name = str(HERE / "solara_test_apps" / "single_file_multiple_routes.py")
     app = AppScript(name)
     try:
-        with app_context:
+        with kernel_context:
             c = app.run()
             root = solara.RoutingProvider(children=[c], routes=app.routes, pathname="/")
             box, rc = solara.render(root, handle_error=False)
@@ -76,11 +76,11 @@ def test_sidebar_single_file_multiple_routes(app_context, no_app_context):
         app.close()
 
 
-def test_sidebar_single_file(app_context, no_app_context):
+def test_sidebar_single_file(kernel_context, no_kernel_context):
     name = str(HERE / "solara_test_apps" / "single_file.py")
     app = AppScript(name)
     try:
-        with app_context:
+        with kernel_context:
             c = app.run()
             root = solara.RoutingProvider(children=[c], routes=app.routes, pathname="/")
             box, rc = solara.render(root, handle_error=False)
@@ -89,11 +89,11 @@ def test_sidebar_single_file(app_context, no_app_context):
         app.close()
 
 
-def test_sidebar_single_file_missing(app_context, no_app_context):
+def test_sidebar_single_file_missing(kernel_context, no_kernel_context):
     name = str(HERE / "solara_test_apps" / "single_file.py:doesnotexist")
     app = AppScript(name)
     try:
-        with app_context:
+        with kernel_context:
             c = app.run()
             root = solara.RoutingProvider(children=[c], routes=app.routes, pathname="/")
             box, rc = solara.render(root, handle_error=False)
@@ -103,7 +103,7 @@ def test_sidebar_single_file_missing(app_context, no_app_context):
 
 
 # these make other test fail on CI (vaex is used, which causes a blake3 reload, which fails)
-def test_watch_module_reload(tmpdir, app_context, extra_include_path, no_app_context):
+def test_watch_module_reload(tmpdir, kernel_context, extra_include_path, no_kernel_context):
     import ipyvuetify as v
 
     with extra_include_path(str(tmpdir)):
@@ -150,7 +150,7 @@ def test_watch_module_reload(tmpdir, app_context, extra_include_path, no_app_con
             reload.reloader.watched_modules.remove("somemod")
 
 
-# def test_script_reload_component(tmpdir, app_context, extra_include_path, no_app_context):
+# def test_script_reload_component(tmpdir, kernel_context, extra_include_path, no_kernel_context):
 #     import ipyvuetify as v
 
 #     with extra_include_path(str(tmpdir)):
@@ -176,7 +176,7 @@ def test_watch_module_reload(tmpdir, app_context, extra_include_path, no_app_con
 #             app.close()
 
 
-# def test_watch_module_import_error(tmpdir, app_context, extra_include_path, no_app_context):
+# def test_watch_module_import_error(tmpdir, kernel_context, extra_include_path, no_kernel_context):
 #     import ipyvuetify as v
 
 #     with extra_include_path(str(tmpdir)):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,14 +1,15 @@
 import pytest
 
 import solara.server.app
+import solara.server.kernel_context
 from solara.server import kernel
-from solara.server.app import AppContext
+from solara.server.kernel_context import VirtualKernelContext
 
 
 @pytest.fixture(autouse=True)
-def app_context():
+def kernel_context():
     kernel_shared = kernel.Kernel()
-    context = AppContext(id="1", kernel=kernel_shared)
+    context = VirtualKernelContext(id="1", kernel=kernel_shared)
     try:
         with context:
             yield context
@@ -18,10 +19,10 @@ def app_context():
 
 
 @pytest.fixture()
-def no_app_context(app_context):
-    context = solara.server.app.get_current_context()
-    solara.server.app.set_current_context(None)
+def no_kernel_context(kernel_context):
+    context = solara.server.kernel_context.get_current_context()
+    solara.server.kernel_context.set_current_context(None)
     try:
         yield
     finally:
-        solara.server.app.set_current_context(context)
+        solara.server.kernel_context.set_current_context(context)

--- a/tests/unit/no_solara_test.py
+++ b/tests/unit/no_solara_test.py
@@ -6,16 +6,16 @@ import solara.components.file_download
 # test if normal widget code works with no app context
 
 
-def test_create_widget(no_app_context):
+def test_create_widget(no_kernel_context):
     button = widgets.Button(description="Click me")
     button.layout.close()
     button.close()
 
 
-def test_vue_template(no_app_context):
+def test_vue_template(no_kernel_context):
     widget = solara.components.file_download.FileDownloadWidget()
     widget.close()
 
 
-def test_display(no_app_context):
+def test_display(no_kernel_context):
     display("test")

--- a/tests/unit/output_widget_test.py
+++ b/tests/unit/output_widget_test.py
@@ -3,18 +3,18 @@ from unittest.mock import Mock
 import IPython.display
 import ipywidgets as widgets
 
-from solara.server import app, kernel
+from solara.server import kernel, kernel_context
 
 
-def test_interactive_shell(no_app_context):
+def test_interactive_shell(no_kernel_context):
     ws1 = Mock()
     ws2 = Mock()
     kernel1 = kernel.Kernel()
     kernel2 = kernel.Kernel()
     kernel1.session.websockets.add(ws1)
     kernel2.session.websockets.add(ws2)
-    context1 = app.AppContext(id="1", kernel=kernel1)
-    context2 = app.AppContext(id="2", kernel=kernel2)
+    context1 = kernel_context.VirtualKernelContext(id="1", kernel=kernel1)
+    context2 = kernel_context.VirtualKernelContext(id="2", kernel=kernel2)
 
     with context1:
         output1 = widgets.Output()

--- a/tests/unit/patch_test.py
+++ b/tests/unit/patch_test.py
@@ -3,26 +3,26 @@ import sys
 import ipywidgets as widgets
 import pytest
 
-from solara.server import app, kernel
+from solara.server import kernel, kernel_context
 
 
 # with python 3.6 we don't use the comm package
 @pytest.mark.skipif(sys.version_info < (3, 7, 0), reason="ipykernel version too low")
-def test_widget_error_message_outside_context(no_app_context):
+def test_widget_error_message_outside_context(no_kernel_context):
     from ipyvuetify.Themes import theme
 
     theme.get_state()
     kernel_shared = kernel.Kernel()
-    context1 = app.AppContext(id="1", kernel=kernel_shared)
+    context1 = kernel_context.VirtualKernelContext(id="1", kernel=kernel_shared)
     with pytest.raises(RuntimeError):
         with context1:
             assert theme.model_id
 
 
-def test_widget_dict(no_app_context):
+def test_widget_dict(no_kernel_context):
     kernel_shared = kernel.Kernel()
-    context1 = app.AppContext(id="1", kernel=kernel_shared, control_sockets=[], widgets={}, templates={})
-    context2 = app.AppContext(id="2", kernel=kernel_shared, control_sockets=[], widgets={}, templates={})
+    context1 = kernel_context.VirtualKernelContext(id="1", kernel=kernel_shared, control_sockets=[], widgets={}, templates={})
+    context2 = kernel_context.VirtualKernelContext(id="2", kernel=kernel_shared, control_sockets=[], widgets={}, templates={})
 
     with context1:
         btn1 = widgets.Button(description="context1")

--- a/tests/unit/shell_test.py
+++ b/tests/unit/shell_test.py
@@ -2,18 +2,18 @@ from unittest.mock import Mock
 
 import IPython.display
 
-from solara.server import app, kernel
+from solara.server import kernel, kernel_context
 
 
-def test_shell(no_app_context):
+def test_shell(no_kernel_context):
     ws1 = Mock()
     ws2 = Mock()
     kernel1 = kernel.Kernel()
     kernel2 = kernel.Kernel()
     kernel1.session.websockets.add(ws1)
     kernel2.session.websockets.add(ws2)
-    context1 = app.AppContext(id="1", kernel=kernel1)
-    context2 = app.AppContext(id="2", kernel=kernel2)
+    context1 = kernel_context.VirtualKernelContext(id="1", kernel=kernel1)
+    context2 = kernel_context.VirtualKernelContext(id="2", kernel=kernel2)
 
     with context1:
         IPython.display.display("test1")

--- a/tests/unit/toestand_test.py
+++ b/tests/unit/toestand_test.py
@@ -10,7 +10,7 @@ from typing_extensions import TypedDict
 import solara
 import solara as sol
 import solara.lab
-from solara.server import app, kernel
+from solara.server import kernel, kernel_context
 from solara.toestand import Reactive, Ref, State, use_sync_external_store
 
 from .common import click
@@ -112,17 +112,17 @@ def test_subscribe():
         u()
 
 
-def test_scopes(no_app_context):
+def test_scopes(no_kernel_context):
     bear_store = BearReactive(bears)
     mock_global = unittest.mock.Mock()
     unsub = []
     unsub += [bear_store.subscribe(mock_global)]
 
     kernel_shared = kernel.Kernel()
-    assert app.current_context[app.get_current_thread_key()] is None
+    assert kernel_context.current_context[kernel_context.get_current_thread_key()] is None
 
-    context1 = app.AppContext(id="toestand-1", kernel=kernel_shared, control_sockets=[], widgets={}, templates={})
-    context2 = app.AppContext(id="toestand-2", kernel=kernel_shared, control_sockets=[], widgets={}, templates={})
+    context1 = kernel_context.VirtualKernelContext(id="toestand-1", kernel=kernel_shared, control_sockets=[], widgets={}, templates={})
+    context2 = kernel_context.VirtualKernelContext(id="toestand-2", kernel=kernel_shared, control_sockets=[], widgets={}, templates={})
 
     with context1:
         mock1 = unittest.mock.Mock()
@@ -378,8 +378,8 @@ def test_bear_store_react():
 
     # the storage should live in the app context to support multiple users/connections
     kernel_shared = kernel.Kernel()
-    context1 = app.AppContext(id="bear-1", kernel=kernel_shared, control_sockets=[], widgets={}, templates={})
-    context2 = app.AppContext(id="bear-2", kernel=kernel_shared, control_sockets=[], widgets={}, templates={})
+    context1 = kernel_context.VirtualKernelContext(id="bear-1", kernel=kernel_shared, control_sockets=[], widgets={}, templates={})
+    context2 = kernel_context.VirtualKernelContext(id="bear-2", kernel=kernel_shared, control_sockets=[], widgets={}, templates={})
     rcs = []
     for context in [context1, context2]:
         with context:
@@ -781,7 +781,7 @@ def test_thread_local():
     t.join()
 
 
-def test_reactive_auto_subscribe(app_context):
+def test_reactive_auto_subscribe(kernel_context):
     x = Reactive(1)
     y = Reactive("hi")
     extra = Reactive("extra")
@@ -815,10 +815,10 @@ def test_reactive_auto_subscribe(app_context):
 
     count.value = 2
     assert len(rc.find(v.Slider)) == 2
-    assert len(x._storage.listeners2[app_context.id]) == 2
+    assert len(x._storage.listeners2[kernel_context.id]) == 2
     x.value = 3
     assert rc.find(v.Slider)[0].widget.v_model == 3
-    assert len(x._storage.listeners2[app_context.id]) == 2
+    assert len(x._storage.listeners2[kernel_context.id]) == 2
 
     count.value = 1
     assert len(rc.find(v.Slider)) == 1
@@ -826,8 +826,8 @@ def test_reactive_auto_subscribe(app_context):
     assert len(rc.find(v.Slider)) == 0
 
     rc.close()
-    assert not x._storage.listeners[app_context.id]
-    assert not x._storage.listeners2[app_context.id]
+    assert not x._storage.listeners[kernel_context.id]
+    assert not x._storage.listeners2[kernel_context.id]
 
 
 def test_reactive_auto_subscribe_sub():
@@ -851,7 +851,7 @@ def test_reactive_auto_subscribe_sub():
     assert renders == renders_before
 
 
-def test_reactive_auto_subscribe_cleanup(app_context):
+def test_reactive_auto_subscribe_cleanup(kernel_context):
     x = Reactive(1)
     y = Reactive("hi")
     renders = 0
@@ -874,22 +874,22 @@ def test_reactive_auto_subscribe_cleanup(app_context):
     assert len(y._storage.listeners2) == 0
     x.value = 42
     assert renders == 2
-    assert len(x._storage.listeners2[app_context.id]) == 1
-    assert len(y._storage.listeners2[app_context.id]) == 1
+    assert len(x._storage.listeners2[kernel_context.id]) == 1
+    assert len(y._storage.listeners2[kernel_context.id]) == 1
 
     # this triggers two renders, where during the first one we use y, but the seconds we don't
     x.value = 0
     assert rc.find(v.Slider).widget.v_model == 100
-    assert len(x._storage.listeners2[app_context.id]) == 1
+    assert len(x._storage.listeners2[kernel_context.id]) == 1
     # which means we shouldn't have a listener on y
-    assert len(y._storage.listeners2[app_context.id]) == 0
+    assert len(y._storage.listeners2[kernel_context.id]) == 0
 
     rc.close()
-    assert not x._storage.listeners[app_context.id]
-    assert not y._storage.listeners2[app_context.id]
+    assert not x._storage.listeners[kernel_context.id]
+    assert not y._storage.listeners2[kernel_context.id]
 
 
-def test_reactive_auto_subscribe_subfield_limit(app_context):
+def test_reactive_auto_subscribe_subfield_limit(kernel_context):
     bears = Reactive(Bears(type="brown", count=1))
     renders = 0
 
@@ -906,8 +906,8 @@ def test_reactive_auto_subscribe_subfield_limit(app_context):
     Ref(bears.fields.count).value = 2
     assert renders == 2
     rc.close()
-    assert not bears._storage.listeners[app_context.id]
-    assert not bears._storage.listeners2[app_context.id]
+    assert not bears._storage.listeners[kernel_context.id]
+    assert not bears._storage.listeners2[kernel_context.id]
 
 
 def test_reactive_batch_update():


### PR DESCRIPTION
We have been using the jupyter session_id as a unique key for
the ill defined concept of a "AppContext".
For consistency, we now use the kernel_id as the unique key
and renamed the AppContext to VirtualKernelContext.

A VirtualKernelContext is a context manager that
needs to wrap any code that uses a kernel, either explicitly
or implicitly, such as widgets.