### PR TITLE
fix: close playwright properly when building ssg

### DIFF
--- a/packages/solara-enterprise/solara_enterprise/ssg.py
+++ b/packages/solara-enterprise/solara_enterprise/ssg.py
@@ -53,6 +53,15 @@ def _get_playwright():
     return pw
 
 
+def close_playwrights():
+    for pw in playwrights:
+        if pw.browser is not None:
+            pw.browser.close()
+        if pw.context_manager is not None:
+            pw.context_manager.__exit__(None, None, None)
+    playwrights.clear()
+
+
 def ssg_crawl(base_url: str):
     license.check("SSG")
     import solara.server.app
@@ -82,13 +91,10 @@ def ssg_crawl(base_url: str):
 
     for result in results:
         wait(result)
+
+    thread_pool.apply_async(close_playwrights)
     thread_pool.close()
     thread_pool.join()
-    for pw in playwrights:
-        assert pw.browser is not None
-        assert pw.context_manager is not None
-        pw.browser.close()
-        pw.context_manager.__exit__(None, None, None)
 
     rprint("Done building SSG")
 


### PR DESCRIPTION
Previously we attempted to close the playwrights after the threadpool has been closed. However, outside of the async context we only find `pw.browser` (as well as all other properties) to be `None`, which previously resulted in an error due to us asserting that `pw.browser is not None`. Closing the browser and context manager properly should ensure they don't drain any resources after ssg generation is done.

I'm not sure if there is a concern that `close_playwrights` executes before the ssg is done, resulting in the opening of a new context, and that one not being closed.

