### PR TITLE
refactor: split assets settings in server and non-server parts

### DIFF
--- a/solara/server/cdn_helper.py
+++ b/solara/server/cdn_helper.py
@@ -4,7 +4,7 @@ import shutil
 
 import requests
 
-from . import settings
+import solara.settings
 
 logger = logging.getLogger("Solara.cdn")
 
@@ -32,7 +32,7 @@ def get_from_cache(base_cache_dir: pathlib.Path, path):
 
 def get_cdn_url(path):
     path = str(path)  # on windows, the path can contain a \
-    return str(settings.assets.cdn) + str(path).replace("\\", "/")
+    return str(solara.settings.assets.cdn) + str(path).replace("\\", "/")
 
 
 def get_data(base_cache_dir: pathlib.Path, path):

--- a/solara/server/flask.py
+++ b/solara/server/flask.py
@@ -39,6 +39,7 @@ else:
 
 
 import solara
+import solara.settings
 from solara.server.threaded import ServerBase
 
 from . import app as appmod
@@ -195,7 +196,7 @@ def serve_static(path):
     return send_from_directory(server.solara_static, path)
 
 
-if settings.assets:
+if solara.settings.assets.proxy:
 
     @blueprint.route(f"/{cdn_helper.cdn_url_path}/<path:path>")
     def cdn(path):

--- a/solara/server/server.py
+++ b/solara/server/server.py
@@ -15,6 +15,7 @@ import requests
 
 import solara
 import solara.routing
+import solara.settings
 
 from . import app, jupytertools, patch, settings, websocket
 from .kernel import Kernel, deserialize_binary_message
@@ -327,11 +328,11 @@ def read_root(path: str, root_path: str = "", render_kwargs={}, use_nbextensions
             pre_rendered_metas = "\n    ".join(ssg_data["metas"])
             title = ssg_data["title"]
 
-    if settings.assets.proxy:
+    if solara.settings.assets.proxy:
         # solara acts as a proxy
         cdn = f"{root_path}/_solara/cdn"
     else:
-        cdn = settings.assets.cdn
+        cdn = solara.settings.assets.cdn
 
     render_settings = {
         "title": title,

--- a/solara/server/settings.py
+++ b/solara/server/settings.py
@@ -74,8 +74,6 @@ class Telemetry(BaseSettings):
 
 
 class Assets(BaseSettings):
-    cdn: str = "https://cdn.jsdelivr.net/npm/"
-    proxy: bool = True
     proxy_cache_dir: Path = Path(prefix + "/share/solara/cdn/")
     fontawesome_enabled: bool = True
     fontawesome_path: str = "/font-awesome@4.5.0/css/font-awesome.min.css"
@@ -171,14 +169,15 @@ kernel = Kernel()
 # fail early
 solara.util.parse_timedelta(kernel.cull_timeout)
 
-if assets.proxy:
+if settings.assets.proxy:
     try:
         assets.proxy_cache_dir.mkdir(exist_ok=True, parents=True)
     except OSError as e:
-        assets.proxy = False
+        settings.assets.proxy = False
         warnings.warn(
             f"Could not create {assets.proxy_cache_dir} due to {e}. We will automatically disable the assets proxy for you. "
-            "If you want to disable this warning, set SOLARA_ASSETS_PROXY to False (e.g. export SOLARA_ASSETS_PROXY=false)."
+            "If you want to disable this warning, set SOLARA_ASSETS_PROXY to False (e.g. export SOLARA_ASSETS_PROXY=false). "
+            "Or change the SOLARA_PROXY_CACHE_DIR environment variable to a directory where you have write access."
         )
         # that's ok, the user probably doesn't have permission to create the directory
         # in this case, we would need to install solara-assets?

--- a/solara/server/starlette.py
+++ b/solara/server/starlette.py
@@ -43,6 +43,7 @@ from starlette.staticfiles import StaticFiles
 from starlette.types import Receive, Scope, Send
 
 import solara
+import solara.settings
 from solara.server.threaded import ServerBase
 
 from . import app as appmod
@@ -415,7 +416,7 @@ routes = [
     Route("/{fullpath}", endpoint=root),
     Route("/_solara/api/close/{kernel_id}", endpoint=close, methods=["POST"]),
     # only enable when the proxy is turned on, otherwise if the directory does not exists we will get an exception
-    *([Mount(f"/{cdn_url_path}", app=StaticCdn(directory=settings.assets.proxy_cache_dir))] if settings.assets.proxy else []),
+    *([Mount(f"/{cdn_url_path}", app=StaticCdn(directory=settings.assets.proxy_cache_dir))] if solara.settings.assets.proxy else []),
     Mount(f"{prefix}/static/public", app=StaticPublic()),
     Mount(f"{prefix}/static/assets", app=StaticAssets()),
     Mount(f"{prefix}/static/nbextensions", app=StaticNbFiles()),

--- a/solara/settings.py
+++ b/solara/settings.py
@@ -36,4 +36,15 @@ class Cache(BaseSettings):
         env_file = ".env"
 
 
+class Assets(BaseSettings):
+    cdn: str = "https://cdn.jsdelivr.net/npm/"
+    proxy: bool = True
+
+    class Config:
+        env_prefix = "solara_assets_"
+        case_sensitive = False
+        env_file = ".env"
+
+
+assets: Assets = Assets()
 cache: Cache = Cache()


### PR DESCRIPTION
Based on:
 * https://github.com/widgetti/solara/pull/479
 * https://github.com/widgetti/solara/pull/480
 * https://github.com/widgetti/solara/issues/486

We decided that using the proxy and the cdn if the proxy is not used
is not only something to be used in solara server. In vscode
or colab, we cannot use the proxy, and need to use the cdn directly.