### PR TITLE
perf: throttle sending websocket messages

### DIFF
--- a/solara/server/settings.py
+++ b/solara/server/settings.py
@@ -151,6 +151,7 @@ class MainSettings(BaseSettings):
     base_url: str = ""  # e.g. https://myapp.solara.run/myapp/
     platform: str = sys.platform
     host: str = HOST_DEFAULT
+    experimental_performance: bool = False
 
     class Config:
         env_prefix = "solara_"


### PR DESCRIPTION
This gives a better performance for starlette.
enable with SOLARA_EXPERIMENTAL_PERFORMANCE=1