### PR TITLE
fix: avoid extra scrollbar when having no appbar or sidebar

### DIFF
--- a/solara/server/assets/style.css
+++ b/solara/server/assets/style.css
@@ -112,6 +112,7 @@ div.highlight {
 
 .solara-autorouter-content {
     height: 100%;
+    overflow: auto;
 }
 
 /* originally from index.css */


### PR DESCRIPTION
This issue was introduced in 3884d6a035ab11098d78f6ff6c76aec060dfd785 and was caused by a full height 100% chain and a single element with padding, causing the solara-autorouter-content to be pushed down and creating scrollbars on its parents.
If instead, we add the scrollbar to the solara-autorouter-content element, we can avoid this issue.

See
<img width="920" alt="image" src="https://github.com/widgetti/solara/assets/1765949/118556ba-a0d4-4523-83be-045e905e22e9">

where the anonymous div is causing scrollbars, and the solara-autorouter-content causes overflow.

The v-input has a top-margin of 4, triggering this.

After this fix, we don't see overflow and scrollbars:
<img width="813" alt="image" src="https://github.com/widgetti/solara/assets/1765949/4ae78032-536e-44cc-86fc-c245186f5a21">
