### PR TITLE
fix: futureproof jupyter server extension (paths -> points)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
 
 [tool.hatch.build.targets.wheel.shared-data]
 "prefix" = "prefix"
+"prefix/etc/jupyter" = "etc/jupyter"
 
 [tool.hatch.version]
 path = "solara/__init__.py"

--- a/solara/server/jupyter/server_extension.py
+++ b/solara/server/jupyter/server_extension.py
@@ -24,3 +24,6 @@ def _load_jupyter_server_extension(server_app):
 
 # For backward compatibility
 load_jupyter_server_extension = _load_jupyter_server_extension
+
+# For future compatibility
+_jupyter_server_extension_points = _jupyter_server_extension_paths


### PR DESCRIPTION
add an alias `_jupyter_server_extension_points` for `_jupyter_server_extension_paths`, as per https://github.com/jupyter-server/jupyter_server/pull/248/commits/0003ade330561981e6bc75a9d32b00b2d34c54fb