### PR TITLE
fix: avoid re-render when using sidebar or appbar

### DIFF
--- a/solara/components/applayout.py
+++ b/solara/components/applayout.py
@@ -252,8 +252,6 @@ def AppLayout(
     title = t.use_title_get() or title
     children_appbartitle = apptitle_portal.use_portal()
     show_app_bar = (title and (len(routes) > 1 and navigation)) or children_appbar or use_drawer or children_appbartitle
-    if not show_app_bar and not children_sidebar and len(children) == 1:
-        return children[0]
 
     def set_path(index):
         path = paths[index]
@@ -329,23 +327,25 @@ def AppLayout(
                         if not show_app_bar:
                             AppIcon(sidebar_open, on_click=lambda: set_sidebar_open(not sidebar_open))
                         v.Html(tag="div", children=children_sidebar, style_="padding: 12px;").meta(ref="sidebar-content")
-                else:
-                    AppIcon(sidebar_open, on_click=lambda: set_sidebar_open(not sidebar_open), style_="position: absolute; z-index: 2")
             if show_app_bar:
                 # if hide_on_scroll is True, and we have a little bit of scrolling, vuetify seems to act strangely
                 # when scrolling (on @mariobuikhuizen/vuetify v2.2.26-rc.0
-                with v.AppBar(color="primary", dark=True, app=True, clipped_left=True, hide_on_scroll=False, v_slots=v_slots):
+                with v.AppBar(color="primary", dark=True, app=True, clipped_left=True, hide_on_scroll=False, v_slots=v_slots).key("app-layout-appbar"):
                     if use_drawer:
                         AppIcon(sidebar_open, on_click=lambda: set_sidebar_open(not sidebar_open))
                     if title or children_appbartitle:
                         v.ToolbarTitle(children=children_appbartitle or [title])
                     v.Spacer()
-                    for child in children_appbar:
-                        solara.display(child)
+                    for i, child in enumerate(children_appbar):
+                        # if the user already provided a key, don't override it
+                        if child._key is None:
+                            solara.display(child.key(f"app-layout-appbar-user-child-{i}"))
+                        else:
+                            solara.display(child)
                     if fullscreen:
                         solara.Button(icon_name="mdi-fullscreen-exit", on_click=lambda: set_fullscreen(False), icon=True, dark=False)
 
-            with v.Content(class_="solara-content-main", style_="height: 100%;"):
+            with v.Content(class_="solara-content-main", style_="height: 100%;").key("app-layout-content"):
                 # make sure the scrollbar does no go under the appbar by adding overflow: auto
                 # to a child of content, because content has padding-top: 64px (set by vuetify)
                 # the padding: 12px is needed for backward compatibility with the previously used

--- a/solara/test/pytest_plugin.py
+++ b/solara/test/pytest_plugin.py
@@ -197,6 +197,13 @@ def _solara_test(solara_server, solara_app, page_session: "playwright.sync_api.P
                     assert context.container
                     context.container.children[0].children[1].children[1].children = [test_output_warmup]  # type: ignore
                     with test_output_warmup:
+                        page_session.add_style_tag(
+                            content="""
+                            .solara-content-main {
+                                animation-duration: 0s !important;
+                            }
+                        """
+                        )
                         if require_vuetify_warmup:
                             warmup()
                             button = page_session.locator(".solara-warmup-widget")

--- a/tests/unit/applayout_test.py
+++ b/tests/unit/applayout_test.py
@@ -96,3 +96,87 @@ def test_sidebar():
     rc.find(v.NavigationDrawer).assert_empty()
     set_content(5)
     assert len(rc.find(v.ToolbarTitle).widget.children) == 3
+
+
+def test_no_rerender():
+    have_sidebar = solara.reactive(False)
+    have_app_bar = solara.reactive(False)
+    content_use_effects = 0
+    content_renders = 0
+    app_bar_use_effects = 0
+    app_bar_renders = 0
+
+    @solara.component
+    def AppBarComponent():
+        nonlocal app_bar_renders, app_bar_use_effects
+
+        def effect():
+            nonlocal app_bar_use_effects
+            app_bar_use_effects += 1
+
+        solara.use_effect(effect, [])
+        app_bar_renders += 1
+        solara.Button("1")
+        solara.Button("2")
+
+    @solara.component
+    def Content():
+        nonlocal content_renders, content_use_effects
+
+        def effect():
+            nonlocal content_use_effects
+            content_use_effects += 1
+
+        solara.use_effect(effect, [])
+        content_renders += 1
+        if have_app_bar.value:
+            with solara.AppBar():
+                AppBarComponent()
+
+        if have_sidebar.value:
+            with solara.Sidebar():
+                solara.Button("Hi")
+        with solara.Card("Content"):
+            solara.Markdown("This is the content")
+
+    @solara.component
+    def Layout():
+        with solara.AppLayout(title="Test"):
+            Content()
+
+    box, rc = solara.render(Layout(), handle_error=False)
+    assert len(rc.find(v.NavigationDrawer).find(v.Btn, children=["Hi"])) == 0
+    assert len(rc.find(v.AppBar).find(v.Btn)) == 0
+    assert content_renders == 1
+    assert content_use_effects == 1
+    assert app_bar_renders == 0
+    assert app_bar_use_effects == 0
+
+    have_app_bar.value = True
+    assert len(rc.find(v.AppBar).find(v.Btn)) == 2
+    assert content_renders == 2
+    assert content_use_effects == 1
+    assert app_bar_renders == 1
+    assert app_bar_use_effects == 1
+
+    have_sidebar.value = True
+    assert len(rc.find(v.NavigationDrawer).find(v.Btn, children=["Hi"])) == 1
+    assert len(rc.find(v.AppBar).find(v.Btn)) == 2
+    assert content_renders == 3
+    assert content_use_effects == 1
+    assert app_bar_renders == 1
+    assert app_bar_use_effects == 1
+    rc.close()
+
+    # now, a render with in 1 go
+    content_renders = 0
+    content_use_effects = 0
+    app_bar_renders = 0
+    app_bar_use_effects = 0
+    box, rc = solara.render(Layout(), handle_error=False)
+    assert len(rc.find(v.NavigationDrawer).find(v.Btn, children=["Hi"])) == 1
+    assert len(rc.find(v.AppBar).find(v.Btn)) == 2
+    assert content_renders == 1
+    assert content_use_effects == 1
+    assert app_bar_renders == 1
+    assert app_bar_use_effects == 1


### PR DESCRIPTION
Before we had a 'fast path' which did not render the nav drawer and
appbar when not used. This caused a different component tree to be
rendered, which caused a re-render of the entire app.

This also causes our parent div to always be the same, which will
make the app behave more consistently (always 100vh parent).

Fixes #331