### PR TITLE
ci: fix `update-ci-package-locks` for PRs opened from a fork

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -451,7 +451,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           ref: ${{ github.head_ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.event.repository.full_name }}
 
       - name: Prepare
         id: prepare


### PR DESCRIPTION
Opening this from a fork to properly test the functionality