### PR TITLE
fix: support altair in vscode and colab (and more)

### DIFF
--- a/solara/server/telemetry.py
+++ b/solara/server/telemetry.py
@@ -15,6 +15,7 @@ import ipywidgets
 import requests
 
 import solara
+import solara.util
 
 from . import settings
 
@@ -44,15 +45,6 @@ _docker = False
 _compute_platform = "unknown"
 
 
-def is_running_in_colab():
-    try:
-        import google.colab  # noqa
-
-        return True
-    except ImportError:
-        return False
-
-
 def is_running_on_domino():
     return "DOMINO_PROJECT_OWNER" in os.environ
 
@@ -65,7 +57,7 @@ def is_running_on_azure():
     return "AZURE_NOTEBOOKS_VM" in os.environ or "AZUREML_RUN_ID" in os.environ
 
 
-if is_running_in_colab():
+if solara.util.is_running_in_colab():
     _compute_platform = "colab"
 elif is_running_on_domino():
     _compute_platform = "domino"
@@ -74,7 +66,7 @@ elif is_running_on_sagemaker_notebook():
 elif is_running_on_azure():
     _compute_platform = "azure"
 
-_vscode = any(k for k in os.environ if k.upper().startswith("VSCODE_"))
+_vscode = solara.util.is_running_in_vscode()
 
 try:
     path = "/proc/self/cgroup"

--- a/solara/settings.py
+++ b/solara/settings.py
@@ -39,7 +39,7 @@ class Cache(BaseSettings):
 
 
 # in colab or vscode there is not solara cdn proxy available
-_should_not_use_proxy = solara.util.is_running_in_colab() or solara.util.is_running_in_vscode()
+_should_use_proxy = not (solara.util.is_running_in_colab() or solara.util.is_running_in_vscode())
 
 
 class Assets(BaseSettings):

--- a/solara/settings.py
+++ b/solara/settings.py
@@ -1,6 +1,8 @@
 import os
 from typing import Optional
 
+import solara.util
+
 from .minisettings import BaseSettings, Field
 from .util import get_solara_home
 
@@ -36,9 +38,13 @@ class Cache(BaseSettings):
         env_file = ".env"
 
 
+# in colab or vscode there is not solara cdn proxy available
+_should_not_use_proxy = solara.util.is_running_in_colab() or solara.util.is_running_in_vscode()
+
+
 class Assets(BaseSettings):
     cdn: str = "https://cdn.jsdelivr.net/npm/"
-    proxy: bool = True
+    proxy: bool = not _should_not_use_proxy
 
     class Config:
         env_prefix = "solara_assets_"

--- a/solara/settings.py
+++ b/solara/settings.py
@@ -44,7 +44,7 @@ _should_use_proxy = not (solara.util.is_running_in_colab() or solara.util.is_run
 
 class Assets(BaseSettings):
     cdn: str = "https://cdn.jsdelivr.net/npm/"
-    proxy: bool = not _should_not_use_proxy
+    proxy: bool = _should_use_proxy
 
     class Config:
         env_prefix = "solara_assets_"

--- a/solara/settings.py
+++ b/solara/settings.py
@@ -39,7 +39,7 @@ class Cache(BaseSettings):
 
 
 # in colab or vscode there is not solara cdn proxy available
-_should_use_proxy = not (solara.util.is_running_in_colab() or solara.util.is_running_in_vscode())
+_should_use_proxy = not (solara.util.is_running_in_colab() or solara.util.is_running_in_vscode() or solara.util.is_running_in_voila())
 
 
 class Assets(BaseSettings):

--- a/solara/util.py
+++ b/solara/util.py
@@ -280,3 +280,7 @@ def is_running_in_colab():
 
 def is_running_in_vscode():
     return "VSCODE_PID" in os.environ or "VSCODE_CWD" in os.environ
+
+
+def is_running_in_voila():
+    return os.environ.get("SERVER_SOFTWARE", "").startswith("voila")

--- a/solara/util.py
+++ b/solara/util.py
@@ -267,3 +267,16 @@ def get_file_hash(path: Path, algorithm="md5") -> Tuple[bytes, str]:
         h = hashlib.new(algorithm, usedforsecurity=False)  # type: ignore
     h.update(data)
     return data, h.hexdigest()
+
+
+def is_running_in_colab():
+    try:
+        import google.colab  # noqa
+
+        return True
+    except ImportError:
+        return False
+
+
+def is_running_in_vscode():
+    return "VSCODE_PID" in os.environ or "VSCODE_CWD" in os.environ

--- a/solara/widgets/vue/vegalite.vue
+++ b/solara/widgets/vue/vegalite.vue
@@ -108,7 +108,7 @@ module.exports = {
             return base
         },
         getCdn() {
-            return (typeof solara_cdn !== "undefined" && solara_cdn) || `${this.getBaseUrl()}_solara/cdn`;
+            return this.cdn || (typeof solara_cdn !== "undefined" && solara_cdn) || `${this.getBaseUrl()}_solara/cdn`;
         }
     },
 }

--- a/solara/widgets/widgets.py
+++ b/solara/widgets/widgets.py
@@ -20,6 +20,7 @@ class VegaLite(v.VuetifyTemplate):
     listen_to_hover = traitlets.Bool(False).tag(sync=True)
     on_click = traitlets.traitlets.Callable(None, allow_none=True)
     on_hover = traitlets.traitlets.Callable(None, allow_none=True)
+    cdn = traitlets.Unicode(None, allow_none=True).tag(sync=True)
 
     def vue_altair_click(self, *args):
         if self.on_click:
@@ -28,6 +29,13 @@ class VegaLite(v.VuetifyTemplate):
     def vue_altair_hover(self, *args):
         if self.on_hover:
             self.on_hover(*args)
+
+    @traitlets.default("cdn")
+    def _cdn(self):
+        import solara.settings
+
+        if not solara.settings.assets.proxy:
+            return solara.settings.assets.cdn
 
 
 class Navigator(v.VuetifyTemplate):

--- a/tests/integration/cdn_test.py
+++ b/tests/integration/cdn_test.py
@@ -10,9 +10,6 @@ from .conftest import SERVERS
 def test_cdn_via_altair(ipywidgets_runner, page_session: playwright.sync_api.Page, request, assert_solara_snapshot):
     if request.node.callspec.params["ipywidgets_runner"] != "solara" and request.node.callspec.params["solara_server"] != SERVERS[0]:
         pytest.skip("No need to run this test for all servers.")
-    if request.node.callspec.params["ipywidgets_runner"] == "voila":
-        # see https://github.com/widgetti/solara/issues/486
-        pytest.skip("Does not work with Voila.")
 
     # this function (or rather its lines) will be executed in the kernel
     # voila, lab, classic notebook and solara will all execute it


### PR DESCRIPTION
By setting SOLARA_ASSETS_PROXY=False, the JS assets will be fetched
directly from the CDN, and not the proxy. This is the default setting
for colab and vscode now, such that Altair works out of the box.