### PR TITLE
ci: oauth tests do not work with playwright 1.42.0

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -53,7 +53,7 @@ jobs:
         run: mkdir test-results
       - name: Install
         run: |
-          pip install ".[dev,server,flask,documentation,pytest]" "voila~=${{ matrix.voila }}" "jupyterlab<4" "pydantic<2"
+          pip install ".[dev,server,flask,documentation,pytest]" "voila~=${{ matrix.voila }}" "jupyterlab<4" "pydantic<2" "playwright==1.41.2"
           (cd packages/solara-enterprise && pip install ".[ssg,auth]" "ipywidgets~=${{ matrix.ipywidgets }}")
       - name: Install playwright
         run: playwright install


### PR DESCRIPTION
Getting "This site can't be reached":

<img width="1217" alt="image" src="https://github.com/widgetti/solara/assets/1765949/55c37f02-68c4-4bfe-a989-003924b75461">
