### PR TITLE
fix: make parent div of activator not display it as block

### DIFF
--- a/solara/lab/components/menu.vue
+++ b/solara/lab/components/menu.vue
@@ -15,7 +15,7 @@
             <div v-for="(element, index) in activator"
                 :key="index"
                 v-on="on"
-                style="width: fit-content;"
+                style="width: fit-content; display: inline-block;"
                 >
                 <jupyter-widget :widget="element"></jupyter-widget>
             </div>


### PR DESCRIPTION
We now give it inline-block. Ideally, we do not have the parent div. But that would require us to use @click.native which will be a breaking change in vue3.