### PR TITLE
Refactor Python code with Python 3.6+ features

### DIFF
--- a/solara/__main__.py
+++ b/solara/__main__.py
@@ -84,7 +84,7 @@ def _check_version():
 def find_all_packages_paths():
     paths = []
     # sitepackages = set([os.path.dirname(k) for k in site.getsitepackages()])
-    sitepackages = set([k for k in site.getsitepackages()])
+    sitepackages = {k for k in site.getsitepackages()}
     paths.extend(list(sitepackages))
     for name, module in sys.modules.items():
         if hasattr(module, "__path__"):

--- a/solara/minisettings.py
+++ b/solara/minisettings.py
@@ -94,7 +94,7 @@ class BaseSettings:
     def __init__(self, **kwargs) -> None:
         cls = type(self)
         self._values = {**kwargs}
-        keys = set([k.upper() for k in os.environ.keys()])
+        keys = {k.upper() for k in os.environ.keys()}
         for key, field in cls.__dict__.items():
             if key in kwargs:
                 continue

--- a/solara/server/kernel.py
+++ b/solara/server/kernel.py
@@ -196,7 +196,7 @@ def deserialize_binary_message(bmsg):
 SESSION_KEY = b"solara"
 
 
-class WebsocketStream(object):
+class WebsocketStream:
     def __init__(self, session, channel: str):
         self.session = session
         self.channel = channel
@@ -222,7 +222,7 @@ def send_websockets(websockets: Set[websocket.WebsocketWrapper], binary_msg):
 
 class SessionWebsocket(session.Session):
     def __init__(self, *args, **kwargs):
-        super(SessionWebsocket, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.websockets: Set[websocket.WebsocketWrapper] = set()  # map from .. msg id to websocket?
 
     def close(self):
@@ -263,7 +263,7 @@ class Kernel(ipykernel.kernelbase.Kernel):
     banner = "solara"
 
     def __init__(self):
-        super(Kernel, self).__init__()
+        super().__init__()
         self.session = SessionWebsocket(parent=self, key=SESSION_KEY)
         self.msg_queue = queue.Queue()  # type: ignore
         self.stream = self.iopub_socket = WebsocketStream(self.session, "iopub")

--- a/solara/server/reload.py
+++ b/solara/server/reload.py
@@ -98,7 +98,7 @@ else:
                 self.directories.add(directory)
 
         def on_modified(self, event):
-            super(WatcherWatchdog, self).on_modified(event)
+            super().on_modified(event)
             logger.debug("Watch event: %s", event)
             if not event.is_directory:
                 if event.src_path in self.files:

--- a/solara/website/pages/apps/scatter.py
+++ b/solara/website/pages/apps/scatter.py
@@ -28,10 +28,10 @@ class State:
 
     @staticmethod
     def load_sample():
-        State.x.value = str("gdpPercap")
-        State.y.value = str("lifeExp")
-        State.size.value = str("pop")
-        State.color.value = str("continent")
+        State.x.value = "gdpPercap"
+        State.y.value = "lifeExp"
+        State.size.value = "pop"
+        State.color.value = "continent"
         State.logx.value = True
         State.df.value = df_sample
 

--- a/solara/website/pages/doc_use_download.py
+++ b/solara/website/pages/doc_use_download.py
@@ -20,7 +20,7 @@ def DownloadFile(file_path=file_path, url=url, expected_size=expected_size, on_d
         status = "Done 🎉"
     else:
         MEGABYTES = 2.0**20.0
-        status = "Downloading %s... (%6.2f/%6.2f MB)" % (file_path, downloaded_size / MEGABYTES, expected_size / MEGABYTES)
+        status = "Downloading {}... ({:6.2f}/{:6.2f} MB)".format(file_path, downloaded_size / MEGABYTES, expected_size / MEGABYTES)
     # status = "hi"
     # return MarkdownIt(f'{status}')
     assert download.progress is not None


### PR DESCRIPTION
Refactor, cleanup and remove old Python 2 and =<3.5 constructs and replace them with modern Python 3.6+ syntax.

- Remove the default subclass (object) when defining a class
- Use New Super syntax ([PEP 3135](https://peps.python.org/pep-3135/))
- Define sets with curly braces `{}` instead of `set()`
- Remove forced `str("native")` literals
- Replace percent-formatted strings by .format() strings

Used [pyupgrade](https://github.com/asottile/pyupgrade) 3.15.0 with `--py36-plus` as starting point for this PR.