### PR TITLE
fix: installing solara using pixi failing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ dependencies = [
 ]
 
 [tool.hatch.build.targets.wheel.shared-data]
-"prefix" = "prefix"
 "prefix/etc/jupyter" = "etc/jupyter"
 
 [tool.hatch.version]


### PR DESCRIPTION
Failure was due to us attemting to create a folder called "prefix" in the environment main folder, while a file with the same name is created by pixi.

This PR should fix https://github.com/widgetti/solara/issues/552.