### PR TITLE
fix: user reactive variables taking on solara builtin variable values on hot reload

### DIFF
--- a/solara/lab/utils/cookies.py
+++ b/solara/lab/utils/cookies.py
@@ -1,6 +1,5 @@
 from typing import Dict, Optional, cast
 
-from solara.reactive import reactive
 from solara.toestand import Reactive
 
-cookies: Reactive[Optional[Dict[str, str]]] = reactive(cast(Optional[Dict[str, str]], None))
+cookies: Reactive[Optional[Dict[str, str]]] = Reactive(cast(Optional[Dict[str, str]], None), key="solara.lab.cookies")

--- a/solara/lab/utils/headers.py
+++ b/solara/lab/utils/headers.py
@@ -1,6 +1,5 @@
 from typing import Dict, List, Optional, cast
 
-from solara.reactive import reactive
 from solara.toestand import Reactive
 
-headers: Reactive[Optional[Dict[str, List[str]]]] = reactive(cast(Optional[Dict[str, List[str]]], None))
+headers: Reactive[Optional[Dict[str, List[str]]]] = Reactive(cast(Optional[Dict[str, List[str]]], None), key="solara.lab.headers")


### PR DESCRIPTION
Sometimes on hot reload, when the value of a user-defined reactive variable is reset, the value would get updated to that of a solara builtin reactive variable. We avoid this here by manually fixing keys for our variables

Should fix https://github.com/widgetti/solara/issues/510 for `solara.lab.cookies/headers`