### PR TITLE
fix: baseUrl should not be suffixed with /jupyter

### DIFF
--- a/solara/server/templates/solara.html.j2
+++ b/solara/server/templates/solara.html.j2
@@ -39,7 +39,7 @@
 
     <script id="jupyter-config-data" type="application/json">
     {
-        "baseUrl": "{{root_path}}/jupyter",
+        "baseUrl": "{{root_path}}",
         "kernelId": "1234"
     }
     </script>


### PR DESCRIPTION
The fact that this did not affect our code is an indication that we
are not using it internally. Using ipypopout, this bug was found,
because it does use the baseUrl.