### PR TITLE
feat: get_kernel_id and get_session_id for custom storage

### DIFF
--- a/solara/__init__.py
+++ b/solara/__init__.py
@@ -61,6 +61,7 @@ from .components import _component_vue
 from .routing import use_route, use_router, use_route_level, find_route, use_pathname, resolve_path
 from .autorouting import generate_routes, generate_routes_directory, RenderPage, RoutingProvider, DefaultLayout
 from .checks import check_jupyter
+from .scope import get_kernel_id, get_session_id
 
 
 def display(*objs, **kwargs):

--- a/solara/scope/__init__.py
+++ b/solara/scope/__init__.py
@@ -1,3 +1,4 @@
+import re
 import sys
 import threading
 from typing import MutableMapping
@@ -41,3 +42,46 @@ class ObservableDict(ObservableMutableMapping):
 
 worker = ObservableDict()
 connection = ConnectionScope()
+
+
+def get_kernel_id(ipython_fallback=True) -> str:
+    """Returns the kernel id, a unique string for each virtual kernel.
+
+    See [Understanding solara server](/docs/understanding/solara-server) for understanding the concept of virtual kernels
+    and their lifetime.
+
+    This unique ID can be useful to to implement storing state, scoped to a kernel. See [the scope example](/examples/general/scopes) for an example.
+
+    If `ipython_fallback` is `True` (default), this function will also work in IPython notebooks, where it will return the IPython kernel id.
+
+    """
+    import solara.server.kernel_context
+
+    try:
+        context = solara.server.kernel_context.get_current_context()
+    except RuntimeError as e:
+        if not ipython_fallback:
+            raise
+        import IPython
+
+        ipython = IPython.get_ipython()
+        if not ipython or not hasattr(ipython, "kernel"):
+            raise RuntimeError("Not in a kernel") from e
+        kernel = ipython.kernel
+        regex = r"[\\/]kernel-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.json$"
+        connection_file = kernel.config["IPKernelApp"]["connection_file"]
+        return re.compile(regex).search(connection_file).group(1)  # type: ignore
+    return context.id
+
+
+def get_session_id() -> str:
+    """Returns the session id, which is stored using a browser cookie.
+
+    See [Understanding solara server](/docs/understanding/solara-server#session) for more information about the Solara sessions.
+
+    This unique ID can be useful to to implement storing state, scoped to a browser session. See [the scope example](/examples/general/scopes) for an example.
+    """
+    import solara.server.kernel_context
+
+    context = solara.server.kernel_context.get_current_context()
+    return context.session_id

--- a/solara/website/pages/api/__init__.py
+++ b/solara/website/pages/api/__init__.py
@@ -95,7 +95,15 @@ items = [
     {
         "name": "Utils",
         "icon": "mdi-hammer-wrench",
-        "pages": ["display", "memoize", "reactive", "widget", "component_vue"],
+        "pages": [
+            "display",
+            "get_kernel_id",
+            "get_session_id",
+            "memoize",
+            "reactive",
+            "widget",
+            "component_vue",
+        ],
     },
     {
         "name": "Advanced",

--- a/solara/website/pages/api/get_kernel_id.py
+++ b/solara/website/pages/api/get_kernel_id.py
@@ -1,0 +1,16 @@
+"""
+# get_kernel_id
+
+"""
+import solara
+from solara.website.utils import apidoc
+
+from . import NoPage
+
+title = "get_kernel_id"
+
+
+Page = NoPage
+
+
+__doc__ += apidoc(solara.get_kernel_id)  # type: ignore

--- a/solara/website/pages/api/get_session_id.py
+++ b/solara/website/pages/api/get_session_id.py
@@ -1,0 +1,16 @@
+"""
+# get_session_id
+
+"""
+import solara
+from solara.website.utils import apidoc
+
+from . import NoPage
+
+title = "get_session_id"
+
+
+Page = NoPage
+
+
+__doc__ += apidoc(solara.get_session_id)  # type: ignore

--- a/solara/website/pages/examples/general/custom_storage.py
+++ b/solara/website/pages/examples/general/custom_storage.py
@@ -1,0 +1,69 @@
+"""# Custom state storage
+
+Solara makes it easy to store state/data on the server side, scoped to a kernel, using [reactive variables](/api/reactive).
+
+However, sometimes you want to store state yourself in an external system (i.e. not Solara), and for this you can use the
+[get_kernel_id()](/api/get_kernel_id) function to get a unique id for each kernel.
+
+If you want to store state/data scoped to a browser session, you can use the [get_session_id()](/api/get_session_id)
+function to get a unique id tied to the users browser. This can be used to store state that outlives a page refresh.
+
+In case you want to store state/data scoped to a user, you can use a similar strategy, but use a unique identifier based on the user,
+instead of the session id. You can take a look at [Our oauth example](examples/general/login_oauth) or
+[the authorization example](/examples/apps/authorization) for inspiration.
+
+"""
+from typing import Dict
+
+import solara
+import solara.lab
+
+# used only to force updating of the page
+force_update_counter = solara.reactive(0)
+
+# Kernel storage is scoped to the kernel, and will be cleared when the kernel is stopped.
+kernel_storage: Dict[str, str] = {}
+
+
+def store_in_kernel_storage(value):
+    kernel_storage[solara.get_kernel_id()] = value
+    force_update_counter.value += 1
+
+
+@solara.lab.on_kernel_start
+def initialize_kernel_storage():
+    # when a kernel gets started, we initialize the dict entry
+    kernel_storage[solara.get_kernel_id()] = "This does not"
+
+    def cleanup():
+        # when a kernel gets stopped, we remove the dict entry
+        del kernel_storage[solara.get_kernel_id()]
+
+    # cleaning up kernel storage, we prevent memory leaks
+    return cleanup
+
+
+# session storage has no lifecycle management, and will only be cleared when the server is restarted.
+session_storage: Dict[str, str] = {}
+
+
+def store_in_session_storage(value):
+    session_storage[solara.get_session_id()] = value
+    force_update_counter.value += 1
+
+
+@solara.component
+def Page():
+    solara.InputText(
+        "Stored under the kernel id key",
+        value=kernel_storage[solara.get_kernel_id()],
+        on_value=store_in_kernel_storage,
+        continuous_update=True,
+    )
+
+    solara.InputText(
+        "Stored under the session id key",
+        value=session_storage.get(solara.get_session_id(), "This outlives a page refresh"),
+        on_value=store_in_session_storage,
+        continuous_update=True,
+    )


### PR DESCRIPTION
If you want to store data in a custom storage, you need to know the
kernel_id or session_id to scope.

This can be used to implement something similar to reactive variables.