### PR TITLE
fix: docstring list indent

### DIFF
--- a/solara/components/file_browser.py
+++ b/solara/components/file_browser.py
@@ -65,13 +65,13 @@ def FileBrowser(
     There are two modes possible
 
      * `can_select=False`
-        * `on_file_open`: Triggered when **single** clicking a file or directory.
-        * `on_path_select`: Never triggered
-        * `on_directory_change`: Triggered when clicking a directory
+       * `on_file_open`: Triggered when **single** clicking a file or directory.
+       * `on_path_select`: Never triggered
+       * `on_directory_change`: Triggered when clicking a directory
      * `can_select=True`
-        * `on_file_open`: Triggered when **double** clicking a file or directory.
-        * `on_path_select`: Triggered when clicking a file or directory
-        * `on_directory_change`: Triggered when double clicking a directory
+       * `on_file_open`: Triggered when **double** clicking a file or directory.
+       * `on_path_select`: Triggered when clicking a file or directory
+       * `on_directory_change`: Triggered when double clicking a directory
 
     ## Arguments
 


### PR DESCRIPTION
Before:

![image](https://github.com/widgetti/solara/assets/50246090/4bd196e6-abc2-4132-b55e-e670048ce5d2)


After:

![image](https://github.com/widgetti/solara/assets/50246090/08765417-e755-4f89-b892-3dd20438c0ea)

Checked other docstrings, no similar issues.