### PR TITLE
fix: fade out was not restored on navigations from a thread or task

### DIFF
--- a/solara/server/static/main-vuetify.js
+++ b/solara/server/static/main-vuetify.js
@@ -138,7 +138,9 @@ async function solaraInit(mountId, appName) {
     });
 
     window.addEventListener('solara.router', function (event) {
-        app.$data.loadingPage = true;
+        if(kernel.status == 'busy') {
+            app.$data.loadingPage = true;
+        }
     });
     kernel.statusChanged.connect(() => {
         // the first idle after a loadingPage == true (a router event)


### PR DESCRIPTION
A busy/idle pair of messages is only send when around a websocket message is handled in the main solara-server task.
When the browser location changes, we fade out the main content, which we restore again when the idle message is received. But if we change the location from a thread or task, the busy and idle messages are not send, so the fade out is not restored, leaving the main content faded out.

To solve this we only fade out when the location changes and the kernel is busy.