### PR TITLE
feat: reactive_task decorator (re)runs a task when a dependency changes

### DIFF
--- a/solara/lab/__init__.py
+++ b/solara/lab/__init__.py
@@ -2,7 +2,7 @@
 from .components import *  # noqa: F401, F403
 from .utils import cookies, headers  # noqa: F401, F403
 from ..server.kernel_context import on_kernel_start  # noqa: F401
-from ..tasks import task, use_task, Task, TaskResult  # noqa: F401, F403
+from ..tasks import reactive_task, task, use_task, Task, TaskResult  # noqa: F401, F403
 from ..toestand import computed  # noqa: F401
 
 

--- a/solara/toestand.py
+++ b/solara/toestand.py
@@ -749,9 +749,9 @@ class AutoSubscribeContextManagerReacton(AutoSubscribeContextManagerBase):
 
 
 class AutoSubscribeContextManager(AutoSubscribeContextManagerBase):
-    on_change: Callable[[], None]
+    on_change: Callable[[Any, Any], None]
 
-    def __init__(self, on_change: Callable[[], None]):
+    def __init__(self, on_change: Callable[[Any, Any], None]):
         super().__init__()
         self.on_change = on_change
 


### PR DESCRIPTION
Dependencies are other reactive variables.

Examples:

```
import asyncio
import time
import solara
from solara.lab import reactive_task

x = solara.reactive(2)

@reactive_task
async def x_square():
    await asyncio.sleep(2)
    a = b
    return x.value**2

@solara.component
def Page():
    solara.SliderInt("x", value=x, min=0, max=10)
    if x_square.value.state == solara.ResultState.FINISHED:
        solara.Text(repr(x_square.value.value))
    solara.ProgressLinear(x_square.value.state == solara.ResultState.RUNNING)
```