### PR TITLE
fix: on_kernel_start callbacks accumulated after hot reload

### DIFF
--- a/solara/server/reload.py
+++ b/solara/server/reload.py
@@ -152,13 +152,13 @@ class Reloader:
             self._first = False
 
     def _on_change(self, name):
-        # used for testing
-        self.reload_event_next.set()
         # flag that we need to reload all modules next time
         self.requires_reload = True
         # and forward callback
         if self.on_change:
             self.on_change(name)
+        # used for testing
+        self.reload_event_next.set()
 
     def close(self):
         self.watcher.close()

--- a/solara/website/pages/documentation/api/utilities/on_kernel_start.py
+++ b/solara/website/pages/documentation/api/utilities/on_kernel_start.py
@@ -4,7 +4,8 @@
 Run a function when a virtual kernel (re)starts and optionally run a cleanup function on shutdown.
 
 ```python
-def on_kernel_start(f: Callable[[], Optional[Callable[[], None]]]):
+def on_kernel_start(f: Callable[[], Optional[Callable[[], None]]]) -> Callable[[], None]:
+    ...
 ```
 
 `f` will be called on each virtual kernel (re)start. This (usually) happens each time a browser tab connects to the server
@@ -12,7 +13,12 @@ def on_kernel_start(f: Callable[[], Optional[Callable[[], None]]]):
 The (optional) function returned by `f` will be called on kernel shutdown.
 
 Note that the cleanup functions are called in reverse order with respect to the order in which they were registered
-(e.g. the cleanup function of the last call to `on_kernel_start` will be called first on kernel shutdown)
+(e.g. the cleanup function of the last call to `on_kernel_start` will be called first on kernel shutdown).
+
+The return value of on_kernel_start is a cleanup function that will remove the callback from the list of callbacks to be called on kernel start.
+
+During hot reload, the callbacks that are added from scripts or modules that will be reloaded will be removed before the app is loaded
+again. This can cause the order of the callbacks to be different than at first run.
 """
 
 from solara.website.components import NoPage

--- a/tests/unit/reload_test.py
+++ b/tests/unit/reload_test.py
@@ -1,0 +1,56 @@
+import shutil
+from pathlib import Path
+
+import pytest
+
+import solara.lab
+import solara.server.kernel_context
+from solara.server import reload
+from solara.server.app import AppScript
+
+HERE = Path(__file__).parent
+
+kernel_start_path = HERE / "solara_test_apps" / "kernel_start.py"
+
+
+@pytest.mark.parametrize("as_module", [False, True])
+def test_script_reload_component(tmpdir, kernel_context, extra_include_path, no_kernel_context, as_module):
+
+    target = Path(tmpdir) / "kernel_start.py"
+    shutil.copy(kernel_start_path, target)
+    with extra_include_path(str(tmpdir)):
+        on_kernel_start_callbacks = solara.server.kernel_context._on_kernel_start_callbacks.copy()
+        callbacks_start = [k.callback for k in solara.server.kernel_context._on_kernel_start_callbacks]
+        if as_module:
+            app = AppScript(f"{target.stem}")
+        else:
+            app = AppScript(f"{target}")
+        try:
+            app.run()
+            callback = app.routes[0].module.test_callback  # type: ignore
+            callbacks = [k.callback for k in solara.server.kernel_context._on_kernel_start_callbacks]
+            assert callbacks == [*callbacks_start, callback]
+            prev = callbacks.copy()
+            reload.reloader.reload_event_next.clear()
+            target.touch()
+            # wait for the event to trigger
+            reload.reloader.reload_event_next.wait()
+            app.run()
+            callback = app.routes[0].module.test_callback  # type: ignore
+            callbacks = [k[0] for k in solara.server.kernel_context._on_kernel_start_callbacks]
+            assert callbacks != prev
+            assert callbacks == [*callbacks_start, callback]
+        finally:
+            app.close()
+            solara.server.kernel_context._on_kernel_start_callbacks.clear()
+            solara.server.kernel_context._on_kernel_start_callbacks.extend(on_kernel_start_callbacks)
+
+
+def test_on_kernel_start_cleanup(kernel_context, no_kernel_context):
+    def test_callback_cleanup():
+        pass
+
+    cleanup = solara.lab.on_kernel_start(test_callback_cleanup)
+    assert test_callback_cleanup in [k.callback for k in solara.server.kernel_context._on_kernel_start_callbacks]
+    cleanup()
+    assert test_callback_cleanup not in [k.callback for k in solara.server.kernel_context._on_kernel_start_callbacks]

--- a/tests/unit/solara_test_apps/kernel_start.py
+++ b/tests/unit/solara_test_apps/kernel_start.py
@@ -1,0 +1,14 @@
+import solara
+import solara.lab
+
+
+def test_callback():
+    pass
+
+
+solara.lab.on_kernel_start(test_callback)
+
+
+@solara.component
+def Page():
+    solara.Text("Hello, World!")


### PR DESCRIPTION
Introduced in #471
We should remove the on_kernel_start callbacks on a hot reload, but
not remove the ones added by the hot reload itself.

TODO: What happens when we import packages that are in site-packages that will not be reloaded?