### PR TITLE
fix: json_default supports date serialization

### DIFF
--- a/solara/server/kernel.py
+++ b/solara/server/kernel.py
@@ -5,7 +5,7 @@ import queue
 import struct
 import warnings
 from binascii import b2a_base64
-from datetime import datetime
+from datetime import date, datetime
 from typing import Set
 
 import ipykernel
@@ -47,9 +47,11 @@ def json_default(obj):
     if isinstance(obj, datetime):
         obj = _ensure_tzinfo(obj)
         return obj.isoformat().replace("+00:00", "Z")
+    elif isinstance(obj, date):
+        return obj.isoformat()
     elif isinstance(obj, bytes):
         return b2a_base64(obj).decode("ascii")
-    if type(obj).__module__ == "numpy":
+    elif type(obj).__module__ == "numpy":
         import numpy as np
 
         if isinstance(obj, np.number):

--- a/tests/unit/kernel_test.py
+++ b/tests/unit/kernel_test.py
@@ -1,18 +1,29 @@
-from datetime import datetime
+from datetime import date, datetime
 from unittest.mock import Mock
 
 from solara.server.kernel import SessionWebsocket
 
 
-def test_session_datetime():
-    # some libraries, such as plotly may put datetime objects in the json content
-    class Dummy:
-        pass
+class Dummy:
+    pass
 
+
+# some libraries, such as plotly may put date and datetime objects in the json content
+def test_session_datetime():
     websocket = Mock()
     stream = Dummy()
     stream.channel = "iopub"  # type: ignore
     session = SessionWebsocket()
     session.websockets.add(websocket)
     session.send(stream, {"msg_type": "test", "content": {"data": "test"}, "somedate": datetime.now()})  # type: ignore
+    websocket.send.assert_called_once()
+
+
+def test_session_date():
+    websocket = Mock()
+    stream = Dummy()
+    stream.channel = "iopub"  # type: ignore
+    session = SessionWebsocket()
+    session.websockets.add(websocket)
+    session.send(stream, {"msg_type": "test", "content": {"data": "test"}, "somedate": date.today()})  # type: ignore
     websocket.send.assert_called_once()


### PR DESCRIPTION
`datetime` was already supported, I just added `date` to `json_default` as well.

This should fix https://github.com/widgetti/solara/issues/475