### PR TITLE
Add support for customized authentication for fastAPI and starlett

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ dev = [
     "types-markdown",
     "types-PyYAML",
     "pytest",
+    "pytest-asyncio",
     "pytest-mock",
     "pytest-cov",
     "pytest-timeout",

--- a/solara/server/auth_decorator.py
+++ b/solara/server/auth_decorator.py
@@ -48,11 +48,11 @@ def import_module_from_env_var(env_var_name):
         raise e(f"Failed to import module: {e}")
 
 
-def basic_auth(func):
+def auth_required(func):
     """Allow user to customized the authentication when accessing a path."""
     @wraps(func)
     async def wrapper(request: Request, *args, **kwargs):
-        if module := import_module_from_env_var('BASIC_AUTH_MODULE_PATH'):
+        if module := import_module_from_env_var('AUTH_MODULE_PATH'):
             if not module.authenticate(request, *args, **kwargs):
                 raise HTTPException(
                     status_code=status.HTTP_401_UNAUTHORIZED, 

--- a/solara/server/auth_decorator.py
+++ b/solara/server/auth_decorator.py
@@ -24,7 +24,6 @@ def import_module_from_env_var(env_var_name):
     :return: Imported module or None if the file cannot be imported.
     """
 
-    # Read the file path from the environment variable
     file_path = os.getenv(env_var_name)
     if not file_path:
         logger.info(f"Environment variable {env_var_name} is not set, no auth will be applied.")

--- a/solara/server/basic_auth_decorator.py
+++ b/solara/server/basic_auth_decorator.py
@@ -1,0 +1,62 @@
+"""Method for accessing control"""
+from functools import wraps
+from starlette.requests import Request
+from starlette.exceptions import HTTPException
+from starlette import status
+import os
+import importlib.util
+import logging
+logger = logging.getLogger("solara.server.fastapi")
+
+NOT_AUTHRIZED_MESSAGE = "No sufficient user previlege"
+
+class BadAuthModulePath(Exception):
+    """System doesn't find the existing file by the given path"""
+
+class MethodNotFound(Exception):
+    """authenticate method should exist in the auth module."""
+
+def import_module_from_env_var(env_var_name):
+    """
+    Import a Python module from a file path defined in an environment variable.
+
+    :param env_var_name: Name of the environment variable containing the file path.
+    :return: Imported module or None if the file cannot be imported.
+    """
+
+    # Read the file path from the environment variable
+    file_path = os.getenv(env_var_name)
+    if not file_path:
+        logger.info(f"Environment variable {env_var_name} is not set, no auth will be applied.")
+        return None
+
+    if not os.path.exists(file_path):
+        logger.error(f"File {file_path} does not exist.")
+        raise BadAuthModulePath('File {file_path} does not exist.')
+
+    module_name = os.path.splitext(os.path.basename(file_path))[0]
+
+    try:
+        spec = importlib.util.spec_from_file_location(module_name, file_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        getattr(module, 'authenticate')
+        return module
+    except AttributeError:
+        raise MethodNotFound('authenticate method should exist in the auth module.')
+    except Exception as e:
+        raise e(f"Failed to import module: {e}")
+
+
+def basic_auth(func):
+    """Allow user to customized the authentication when accessing a path."""
+    @wraps(func)
+    async def wrapper(request: Request, *args, **kwargs):
+        if module := import_module_from_env_var('BASIC_AUTH_MODULE_PATH'):
+            if not module.authenticate(request, *args, **kwargs):
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED, 
+                    detail=NOT_AUTHRIZED_MESSAGE
+                )
+        return await func(request, *args, **kwargs)
+    return wrapper

--- a/solara/server/starlette.py
+++ b/solara/server/starlette.py
@@ -44,7 +44,7 @@ from starlette.types import Receive, Scope, Send
 
 import solara
 from solara.server.threaded import ServerBase
-from solara.server.basic_auth_decorator import basic_auth
+from solara.server.auth_decorator import auth_required
 from . import app as appmod
 from . import kernel_context, server, settings, telemetry, websocket
 from .cdn_helper import cdn_url_path, get_path
@@ -239,7 +239,7 @@ def close(request: Request):
     return response
 
 
-@basic_auth
+@auth_required
 async def root(request: Request, fullpath: str = ""):
     if settings.oauth.private and not has_auth_support:
         raise RuntimeError("SOLARA_OAUTH_PRIVATE requires solara-enterprise")

--- a/solara/server/starlette.py
+++ b/solara/server/starlette.py
@@ -44,7 +44,7 @@ from starlette.types import Receive, Scope, Send
 
 import solara
 from solara.server.threaded import ServerBase
-
+from solara.server.basic_auth_decorator import basic_auth
 from . import app as appmod
 from . import kernel_context, server, settings, telemetry, websocket
 from .cdn_helper import cdn_url_path, get_path
@@ -239,6 +239,7 @@ def close(request: Request):
     return response
 
 
+@basic_auth
 async def root(request: Request, fullpath: str = ""):
     if settings.oauth.private and not has_auth_support:
         raise RuntimeError("SOLARA_OAUTH_PRIVATE requires solara-enterprise")

--- a/solara/website/pages/docs/content/50-enterprise/20-customized-oauth.md
+++ b/solara/website/pages/docs/content/50-enterprise/20-customized-oauth.md
@@ -1,0 +1,22 @@
+# Customize Oauth with fastAPI
+
+If you're using FastAPI integration with solara, the Oauth can be customized if the two supported methods([Auth0](https://auth0.com/) and [Fief](https://fief.dev/)) doesn't fit for you.
+
+## How to configure customized authorization method:
+
+### Implement your own authentication python module that include a `authentication` method like below:
+
+example of: my_own_oauth_authentication.py
+```
+def authenticate(request: Request):
+    """
+    :param request: FastAPI request object which is available on every endpoint
+    :return: True or False, if False, it will auto matically raise a 401 Unauthorized Exception.
+    """
+    if token := requests.headers.get('Authorization'):
+        return verify_token(token)
+```
+
+### Export the path of the module to environment variable
+
+`export AUTH_MODULE_PATH=file/to/your/my_own_oauth_authentication.py`

--- a/solara/website/pages/docs/content/50-enterprise/20-customized-oauth.md
+++ b/solara/website/pages/docs/content/50-enterprise/20-customized-oauth.md
@@ -1,6 +1,6 @@
-# Customize Oauth with fastAPI
+# Customize Oauth with fastAPI and Starlette
 
-If you're using FastAPI integration with solara, the Oauth can be customized if the two supported methods([Auth0](https://auth0.com/) and [Fief](https://fief.dev/)) doesn't fit for you.
+If you're using FastAPI or startlette integration with solara, the Oauth can be customized if the two supported methods([Auth0](https://auth0.com/) and [Fief](https://fief.dev/)) doesn't fit for you.
 
 ## How to configure customized authorization method:
 

--- a/tests/unit/server/test_auth_decorator.py
+++ b/tests/unit/server/test_auth_decorator.py
@@ -1,7 +1,7 @@
-"""Unit test for basic_auth_decorator module"""
+"""Unit test for auth_decorator module"""
 import pytest
 from unittest.mock import patch
-from solara.server.basic_auth_decorator import import_module_from_env_var, BadAuthModulePath, MethodNotFound, basic_auth, NOT_AUTHRIZED_MESSAGE
+from solara.server.auth_decorator import import_module_from_env_var, BadAuthModulePath, MethodNotFound, auth_required, NOT_AUTHRIZED_MESSAGE
 from starlette.requests import Request
 from starlette.responses import Response
 from starlette import status
@@ -38,9 +38,9 @@ def test_import_module_success(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_auth_decorator_no_basic_auth(monkeypatch):
+async def test_auth_decorator_no_auth(monkeypatch):
 
-    @basic_auth
+    @auth_required
     async def test_func(request):
         return Response()
 
@@ -53,8 +53,8 @@ async def test_auth_decorator_no_basic_auth(monkeypatch):
 async def test_auth_decorator_no_auth_header(tmp_path, monkeypatch):
     module_file = tmp_path / "temp_module.py"
     module_file.write_text("def authenticate(request): ...")
-    monkeypatch.setenv('BASIC_AUTH_MODULE_PATH', str(module_file))
-    @basic_auth
+    monkeypatch.setenv('AUTH_MODULE_PATH', str(module_file))
+    @auth_required
     async def test_func(request):
         return Response()
     request = Mock()

--- a/tests/unit/server/test_basic_auth_decorator.py
+++ b/tests/unit/server/test_basic_auth_decorator.py
@@ -1,0 +1,64 @@
+"""Unit test for basic_auth_decorator module"""
+import pytest
+from unittest.mock import patch
+from solara.server.basic_auth_decorator import import_module_from_env_var, BadAuthModulePath, MethodNotFound, basic_auth, NOT_AUTHRIZED_MESSAGE
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette import status
+from starlette.exceptions import HTTPException
+from unittest.mock import Mock
+
+def test_import_module_env_var_not_set():
+    """test function without env var"""
+    assert import_module_from_env_var('NON_EXISTENT_ENV_VAR') is None
+
+def test_import_module_file_not_exist(caplog, monkeypatch):
+    """Test with module file that doesn't exist"""
+    monkeypatch.setenv('TEST_ENV_VAR', 'nonexistent.py')
+    with pytest.raises(BadAuthModulePath):
+        import_module_from_env_var('TEST_ENV_VAR')
+    assert "File nonexistent.py does not exist" in caplog.text
+
+def test_import_module_no_authenticate_method(tmp_path, monkeypatch):
+    """Test import module with no authenticate method"""
+    module_file = tmp_path / "temp_module.py"
+    module_file.write_text("")
+    monkeypatch.setenv('TEST_ENV_VAR', str(module_file))
+    with pytest.raises(MethodNotFound):
+        import_module_from_env_var('TEST_ENV_VAR')
+
+def test_import_module_success(tmp_path, monkeypatch):
+    """Test import module successfully."""
+    module_file = tmp_path / "temp_module.py"
+    module_file.write_text("def authenticate(request): ...")
+    monkeypatch.setenv('TEST_ENV_VAR', str(module_file))
+    module = import_module_from_env_var('TEST_ENV_VAR')
+    assert module is not None
+    assert hasattr(module, 'authenticate')
+
+
+@pytest.mark.asyncio
+async def test_auth_decorator_no_basic_auth(monkeypatch):
+
+    @basic_auth
+    async def test_func(request):
+        return Response()
+
+    request = Mock()
+    response = await test_func(request)
+    assert isinstance(response, Response)
+
+
+@pytest.mark.asyncio
+async def test_auth_decorator_no_auth_header(tmp_path, monkeypatch):
+    module_file = tmp_path / "temp_module.py"
+    module_file.write_text("def authenticate(request): ...")
+    monkeypatch.setenv('BASIC_AUTH_MODULE_PATH', str(module_file))
+    @basic_auth
+    async def test_func(request):
+        return Response()
+    request = Mock()
+    with pytest.raises(HTTPException) as excinfo:
+        await test_func(request)
+    assert excinfo.value.status_code == status.HTTP_401_UNAUTHORIZED
+    assert excinfo.value.detail == NOT_AUTHRIZED_MESSAGE


### PR DESCRIPTION
Propose a customized way to do authentication for fastAPI and starlette

the reason is nowadays some companies may already have their own solution other than existing Oauth providers currently supported in solara.
[Auth0](https://auth0.com/) and [Fief](https://fief.dev/)
this is to make it more flexible and give user options to implement their own authentication method.

## Usage:

`export AUTH_MODULE_PATH=file/to/your/authenticate_module.py`

the module need to have a method called `authenticate` and return is bool.