### PR TITLE
feat: avoid cache hits when js or css resources change using hash param

### DIFF
--- a/solara/server/templates/solara.html.j2
+++ b/solara/server/templates/solara.html.j2
@@ -24,20 +24,15 @@
     {% if assets.fontawesome_enabled == True %}
     <link rel="stylesheet" href="{{cdn}}{{assets.fontawesome_path}}" type="text/css">
     {% endif %}
-    <link href="{{root_path}}/static/highlight.css" rel="stylesheet">
-    <link href="{{root_path}}/static/highlight-dark.css" rel="stylesheet">
-    </link>
-    <link href="{{root_path}}/static/assets/style.css" rel="stylesheet">
-    </link>
+    {{ resources.include_css("/static/highlight.css") }}
+    {{ resources.include_css("/static/highlight-dark.css") }}
+    {{ resources.include_css("/static/assets/style.css") }}
     {% if theme.variant == "light" %}
-    <link href="{{root_path}}/static/assets/theme-light.css" rel="stylesheet">
-    </link>
+        {{ resources.include_css("/static/assets/theme-light.css") }}
     {% elif theme.variant == "dark" %}
-    <link href="{{root_path}}/static/assets/theme-dark.css" rel="stylesheet">
-    </link>
+        {{ resources.include_css("/static/assets/theme-dark.css") }}
     {% endif %}
-    <link href="{{root_path}}/static/assets/custom.css" rel="stylesheet">
-    </link>
+    {{ resources.include_css("/static/assets/custom.css") }}
 
     <script id="jupyter-config-data" type="application/json">
     {
@@ -238,13 +233,13 @@
         console.log("rootPath", solara.rootPath);
     </script>
 
-    <script src="{{root_path}}/static/assets/custom.js"></script>
-    <script src="{{root_path}}/static/assets/theme.js"></script>
+    {{ resources.include_js("/static/assets/custom.js") }}
+    {{ resources.include_js("/static/assets/theme.js") }}
 
     <script src="{{cdn}}/requirejs@2.3.6/require.js" crossorigin="anonymous">
     </script>
-    <script src="{{root_path}}/static/main-vuetify.js"></script>
-    <script src="{{root_path}}/static/ansi.js"></script>
+    {{ resources.include_js("/static/main-vuetify.js") }}
+    {{ resources.include_js("/static/ansi.js") }}
 
     <script>
         solara.production = {{ production | tojson | safe }};

--- a/solara/util.py
+++ b/solara/util.py
@@ -1,11 +1,12 @@
 import base64
 import contextlib
+import hashlib
 import os
 import sys
 import threading
 from collections import abc
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Union
+from typing import TYPE_CHECKING, Dict, List, Tuple, Union
 
 if TYPE_CHECKING:
     import numpy as np
@@ -252,3 +253,15 @@ def parse_timedelta(size: str) -> float:
         return float(size[:-1])
     else:
         return float(size)
+
+
+def get_file_hash(path: Path, algorithm="md5") -> Tuple[bytes, str]:
+    """Compute the hash of a file. Note that we also return the file content as bytes."""
+    data = path.read_bytes()
+    if sys.version_info[:2] < (3, 9):
+        # usedforsecurity is only available in Python 3.9+
+        h = hashlib.new(algorithm)
+    else:
+        h = hashlib.new(algorithm, usedforsecurity=False)  # type: ignore
+    h.update(data)
+    return data, h.hexdigest()


### PR DESCRIPTION
We include css and js resources with a p=<hash> parameter to avoid hitting the browser cache and serving old versions of the files.

Small contents <10kb are inlined in the html file.

Should solve: 
 * https://github.com/widgetti/solara/discussions/430
 * https://github.com/widgetti/solara/discussions/311
 * https://github.com/widgetti/solara/issues/425

Closes https://github.com/widgetti/solara/issues/315