### PR TITLE
fix: display() did not work in threads

### DIFF
--- a/solara/server/patch.py
+++ b/solara/server/patch.py
@@ -257,8 +257,14 @@ def WidgetContextAwareThread__init__(self, *args, **kwargs):
 def Thread_debug_run(self):
     if self.current_context:
         kernel_context.set_context_for_thread(self.current_context, self)
-    with pdb_guard():
-        Thread__run(self)
+        shell = self.current_context.kernel.shell
+        shell.display_pub.register_hook(shell.display_in_reacton_hook)
+    try:
+        with pdb_guard():
+            Thread__run(self)
+    finally:
+        if self.current_context:
+            shell.display_pub.unregister_hook(shell.display_in_reacton_hook)
 
 
 _patched = False

--- a/tests/unit/display_test.py
+++ b/tests/unit/display_test.py
@@ -1,0 +1,43 @@
+import threading
+import time
+
+import solara
+
+
+def test_display_in_thread(kernel_context):
+    rendered_in_thread = threading.Event()
+    column = None
+    render_count = 0
+
+    @solara.component
+    def Page():
+        nonlocal column
+        nonlocal render_count
+        render_count += 1
+        force_redraw = solara.use_reactive(0)
+
+        def run():
+            time.sleep(0.1)
+            force_redraw.value = 1
+
+        solara.use_thread(run, dependencies=[])
+
+        def set_event():
+            if force_redraw.value == 1:
+                rendered_in_thread.set()
+
+        solara.use_effect(set_event, dependencies=[force_redraw.value])
+
+        s = solara.SliderInt("test")
+        with solara.Column() as current_column:
+            solara.display("test")
+            solara.Button("test")
+            solara.display(s)
+        if force_redraw.value == 1:
+            column = current_column
+
+    _, rc = solara.render(Page(), handle_error=False)
+    rendered_in_thread.wait(timeout=2)
+    assert column is not None
+    # assert render_count == 3
+    assert len(column.kwargs["children"]) == 3


### PR DESCRIPTION
We did not attach a display hook to the thread.
Other ways to fix could be to attach a default output instead of using
the display hook.