### PR TITLE
fix: None value in ToggleButtons resulted in Button label value

### DIFF
--- a/solara/components/togglebuttons.py
+++ b/solara/components/togglebuttons.py
@@ -12,11 +12,12 @@ T = TypeVar("T")
 
 
 def _get_button_value(button: reacton.core.Element):
-    value = button.kwargs.get("value")
-    if value is None:
+    if "value" in button.kwargs:
+        value = button.kwargs["value"]
+    else:
         value = button.kwargs.get("label")
-    if value is None and button.args:
-        value = button.args[0]
+        if value is None and button.args:
+            value = button.args[0]
     return value
 
 
@@ -125,7 +126,7 @@ def ToggleButtonsSingle(
     # When mandatory = True, index should not be None, but we are letting the front-end take care of setting index to 0 because of a bug
     # (see https://github.com/widgetti/solara/issues/282)
     # TODO: set index to 0 on python side (after #282 is resolved)
-    index, set_index = solara.use_state_or_update(values.index(reactive_value.value) if reactive_value.value is not None else None, key="index")
+    index, set_index = solara.use_state_or_update(values.index(reactive_value.value) if reactive_value.value in values else None, key="index")
 
     def on_index(index):
         set_index(index)

--- a/tests/unit/toggle_button_test.py
+++ b/tests/unit/toggle_button_test.py
@@ -12,11 +12,16 @@ def test_toggle_buttons_single():
             solara.Button("Aap", value="aap")
             solara.Button("Noot", value="noot")
             solara.Button("Mies", value="mies")
+            solara.Button("Nobody", value=None)
 
     group, rc = solara.render_fixed(Test())
     assert group.v_model == 1
     group.v_model = 2
     assert value.value == "mies"
+    group.v_model = 3
+    assert value.value is None
+    # we don't want it to change the index to None
+    assert group.v_model == 3
 
 
 def test_toggle_buttons_multiple():


### PR DESCRIPTION
In the example below, before, we would get the value 'default'
instead of the value `None`.
```
import solara

@solara.component
def Page():
    size = solara.use_reactive(None)
    print("size", repr(size.value))

    with solara.ToggleButtonsSingle(value=size, on_value=size.set):
        solara.Button("x-small", value="x-small")
        solara.Button("small", value="small")
        solara.Button("default", value=None)
        solara.Button("large", value="large")
        solara.Button("x-large", value="x-large")
```