### PR TITLE
fix: do not trigger re-render due to unneeded state in context

### DIFF
--- a/solara/components/applayout.py
+++ b/solara/components/applayout.py
@@ -32,12 +32,12 @@ def _set_sidebar_default(updater: Callable[[PortalElements], PortalElements]):
 
 class ElementPortal:
     def __init__(self):
-        self.context = solara.create_context((cast(PortalElements, {}), _set_sidebar_default))
+        self.context = solara.create_context(_set_sidebar_default)
 
     # TODO: can we generalize the use of 'portals' ? (i.e. transporting elements from one place to another)
     def use_portal(self) -> List[Element]:
         portal_elements, set_portal_elements = solara.use_state(cast(PortalElements, {}))
-        self.context.provide((portal_elements, set_portal_elements))  # type: ignore
+        self.context.provide(set_portal_elements)  # type: ignore
 
         portal_elements_flat: List[Tuple[int, Element]] = []
         for uuid, value in portal_elements.items():
@@ -47,7 +47,7 @@ class ElementPortal:
 
     def use_portal_add(self, children: List[Element], offset: int):
         key = solara.use_unique_key(prefix="portal-")
-        portal_elements, set_portal_elements = solara.use_context(self.context)
+        set_portal_elements = solara.use_context(self.context)
         values: List[Tuple[int, Element]] = []
         for i, child in enumerate(children):
             values.append((offset + i, child))

--- a/solara/components/title.py
+++ b/solara/components/title.py
@@ -21,12 +21,12 @@ def _set_titles_default(updater: Callable[[Titles], Titles]):
     pass
 
 
-titles_context = solara.create_context((cast(Titles, {}), _set_titles_default))
+titles_context = solara.create_context(_set_titles_default)
 
 
 def use_title_get() -> Optional[str]:
     titles, set_titles = solara.use_state(cast(Titles, {}))
-    titles_context.provide((titles, set_titles))  # type: ignore
+    titles_context.provide(set_titles)  # type: ignore
     if titles:
         title = max([(order, title) for (key, (order, title)) in titles.items()], key=lambda x: x[0])[1]
     else:
@@ -36,7 +36,7 @@ def use_title_get() -> Optional[str]:
 
 def use_title_set(title: str, offset: int):
     key = solara.use_unique_key(prefix="title-")
-    _titles, set_titles = solara.use_context(titles_context)
+    set_titles = solara.use_context(titles_context)
 
     def update():
         set_titles(lambda titles: {**titles, key: (offset, title)})


### PR DESCRIPTION
The title change caused a render twice.