### PR TITLE
feat: improve matplotlib support - mimic Jupyter

### DIFF
--- a/solara/components/matplotlib.py
+++ b/solara/components/matplotlib.py
@@ -14,30 +14,43 @@ def FigureMatplotlib(
 ):
     """Display a matplotlib figure.
 
-    We recomment not to use the pyplot interface, but rather to create a figure directly, e.g:
 
-    ```python
-    import reacton
-    import solara as sol
+    ## Example
+
+    ```solara
+    import solara
     from matplotlib.figure import Figure
 
     @solara.component
     def Page():
-        # do this instead of plt.figure()
         fig = Figure()
         ax = fig.subplots()
         ax.plot([1, 2, 3], [1, 4, 9])
         return solara.FigureMatplotlib(fig)
-
     ```
-
-    You should also avoid drawing using the pyplot interface, as it is not thread-safe. If you do use it,
-    your drawing might be corrupted due to another thread/user drawing at the same time.
 
     When running under solara-server, we by default configure the same 'inline' backend as in the Jupyter notebook.
 
     For performance reasons, you might want to pass in a list of dependencies that indicate when
     the figure changed, to avoid re-rendering it on every render.
+
+    ## Example using pyplot
+
+    Note that it is also possible to use the pyplot interface, but be sure to close the figure not to leak memory.
+
+    ```solara
+    import solara
+    import matplotlib.pyplot as plt
+
+    @solara.component
+    def Page():
+        plt.figure()
+        plt.plot([1, 2, 3], [1, 4, 9])
+        plt.show()
+        plt.close()
+    ```
+
+    Note that the figure is not the same size using the pyplot interface, due to the default figure size being different.
 
 
     ## Arguments

--- a/solara/components/matplotlib.py
+++ b/solara/components/matplotlib.py
@@ -34,8 +34,7 @@ def FigureMatplotlib(
     You should also avoid drawing using the pyplot interface, as it is not thread-safe. If you do use it,
     your drawing might be corrupted due to another thread/user drawing at the same time.
 
-    If you still must use pyplot to create the figure, make sure you call `plt.switch_backend("agg")`
-    before creating the figure, to avoid starting an interactive backend.
+    When running under solara-server, we by default configure the same 'inline' backend as in the Jupyter notebook.
 
     For performance reasons, you might want to pass in a list of dependencies that indicate when
     the figure changed, to avoid re-rendering it on every render.

--- a/solara/server/app.py
+++ b/solara/server/app.py
@@ -15,7 +15,7 @@ from reacton.core import Element, render
 
 import solara
 
-from . import kernel_context, reload, settings
+from . import kernel_context, patch, reload, settings
 from .kernel import Kernel
 from .utils import pdb_guard
 
@@ -67,6 +67,9 @@ class AppScript:
         dummy_kernel_context = kernel_context.create_dummy_context()
         with dummy_kernel_context:
             app = self._execute()
+
+        # We now ran the app, now we can check for patches that require heavy imports
+        patch.patch_heavy_imports()
 
         self._first_execute_app = app
         reload.reloader.root_path = self.directory
@@ -198,6 +201,9 @@ class AppScript:
                     self._first_execute_app = None
                     self._first_execute_app = self._execute()
                     print("Re-executed app", self.name)  # noqa
+                    # We now ran the app again, might contain new imports
+                    patch.patch_heavy_imports()
+
         return self._first_execute_app
 
     def on_file_change(self, name):

--- a/solara/server/patch.py
+++ b/solara/server/patch.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import pdb
 import sys
 import threading
@@ -25,6 +26,7 @@ except:  # noqa
 if patch_display is not None and sys.platform != "emscripten":
     patch_display()
 ipywidget_version_major = int(ipywidgets.__version__.split(".")[0])
+ipykernel_version_major = int(ipykernel.__version__.split(".")[0])
 
 
 class FakeIPython:
@@ -330,6 +332,13 @@ def patch():
         pass
     else:
         patch_ipyreact()
+
+    if "MPLBACKEND" not in os.environ:
+        if ipykernel_version_major < 6:
+            # changed in https://github.com/ipython/ipykernel/pull/591
+            os.environ["MPLBACKEND"] = "ipykernel.pylab.backend_inline"
+        else:
+            os.environ["MPLBACKEND"] = "module://matplotlib_inline.backend_inline"
 
     # the ipyvue.Template module cannot be accessed like ipyvue.Template
     # because the import in ipvue overrides it

--- a/solara/website/components/notebook.py
+++ b/solara/website/components/notebook.py
@@ -11,11 +11,6 @@ import solara.components.applayout
 import solara.toestand
 from solara.components.markdown import ExceptionGuard
 
-if solara._using_solara_server():
-    from matplotlib import pyplot as plt
-
-    plt.switch_backend("agg")
-
 HERE = Path(__file__).parent
 
 

--- a/solara/website/pages/examples/general/live_update.py
+++ b/solara/website/pages/examples/general/live_update.py
@@ -5,9 +5,6 @@ from matplotlib import pyplot as plt
 
 import solara
 
-# ensure that an interactive backend doesn't start when plotting with matplotlib
-plt.switch_backend("agg")
-
 
 @solara.component
 def Page():

--- a/tests/unit/matplotlib_test.py
+++ b/tests/unit/matplotlib_test.py
@@ -31,20 +31,45 @@ def test_pylab(no_kernel_context):
 
         assert len(Gcf.get_all_fig_managers()) == 0
         plt.figure()
+
         assert len(Gcf.get_all_fig_managers()) == 1
+
+        default_color = (1, 1, 1, 0)
+        white = "white"
+        black = "black"
+        assert plt.rcParams["figure.facecolor"] in [default_color, white]
+        plt.style.use("default")
+        assert plt.rcParams["figure.facecolor"] == white
+
+        plt.style.use("dark_background")
+        assert plt.rcParams["figure.facecolor"] == black
+
         with context_1:
             assert len(Gcf.get_all_fig_managers()) == 0
             plt.figure()
+            assert plt.rcParams["figure.facecolor"] == black
             assert len(Gcf.get_all_fig_managers()) == 1
+            plt.style.use("default")
+            assert plt.rcParams["figure.facecolor"] == white
+
+        assert plt.rcParams["figure.facecolor"] == black
         assert len(Gcf.get_all_fig_managers()) == 1
+        plt.style.use("default")
+        assert plt.rcParams["figure.facecolor"] == white
+
         with context_2:
+            assert plt.rcParams["figure.facecolor"] == white
             assert len(Gcf.get_all_fig_managers()) == 0
             plt.figure()
             assert len(Gcf.get_all_fig_managers()) == 1
             plt.figure()
             assert len(Gcf.get_all_fig_managers()) == 2
+            plt.style.use("dark_background")
+            assert plt.rcParams["figure.facecolor"] == black
         with context_1:
             assert len(Gcf.get_all_fig_managers()) == 1
+            assert plt.rcParams["figure.facecolor"] == white
+        assert plt.rcParams["figure.facecolor"] == white
 
     finally:
         cleanup()

--- a/tests/unit/matplotlib_test.py
+++ b/tests/unit/matplotlib_test.py
@@ -1,5 +1,8 @@
-import solara
 from matplotlib.figure import Figure
+
+import solara
+import solara.server.patch
+from solara.server import kernel
 
 
 @solara.component
@@ -14,3 +17,36 @@ def Page():
 def test_render():
     box, rc = solara.render(Page(), handle_error=False)
     assert len(box.children) == 1
+
+
+def test_pylab(no_kernel_context):
+    cleanup = solara.server.patch.patch_matplotlib()
+    try:
+        kernel_1 = kernel.Kernel()
+        context_1 = solara.server.kernel_context.VirtualKernelContext(id="1", kernel=kernel_1, session_id="session-1")
+        kernel_2 = kernel.Kernel()
+        context_2 = solara.server.kernel_context.VirtualKernelContext(id="2", kernel=kernel_2, session_id="session-1")
+        import matplotlib.pyplot as plt
+        from matplotlib._pylab_helpers import Gcf
+
+        assert len(Gcf.get_all_fig_managers()) == 0
+        plt.figure()
+        assert len(Gcf.get_all_fig_managers()) == 1
+        with context_1:
+            assert len(Gcf.get_all_fig_managers()) == 0
+            plt.figure()
+            assert len(Gcf.get_all_fig_managers()) == 1
+        assert len(Gcf.get_all_fig_managers()) == 1
+        with context_2:
+            assert len(Gcf.get_all_fig_managers()) == 0
+            plt.figure()
+            assert len(Gcf.get_all_fig_managers()) == 1
+            plt.figure()
+            assert len(Gcf.get_all_fig_managers()) == 2
+        with context_1:
+            assert len(Gcf.get_all_fig_managers()) == 1
+
+    finally:
+        cleanup()
+        context_1.close()
+        context_2.close()


### PR DESCRIPTION
feat: improve matplotlib support - as Jupyter


Several improvements:

## Default backend
We do this by checking if the env var 'MPLBACKEND' is not set, and if so, we set it to
module://matplotlib_inline.backend_inline

## Support for display(figure)

This makes it behave more like the Jupyter notebook environment.

## Support matplotlib pylab interface in solara server

This makes code that 'just works' in the notebook also work in solara
server. We patch global dicts with scoped dicts.

See #539
