### PR TITLE
fix: only try to watch files that exists

### DIFF
--- a/solara/server/reload.py
+++ b/solara/server/reload.py
@@ -228,7 +228,7 @@ class Reloader:
                     path = inspect.getfile(module)
                 except Exception:
                     pass
-                if path:
+                if path and Path(path).exists():
                     if not path.startswith(sys.prefix):
                         self.watcher.add_file(path)
                         self.watched_modules.add(modname)


### PR DESCRIPTION
Appearently, a module does not always point to a proper file, as shown in #353 .
Fixes #353