### PR TITLE
CI: Run workflows once a week

### DIFF
--- a/.github/workflows/codequality.yaml
+++ b/.github/workflows/codequality.yaml
@@ -6,6 +6,8 @@ on:
       - master
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
 
 jobs:
   code-quality:

--- a/.github/workflows/codequality.yaml
+++ b/.github/workflows/codequality.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
   workflow_dispatch:
   schedule:
-    - cron: '0 6 * * 1'
+    - cron: '0 6 * * 1,4'  # at 06:00 UTC on Monday and Thursday
 
 jobs:
   code-quality:

--- a/.github/workflows/installation.yml
+++ b/.github/workflows/installation.yml
@@ -6,6 +6,8 @@ on:
       - master
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
 
 env:
   SOLARA_TELEMETRY_SERVER_USER_ID: "install-test"

--- a/.github/workflows/installation.yml
+++ b/.github/workflows/installation.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
   workflow_dispatch:
   schedule:
-    - cron: '0 6 * * 1'
+    - cron: '0 6 * * 1,4'  # at 06:00 UTC on Monday and Thursday
 
 env:
   SOLARA_TELEMETRY_SERVER_USER_ID: "install-test"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
   workflow_dispatch:
   schedule:
-    - cron: '0 6 * * 1'
+    - cron: '0 6 * * 1,4'  # at 06:00 UTC on Monday and Thursday
 
 env:
   SOLARA_TELEMETRY_SERVER_USER_ID: "install-test"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -7,6 +7,8 @@ on:
       - fix_ci
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
 
 env:
   SOLARA_TELEMETRY_SERVER_USER_ID: "install-test"

--- a/.github/workflows/javascript.yaml
+++ b/.github/workflows/javascript.yaml
@@ -11,7 +11,7 @@ on:
       - 'packages/**/*'
   workflow_dispatch:
   schedule:
-    - cron: '0 6 * * 1'
+    - cron: '0 6 * * 1,4'  # at 06:00 UTC on Monday and Thursday
 
 jobs:
   build:

--- a/.github/workflows/javascript.yaml
+++ b/.github/workflows/javascript.yaml
@@ -10,6 +10,8 @@ on:
     paths:
       - 'packages/**/*'
   workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
 
 jobs:
   build:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -6,6 +6,8 @@ on:
       - master
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
 
 env:
   SOLARA_TELEMETRY_SERVER_USER_ID: "install-test"

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
   workflow_dispatch:
   schedule:
-    - cron: '0 6 * * 1'
+    - cron: '0 6 * * 1,4'  # at 06:00 UTC on Monday and Thursday
 
 env:
   SOLARA_TELEMETRY_SERVER_USER_ID: "install-test"

--- a/solara/lab/components/menu.py
+++ b/solara/lab/components/menu.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Union
+from typing import Callable, Dict, List, Optional, Union
 
 import solara
 from solara.components.component_vue import component_vue
