### PR TITLE
fix: strange menu behaviour with some child components

### DIFF
--- a/solara/lab/components/menu.py
+++ b/solara/lab/components/menu.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Union
+from typing import Callable, Dict, List, Optional, Union
 
 import solara
 from solara.components.component_vue import component_vue
@@ -7,8 +7,9 @@ from solara.components.component_vue import component_vue
 @component_vue("menu.vue")
 def MenuWidget(
     activator: List[solara.Element],
+    show_menu: bool,
+    on_show_menu: Optional[Callable] = None,
     children: List[solara.Element] = [],
-    show_menu: bool = False,
     style: Optional[str] = None,
     context: bool = False,
     use_absolute: bool = True,
@@ -19,6 +20,8 @@ def MenuWidget(
 @solara.component
 def ClickMenu(
     activator: Union[solara.Element, List[solara.Element]],
+    open: Union[solara.Reactive[bool], bool] = False,
+    on_open: Optional[Callable] = None,
     children: List[solara.Element] = [],
     style: Optional[Union[str, Dict[str, str]]] = None,
 ):
@@ -44,21 +47,38 @@ def ClickMenu(
     ## Arguments
 
     * activator: Clicking on this element will open the menu. Accepts either a `solara.Element`, or a list of elements.
+    * open: Controls and communicates the state of the menu. If True, the menu is open. If False, the menu is closed.
     * menu_contents: List of Elements to be contained in the menu.
     * style: CSS style to apply. Applied directly onto the `v-menu` component.
     """
-    show = solara.use_reactive(False)
+
+    def _on_open(open_value):
+        if open_value:
+            if on_open:
+                on_open()
+
+    open_reactive = solara.use_reactive(open, _on_open)
+    del open
+
     style_flat = solara.util._flatten_style(style)
 
     if not isinstance(activator, list):
         activator = [activator]
 
-    return MenuWidget(activator=activator, children=children, show_menu=show.value, style=style_flat)
+    return MenuWidget(
+        activator=activator,
+        children=children,
+        show_menu=open_reactive.value,
+        on_show_menu=open_reactive.set,
+        style=style_flat,
+    )
 
 
 @solara.component
 def ContextMenu(
     activator: Union[solara.Element, List[solara.Element]],
+    open: Union[solara.Reactive[bool], bool] = False,
+    on_open: Optional[Callable] = None,
     children: List[solara.Element] = [],
     style: Optional[Union[str, Dict[str, str]]] = None,
 ):
@@ -85,21 +105,38 @@ def ContextMenu(
     ## Arguments
 
     * activator: Clicking on this element will open the menu. Accepts either a `solara.Element`, or a list of elements.
+    * open: Controls and communicates the state of the menu. If True, the menu is open. If False, the menu is closed.
     * children: List of Elements to be contained in the menu
     * style: CSS style to apply. Applied directly onto the `v-menu` component.
     """
-    show = solara.use_reactive(False)
+
+    def _on_open(open_value):
+        if open_value:
+            if on_open:
+                on_open()
+
+    open_reactive = solara.use_reactive(open, _on_open)
+    del open
     style_flat = solara.util._flatten_style(style)
 
     if not isinstance(activator, list):
         activator = [activator]
 
-    return MenuWidget(activator=activator, children=children, show_menu=show.value, style=style_flat, context=True)
+    return MenuWidget(
+        activator=activator,
+        children=children,
+        show_menu=open_reactive.value,
+        on_show_menu=open_reactive.set,
+        style=style_flat,
+        context=True,
+    )
 
 
 @solara.component
 def Menu(
     activator: Union[solara.Element, List[solara.Element]],
+    open: Union[solara.Reactive[bool], bool] = False,
+    on_open: Optional[Callable] = None,
     children: List[solara.Element] = [],
     style: Optional[Union[str, Dict[str, str]]] = None,
 ):
@@ -123,13 +160,29 @@ def Menu(
     ## Arguments
 
     * activator: Clicking on this element will open the menu. Accepts either a `solara.Element`, or a list of elements.
+    * open: Controls and communicates the state of the menu. If True, the menu is open. If False, the menu is closed.
     * children: List of Elements to be contained in the menu
     * style: CSS style to apply. Applied directly onto the `v-menu` component.
     """
-    show = solara.use_reactive(False)
+
+    def _on_open(open_value):
+        if open_value:
+            if on_open:
+                on_open()
+
+    open_reactive = solara.use_reactive(open, _on_open)
+    del open
+
     style_flat = solara.util._flatten_style(style)
 
     if not isinstance(activator, list):
         activator = [activator]
 
-    return MenuWidget(activator=activator, children=children, show_menu=show.value, style=style_flat, use_absolute=False)
+    return MenuWidget(
+        activator=activator,
+        children=children,
+        show_menu=open_reactive.value,
+        on_show_menu=open_reactive.set,
+        style=style_flat,
+        use_absolute=False,
+    )

--- a/solara/lab/components/menu.py
+++ b/solara/lab/components/menu.py
@@ -20,8 +20,8 @@ def MenuWidget(
 @solara.component
 def ClickMenu(
     activator: Union[solara.Element, List[solara.Element]],
-    open: Union[solara.Reactive[bool], bool] = False,
-    on_open: Optional[Callable] = None,
+    open_value: Union[solara.Reactive[bool], bool] = False,
+    on_open_value: Optional[Callable] = None,
     children: List[solara.Element] = [],
     style: Optional[Union[str, Dict[str, str]]] = None,
 ):
@@ -47,18 +47,13 @@ def ClickMenu(
     ## Arguments
 
     * activator: Clicking on this element will open the menu. Accepts either a `solara.Element`, or a list of elements.
-    * open: Controls and communicates the state of the menu. If True, the menu is open. If False, the menu is closed.
+    * open_value: Controls and communicates the state of the menu. If True, the menu is open. If False, the menu is closed.
+    * on_open_value: Function to call when the menu is opened or closed.
     * menu_contents: List of Elements to be contained in the menu.
     * style: CSS style to apply. Applied directly onto the `v-menu` component.
     """
-
-    def _on_open(open_value):
-        if open_value:
-            if on_open:
-                on_open()
-
-    open_reactive = solara.use_reactive(open, _on_open)
-    del open
+    open_reactive = solara.use_reactive(open_value, on_open_value)
+    del open_value
 
     style_flat = solara.util._flatten_style(style)
 
@@ -77,8 +72,8 @@ def ClickMenu(
 @solara.component
 def ContextMenu(
     activator: Union[solara.Element, List[solara.Element]],
-    open: Union[solara.Reactive[bool], bool] = False,
-    on_open: Optional[Callable] = None,
+    open_value: Union[solara.Reactive[bool], bool] = False,
+    on_open_value: Optional[Callable] = None,
     children: List[solara.Element] = [],
     style: Optional[Union[str, Dict[str, str]]] = None,
 ):
@@ -105,18 +100,13 @@ def ContextMenu(
     ## Arguments
 
     * activator: Clicking on this element will open the menu. Accepts either a `solara.Element`, or a list of elements.
-    * open: Controls and communicates the state of the menu. If True, the menu is open. If False, the menu is closed.
+    * open_value: Controls and communicates the state of the menu. If True, the menu is open. If False, the menu is closed.
+    * on_open_value: Function to call when the menu is opened or closed.
     * children: List of Elements to be contained in the menu
     * style: CSS style to apply. Applied directly onto the `v-menu` component.
     """
-
-    def _on_open(open_value):
-        if open_value:
-            if on_open:
-                on_open()
-
-    open_reactive = solara.use_reactive(open, _on_open)
-    del open
+    open_reactive = solara.use_reactive(open_value, on_open_value)
+    del open_value
     style_flat = solara.util._flatten_style(style)
 
     if not isinstance(activator, list):
@@ -135,8 +125,8 @@ def ContextMenu(
 @solara.component
 def Menu(
     activator: Union[solara.Element, List[solara.Element]],
-    open: Union[solara.Reactive[bool], bool] = False,
-    on_open: Optional[Callable] = None,
+    open_value: Union[solara.Reactive[bool], bool] = False,
+    on_open_value: Optional[Callable] = None,
     children: List[solara.Element] = [],
     style: Optional[Union[str, Dict[str, str]]] = None,
 ):
@@ -160,18 +150,13 @@ def Menu(
     ## Arguments
 
     * activator: Clicking on this element will open the menu. Accepts either a `solara.Element`, or a list of elements.
-    * open: Controls and communicates the state of the menu. If True, the menu is open. If False, the menu is closed.
+    * open_value: Controls and communicates the state of the menu. If True, the menu is open. If False, the menu is closed.
+    * on_open_value: Function to call when the menu is opened or closed.
     * children: List of Elements to be contained in the menu
     * style: CSS style to apply. Applied directly onto the `v-menu` component.
     """
-
-    def _on_open(open_value):
-        if open_value:
-            if on_open:
-                on_open()
-
-    open_reactive = solara.use_reactive(open, _on_open)
-    del open
+    open_reactive = solara.use_reactive(open_value, on_open_value)
+    del open_value
 
     style_flat = solara.util._flatten_style(style)
 


### PR DESCRIPTION
Because `on_show_menu` hadn't been set, Python and Vue weren't in sync about the status of a menu being open.