### PR TITLE
fix: support Layout when specifying routes

### DIFF
--- a/tests/unit/solara_test_apps/single_file_routes.py
+++ b/tests/unit/solara_test_apps/single_file_routes.py
@@ -1,0 +1,25 @@
+import solara
+
+
+@solara.component
+def Page1():
+    solara.Text("Page 1")
+
+
+@solara.component
+def Page2():
+    solara.Text("Page 2")
+
+
+@solara.component
+def Layout(children):
+    with solara.AppLayout():
+        with solara.Column():
+            solara.Text("Custom layout")
+            solara.display(*children)
+
+
+routes = [
+    solara.Route("/", component=Page1, layout=Layout),
+    solara.Route("page2", component=Page2),
+]


### PR DESCRIPTION
Before, if we specified

```python

routes = [
    solara.Route(path="/", component=Home, label="Home", layout=Layout),
    solara.Route(path="about", component=About, label="About"),
]
```


We would not render the the page and layout correcly.
