### PR TITLE
docs: fix and improve search result display on website

### DIFF
--- a/solara/website/assets/custom.css
+++ b/solara/website/assets/custom.css
@@ -183,6 +183,12 @@ blockquote p:last-child {
     background-color: var(--dark-color-primary-lightest);
 }
 
+/* Algolia search results styling */
+.algolia-docsearch-suggestion--highlight {
+    color: var(--color-primary);
+    font-weight: 700;
+}
+
 /* API PAGE REFACTOR STYLE */
 
 .v-sheet.api-search-container{


### PR DESCRIPTION
Previously sub-headers in which hits were found were not displayed in the results box. This should guarantee that some header + subheader is displayed. A preview string of the hit is also shown.
