### PR TITLE
fix: make solara_test fixture not fail subsequent tests

### DIFF
--- a/solara/test/pytest_plugin.py
+++ b/solara/test/pytest_plugin.py
@@ -184,20 +184,23 @@ def _solara_test(solara_server, solara_app, page_session: "playwright.sync_api.P
             with context:
                 test_output_warmup = widgets.Output()
                 test_output = widgets.Output()
-                page_session.locator("text=Test in solara").wait_for()
-                context.container.children[0].children[1].children[1].children = [test_output_warmup]  # type: ignore
-                with test_output_warmup:
-                    warmup()
-                    button = page_session.locator(".solara-warmup-widget")
-                    button.wait_for()
-                    page_session.evaluate("document.fonts.ready")
-                    button.click()
-                    button.wait_for(state="detached")
-                    page_session.evaluate("document.fonts.ready")
-                context.container.children[0].children[1].children[1].children = [test_output]  # type: ignore
-                with test_output:
-                    yield
-                test_output.close()
+                try:
+                    page_session.locator("text=Test in solara").wait_for()
+                    context.container.children[0].children[1].children[1].children = [test_output_warmup]  # type: ignore
+                    with test_output_warmup:
+                        warmup()
+                        button = page_session.locator(".solara-warmup-widget")
+                        button.wait_for()
+                        page_session.evaluate("document.fonts.ready")
+                        button.click()
+                        button.wait_for(state="detached")
+                        page_session.evaluate("document.fonts.ready")
+                    context.container.children[0].children[1].children[1].children = [test_output]  # type: ignore
+                    with test_output:
+                        yield
+                finally:
+                    test_output.close()
+                    test_output_warmup.close()
         finally:
             run_calls = 0
             run_event.clear()


### PR DESCRIPTION
If the test failed once, it will fail all subsequent tests because
it did not do a proper cleanup.