### PR TITLE
pytest config: remove `--disable-warnings`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ profile = "black"
 
 
 [tool.pytest.ini_options]
-addopts = "--disable-warnings --ignore=tests/integration/app_widget.py  --ignore=tests/unit/solara_test_apps"
+addopts = "--ignore=tests/integration/app_widget.py  --ignore=tests/unit/solara_test_apps"
 timeout = 180
 
 


### PR DESCRIPTION
Remove the `--disable-warnings` argument from the pytest configuration in `pyproject.toml`.

This will re-enable warmings in the unit and integrations tests, allowing deprecations and future unsupported behaviour to be noticed before they turn into errors.