### PR TITLE
fix: pass search query directly to solara

### DIFF
--- a/solara/server/static/main-vuetify.js
+++ b/solara/server/static/main-vuetify.js
@@ -201,7 +201,7 @@ async function solaraInit(mountId, appName) {
     let widgetManager = new solara.WidgetManager(context, rendermime, settings);
     // it seems if we attach this to early, it will not be called
     app.$data.loading_text = 'Loading app';
-    const path = window.location.pathname.slice(solara.rootPath.length);
+    const path = window.location.pathname.slice(solara.rootPath.length) + window.location.search;
     const widgetId = await widgetManager.run(appName, path);
     await solaraMount(widgetManager, mountId || 'content', widgetId);
     skipReconnectedCheck = false;


### PR DESCRIPTION
Before, we ran the solara component with an empty search query first,
and then updated the search query. This caused a flicker in the UI.