### PR TITLE
refactor: replace --dev with --auto-restart and have a --production mode

### DIFF
--- a/solara/server/reload.py
+++ b/solara/server/reload.py
@@ -9,6 +9,8 @@ import threading
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Set, Type
 
+import solara.server.settings as settings
+
 NO_WATCHDOG = False
 try:
     from watchdog.events import FileSystemEventHandler
@@ -126,7 +128,8 @@ class Reloader:
         self.watched_modules: Set[str] = set()
         self._first = True
         self.on_change: Optional[Callable[[str], None]] = on_change
-        self.watcher = WatcherType([], self._on_change)
+        WatcherCls = WatcherType if settings.main.mode == "development" else WatcherDummy
+        self.watcher = WatcherCls([], self._on_change)
         self.requires_reload = False
         self.ignore_modules: Set[str] = set()
         self.reload_event_next = threading.Event()

--- a/solara/website/pages/docs/content/15-reference/80-reloading.md
+++ b/solara/website/pages/docs/content/15-reference/80-reloading.md
@@ -12,9 +12,14 @@ The solara server automatically watches all `.vue` files that are used by vue te
 When a `.vue` file is saved, the widgets get updated automatically, without needing a page reload, aiding rapid development.
 
 
-## Reloading after changes to the solara packages
+## Restarting the server after changes to the solara packages
 
 
 You don't need to care about this feature if you only use solara, this is only relevant for development on solara itself, [see also development instructions](/docs/development).
 
-If the `--dev` flag is passed to solara-server, if any changes occur in the `solara` package (excluding `solara.webpage`), solara-server will restart. This takes slightly longer, but speeds up development on `solara-server` itself for developers.
+If the `--auto-restart/-a` flag is passed to solara-server and any changes occur in the `solara` package (excluding `solara.webpage`), solara-server will restart. This speeds up development on `solara-server` for developers since you do not
+need to manually restart the server in the terminal.
+
+## Disabling reloading
+
+In production mode (pass the `--production` argument to `solara run`) watching of files is disabled, and no reloading of files or vue templates will occur. If you run solara integrated in flask or uvicorn as laid out in [deployment documentation](https://solara.dev/docs/deploying/self-hosted)

--- a/solara/website/pages/docs/content/20-understanding/50-solara-server.md
+++ b/solara/website/pages/docs/content/20-understanding/50-solara-server.md
@@ -14,10 +14,20 @@ HTTP/1.1 200 OK
 ...
 ```
 
+
+## Production mode
+
+By default, solara runs in development mode. This means, it will:
+
+   * Automatically [reload your project files](docs/reference/reloading) by watching files on the filesystemn
+   * Load debug version of the CSS files and JavaScript files for improved error messages (which leads to larger asset files).
+
+To disabled all of these option, pass the `--production` flag, or set the environment variable `SOLARA_MODE=production`.
+
 ## Telemetry
 
 Solara uses Mixpanel to collect usage of the solara server. We track when a server is started, stopped and a daily report of the number of unique users and connections made. To opt out of mixpanel telemetry, either:
 
  * Set the environmental variable `SOLARA_TELEMETRY_MIXPANEL_ENABLE` to `False`.
- * Run in development mode (e.g. using `$ solara run sol.py --dev`)
  * Install [python-dotenv](https://pypi.org/project/python-dotenv/) and put `SOLARA_TELEMETRY_MIXPANEL_ENABLE=False` in a `.env` file.
+ * Run in auto restart mode (e.g. using `$ solara run sol.py --auto-restart`)

--- a/solara/website/pages/docs/content/30-deploying/10-self-hosted.md
+++ b/solara/website/pages/docs/content/30-deploying/10-self-hosted.md
@@ -16,7 +16,7 @@ Solara runs on several web frameworks, such as
 
 The most straightforward and well-tested method to deploy Solara is through the `solara run` command:
 
-    $ solara run sol.py
+    $ solara run sol.py --production
 
 which uses Starlette under the hood.
 
@@ -42,13 +42,13 @@ def Page():
 ```
 
 
-If you're aiming to integrate Solara with other web frameworks such as [Flask](https://flask.palletsprojects.com/deploying/), [Starlette](https://www.starlette.io/), or [FastAPI](https://fastapi.tiangolo.com/), you shouldn't execute `solara run sol.py`.
+If you're aiming to integrate Solara with other web frameworks such as [Flask](https://flask.palletsprojects.com/deploying/), [Starlette](https://www.starlette.io/), or [FastAPI](https://fastapi.tiangolo.com/), you normally do not execute `solara run sol.py`.
 Instead, start your chosen web framework as directed by their documentation and configure Solara via environment variables. For instance, instead of running the development server like `solara run sol.py`, set the `SOLARA_APP` environment variable to `sol.py`:
 
     $ export SOLARA_APP=sol.py
     # run flask or starlette
 
-or look at the examples below for more detailed instructions per web framework.
+or look at the examples below for more detailed instructions per web framework. Note that when solara is used this way it [by default runs in production mode](https://solara.dev/docs/understanding/solara-server).
 
 ## Flask
 
@@ -259,7 +259,7 @@ Your Dockerfile could look like:
 FROM ....
 
 ...
-CMD ["solara", "run", "sol.py", "--host=0.0.0.0"]
+CMD ["solara", "run", "sol.py", "--host=0.0.0.0", "--production"]
 
 ```
 

--- a/solara/website/pages/docs/content/90-development/10-setup.md
+++ b/solara/website/pages/docs/content/90-development/10-setup.md
@@ -10,16 +10,15 @@ Assuming you have created a virtual environment as described in [the installatio
     $ pip install ".[dev,documentation]"  # documentation is optional
 
 
-## Running Solara in dev mode
+## Running Solara server in auto restart mode
 
-By passing the `--dev` flag, solara enters "dev" mode, which makes it friendlier for development
+By passing the `--auto-restart/-a` flag, the solara server will automatically restart when the sourcecode of the solara server changes, which makes it friendlier for development
 
-    $ solara run myscript.py --dev
+    $ solara run myscript.py -a
 
 This will:
 
     * Automatically restart the server if any of the source code of solara changes (excluding solara.website)
-    * Load non-minified JS/CSS to make debugging easier)
 
 ## Contributing
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,11 +4,14 @@ import sys
 import pytest
 from dotenv import load_dotenv
 
+import solara.server.reload
 import solara.server.settings
 
 load_dotenv()  # take environment variables from .env.  should be in os.environ for the whole test
 
 solara.server.settings.telemetry.mixpanel_token = "adbf863d17cba80db608788e7fce9843"
+solara.server.settings.main.mode = "development"
+solara.server.reload.reloader.watcher = solara.server.reload.WatcherType([], solara.server.reload.reloader._on_change)
 
 
 @pytest.fixture


### PR DESCRIPTION
Before, we had a --dev mode that would auto-restart the server when
files changed. This means that auto restart was connected to dev mode.
Now, by default solara is in development mode, and the --auto-restart
option is separated.
This means that we now have a special --production mode that should
be used in production settings. It will serve users with minimized
JS and CSS and disable project and .vue reloading.

This means --reload (a bad and confusing name) and --dev are now
deprecated, but will behave the same as --auto-reload/-a.