@@ -7,8 +7,9 @@ from solara.components.component_vue import component_vue
 @component_vue("menu.vue")
 def MenuWidget(
     activator: List[solara.Element],
+    show_menu: bool,
+    on_show_menu: Optional[Callable] = None,
     children: List[solara.Element] = [],
-    show_menu: bool = False,
     style: Optional[str] = None,
     context: bool = False,
     use_absolute: bool = True,
@@ -19,6 +20,8 @@ def MenuWidget(
 @solara.component
 def ClickMenu(
     activator: Union[solara.Element, List[solara.Element]],
+    open_value: Union[solara.Reactive[bool], bool] = False,
+    on_open_value: Optional[Callable] = None,
     children: List[solara.Element] = [],
     style: Optional[Union[str, Dict[str, str]]] = None,
 ):
@@ -44,21 +47,33 @@ def ClickMenu(
     ## Arguments
 
     * activator: Clicking on this element will open the menu. Accepts either a `solara.Element`, or a list of elements.
+    * open_value: Controls and communicates the state of the menu. If True, the menu is open. If False, the menu is closed.
+    * on_open_value: Function to call when the menu is opened or closed.
     * menu_contents: List of Elements to be contained in the menu.
     * style: CSS style to apply. Applied directly onto the `v-menu` component.
     """
-    show = solara.use_reactive(False)
+    open_reactive = solara.use_reactive(open_value, on_open_value)
+    del open_value
+
     style_flat = solara.util._flatten_style(style)
 
     if not isinstance(activator, list):
         activator = [activator]
 
-    return MenuWidget(activator=activator, children=children, show_menu=show.value, style=style_flat)
+    return MenuWidget(
+        activator=activator,
+        children=children,
+        show_menu=open_reactive.value,
+        on_show_menu=open_reactive.set,
+        style=style_flat,
+    )
 
 
 @solara.component
 def ContextMenu(
     activator: Union[solara.Element, List[solara.Element]],
+    open_value: Union[solara.Reactive[bool], bool] = False,
+    on_open_value: Optional[Callable] = None,
     children: List[solara.Element] = [],
     style: Optional[Union[str, Dict[str, str]]] = None,
 ):
@@ -85,21 +100,33 @@ def ContextMenu(
     ## Arguments
 
     * activator: Clicking on this element will open the menu. Accepts either a `solara.Element`, or a list of elements.
+    * open_value: Controls and communicates the state of the menu. If True, the menu is open. If False, the menu is closed.
+    * on_open_value: Function to call when the menu is opened or closed.
     * children: List of Elements to be contained in the menu
     * style: CSS style to apply. Applied directly onto the `v-menu` component.
     """
-    show = solara.use_reactive(False)
+    open_reactive = solara.use_reactive(open_value, on_open_value)
+    del open_value
     style_flat = solara.util._flatten_style(style)
 
     if not isinstance(activator, list):
         activator = [activator]
 
-    return MenuWidget(activator=activator, children=children, show_menu=show.value, style=style_flat, context=True)
+    return MenuWidget(
+        activator=activator,
+        children=children,
+        show_menu=open_reactive.value,
+        on_show_menu=open_reactive.set,
+        style=style_flat,
+        context=True,
+    )
 
 
 @solara.component
 def Menu(
     activator: Union[solara.Element, List[solara.Element]],
+    open_value: Union[solara.Reactive[bool], bool] = False,
+    on_open_value: Optional[Callable] = None,
     children: List[solara.Element] = [],
     style: Optional[Union[str, Dict[str, str]]] = None,
 ):
@@ -123,13 +150,24 @@ def Menu(
     ## Arguments
 
     * activator: Clicking on this element will open the menu. Accepts either a `solara.Element`, or a list of elements.
+    * open_value: Controls and communicates the state of the menu. If True, the menu is open. If False, the menu is closed.
+    * on_open_value: Function to call when the menu is opened or closed.
     * children: List of Elements to be contained in the menu
     * style: CSS style to apply. Applied directly onto the `v-menu` component.
     """
-    show = solara.use_reactive(False)
+    open_reactive = solara.use_reactive(open_value, on_open_value)
+    del open_value
+
     style_flat = solara.util._flatten_style(style)
 
     if not isinstance(activator, list):
         activator = [activator]
 
-    return MenuWidget(activator=activator, children=children, show_menu=show.value, style=style_flat, use_absolute=False)
+    return MenuWidget(
+        activator=activator,
+        children=children,
+        show_menu=open_reactive.value,
+        on_show_menu=open_reactive.set,
+        style=style_flat,
+        use_absolute=False,
+    )


### PR DESCRIPTION
Adds a weekly scheduled run to all CI workflows which run on push or PR, which now run each Monday at 06:00 UTC.

A periodically scheduled run can detect errors and warnings appearing in changes in upstream dependencies or the build environment. By having a scheduled run they can be traced back easier to a dependency or environment change, then if they would pop up in a random PR.