### PR TITLE
feat(testing): add option to not load vuetify assets before testing

### DIFF
--- a/solara/test/pytest_plugin.py
+++ b/solara/test/pytest_plugin.py
@@ -376,7 +376,7 @@ def create_runner_voila(voila_server, notebook_path, page_session: "playwright.s
     count = 0
     base_url = voila_server.base_url
 
-    def run(f: Callable):
+    def run(f: Callable, locals={}):
         nonlocal count
         path = Path(f.__code__.co_filename)
         cwd = str(path.parent)
@@ -384,6 +384,8 @@ def create_runner_voila(voila_server, notebook_path, page_session: "playwright.s
 import os
 os.chdir({cwd!r})
         \n"""
+        for name, value in locals.items():
+            code_setup += f"{name} = {value!r}\n"
         if require_vuetify_warmup:
             write_notebook([code_setup, code_from_function(warmup), code_from_function(f)], notebook_path)
         else:
@@ -405,7 +407,7 @@ def create_runner_jupyter_lab(jupyter_server, notebook_path, page_session: "play
     count = 0
     base_url = jupyter_server.base_url
 
-    def run(f: Callable):
+    def run(f: Callable, locals={}):
         nonlocal count
         path = Path(f.__code__.co_filename)
         cwd = str(path.parent)
@@ -418,6 +420,8 @@ os.chdir({cwd!r})
 import ipyvuetify as v;
 display(v.Btn(children=['Warmup js/css/fonts', v.Icon(children=["mdi-check"])], class_="solara-warmup-widget"))
         \n"""
+        for name, value in locals.items():
+            code_setup += f"{name} = {value!r}\n"
 
         write_notebook([code_setup, code_from_function(f)], notebook_path)
         page_session.goto(base_url + f"/lab/workspaces/solara-test/tree/notebook.ipynb?reset&v={count}")
@@ -449,7 +453,7 @@ def create_runner_jupyter_notebook(jupyter_server, notebook_path, page_session: 
     count = 0
     base_url = jupyter_server.base_url
 
-    def run(f: Callable):
+    def run(f: Callable, locals={}):
         nonlocal count
         path = Path(f.__code__.co_filename)
         cwd = str(path.parent)
@@ -462,6 +466,8 @@ os.chdir({cwd!r})
 import ipyvuetify as v;
 display(v.Btn(children=['Warmup js/css/fonts', v.Icon(children=["mdi-check"])], class_="solara-warmup-widget"))
         \n"""
+        for name, value in locals.items():
+            code_setup += f"{name} = {value!r}\n"
         write_notebook([code_setup, code_from_function(f)], notebook_path)
         page_session.goto(base_url + f"/notebooks/notebook.ipynb?v={count}")
         page_session.locator(".prompt_container >> nth=0").wait_for()
@@ -481,7 +487,7 @@ display(v.Btn(children=['Warmup js/css/fonts', v.Icon(children=["mdi-check"])], 
 def create_runner_solara(solara_server, solara_app, page_session: "playwright.sync_api.Page", require_vuetify_warmup: bool):
     count = 0
 
-    def run(f: Callable):
+    def run(f: Callable, locals={}):
         nonlocal count
         path = Path(f.__code__.co_filename)
         cwd = str(path.parent)

--- a/solara/website/pages/docs/content/10-howto/50-testing.md
+++ b/solara/website/pages/docs/content/10-howto/50-testing.md
@@ -141,3 +141,7 @@ To configure the hostname the socket is bound to when starting the test server, 
 ## Changing the Port
 
 To configure the ports the socket is bound to when starting the test servers, use the `PORT` environment variable (e.g. `PORT=18865`). This port and subsequent port will be used for solara-server, jupyter-server and voila. Alternatively the `--solara-port` argument can be passed on the command line for pytest for the solara server, and `--jupyter-port` and `--voila-port` for the ports of jupyter server and voila respectively.
+
+## Vuetify warmup
+
+By default, we insert an ipyvuetify widget with an icon into the frontend to force loading all the vuetify assets, such as CSS and fonts. However, if you are using the solara test plugin to test pure ipywidgets or a 3rd ipywidget based party library you might not need this. Disable this vuetify warmup phase by passing the `--no-solara-vuetify-warmup` argument to pytest, or setting the environment variable `SOLARA_TEST_VUETIFY_WARMUP` to a falsey value (e.g. `SOLARA_TEST_VUETIFY_WARMUP=0`).

--- a/solara/website/pages/docs/content/10-howto/50-testing.md
+++ b/solara/website/pages/docs/content/10-howto/50-testing.md
@@ -81,7 +81,9 @@ def test_solara_button_all(ipywidgets_runner, page_session: playwright.sync_api.
     page_session.wait_for_timeout(1000)
 ```
 
-Note that the function in the code will be executed in a different process, which will make it harder to debug and slower to run.
+Note that the function in the code will be executed in a different process (a Jupyter kernel), which will make it harder to debug and slower to run.
+Because the function code executes in the kernel, you do not have access to local variables. However, by passing a dictionary as second argument
+to `ipywidgets_runner` we can pass in extra local variables (e.g. `ipywidgets_runner(kernel_code, {"extra_argument": extra_argument})`).
 
 ## Limiting the Jupyter Environments
 To limit the ipywidgets_runner fixture to only run in a specific environment, use the `SOLARA_TEST_RUNNERS` environment variable:


### PR DESCRIPTION
We need this to test a new ipyvue version that might not have a vuetify
version that works. Also, if a non-ipyvuetify based test is run, this
step can be skipped.