### PR TITLE
CI: Test against Python 3.10

### DIFF
--- a/.github/workflows/codequality.yaml
+++ b/.github/workflows/codequality.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, "3.9"]
+        python-version: [3.7, "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,14 +25,13 @@ jobs:
         # just ubuntu and windows give enough confidence
         # osx should work fine (and we test that locally often)
         os: [ubuntu, windows]
-        # just 1 version, it's heavy
-        python-version: [3.8]
-        ipywidgets: ["7.7", "8.0"]
         include:
-          - ipywidgets: "7.7"
-            voila: "0.3.0"
-          - ipywidgets: "8.0"
-            voila: "0.4.0"
+          - ipywidgets: "7.8"
+            voila: "0.3.7"
+            python-version: "3.10"
+          - ipywidgets: "8.1"
+            voila: "0.5.4"
+            python-version: "3.10"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/javascript.yaml
+++ b/.github/workflows/javascript.yaml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.7
+      - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: "3.10"
       - uses: actions/setup-node@v3
         with:
           node-version: 14

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.7
+      - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: "3.10"
       - uses: actions/download-artifact@v2
         with:
           name: solara-builds-${{ github.run_number }}

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -22,17 +22,17 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        python: [3.6, 3.9]
-        ipywidgets: ["7.7", "8.0"]
+        python: ["3.6", "3.10"]
+        ipywidgets: ["7.8", "8.1"]
         exclude:
           - os: windows
             python: 3.6
           - os: ubuntu
             python: 3.6
-            ipywidgets: "8.0"
+            ipywidgets: "8.1"
           - os: macos
             python: 3.6
-            ipywidgets: "8.0"
+            ipywidgets: "8.1"
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Two bits of maintenance on the CI:
- In GitHub Actions, test against Python 3.10
- Update ipywidgets to the latest minor versions (7.8 and 8.1 respectively)

Testing against a more modern Python version ensures it not only works on that version, but also gives warnings about potential incompatibilities with future Python versions. Since some packages are already dropping support for Python 3.9 and older (see [SPEC 0](https://scientific-python.org/specs/spec-0000/)), testing at least against Python 3.10 is recommended.

Testing against Python 3.11 and Python 3.12 is currently blocked by Vaex not supporting those versions, see https://github.com/vaexio/vaex/pull/2331. I don't know exactly what Vaex is used for in Solara, but it could be worth considering removing it as a dependency.