### PR TITLE
fix: nested vuetify apps should not have 100vh

### DIFF
--- a/solara/server/assets/style.css
+++ b/solara/server/assets/style.css
@@ -23,6 +23,12 @@ code::before {
     box-shadow: unset !important;
 }
 
+.v-application--wrap .v-application--wrap {
+  /* disable min-height: 100vh set by vuetify for nested apps */
+  min-height: unset;
+}
+
+
 div.highlight pre code {
     /* box-shadow: 0 2px 1px -1px rgb(0 0 0 / 20%), 0 1px 1px 0 rgb(0 0 0 / 14%), 0 1px 3px 0 rgb(0 0 0 / 12%); */
     /* border: 1px #333 solid; */


### PR DESCRIPTION
If a vue tree gets interrupted (by ipyreact or classic ipywidgets) we start a new (vuetify) app. This causes that root DOM element to take up 100vh, which is only needed for the top-level app.