### PR TITLE
feat: detect mutation to values of reactive vars

### DIFF
--- a/solara/_stores.py
+++ b/solara/_stores.py
@@ -1,0 +1,178 @@
+import copy
+import dataclasses
+import inspect
+from typing import Callable, ContextManager, Generic, Optional
+import warnings
+from .toestand import ValueBase, S, _find_outside_solara_frame
+import solara.util
+
+
+@dataclasses.dataclass
+class StoreValue(Generic[S]):
+    private: S  # the internal private value, should never be mutated
+    public: Optional[S]  # this is the value that is exposed in .get(), it is a deep copy of private
+    get_traceback: Optional[inspect.Traceback]
+    set_value: Optional[S]  # the value that was set using .set(..), we deepcopy this to set private
+    set_traceback: Optional[inspect.Traceback]
+
+
+class MutateDetectorStore(ValueBase[S]):
+    def __init__(self, store: ValueBase[StoreValue[S]], equals=solara.util.equals):
+        self._storage = store
+        self._enabled = True
+        super().__init__(equals=equals)
+
+    @property
+    def lock(self):
+        return self._storage.lock
+
+    def get(self) -> S:
+        print("check!")
+        self.check_mutations()
+        self._ensure_public_exists()
+        value = self._storage.get()
+        assert value.public is not None
+        return value.public
+
+    def peek(self) -> S:
+        """Return the value without automatically subscribing to listeners."""
+        self.check_mutations()
+        store_value = self._storage.peek()
+        self._ensure_public_exists()
+        assert store_value.public is not None
+        return store_value.public
+
+    def set(self, value: S):
+        self._ensure_public_exists()
+        private = copy.deepcopy(value)
+        self._check_equals(private, value)
+        frame = _find_outside_solara_frame()
+        if frame is not None:
+            frame_info = inspect.getframeinfo(frame)
+        else:
+            frame_info = None
+        store_value = StoreValue(private=private, public=None, get_traceback=None, set_value=value, set_traceback=frame_info)
+        self._storage.set(store_value)
+
+    def check_mutations(self):
+        if not self._enabled:
+            return
+        store_value = self._storage.peek()
+        if store_value.public is not None and not self.equals(store_value.public, store_value.private):
+            tb = store_value.get_traceback
+            # TODO: make the error message as elaborate as below
+            msg = (
+                f"Reactive variable was read when it had the value of {store_value.private!r}, but was later mutated to {store_value.public!r}.\n"
+                "Mutation should not be done on the value of a reactive variable, as in production mode we would be unable to track changes.\n"
+            )
+            if tb:
+                if tb.code_context:
+                    code = tb.code_context[0]
+                else:
+                    code = "<No code context available>"
+                msg += f"The last value was read in the following code:\n" f"{tb.filename}:{tb.lineno}\n" f"{code}"
+            raise ValueError(msg)
+        elif store_value.set_value is not None and not self.equals(store_value.set_value, store_value.private):
+            tb = store_value.set_traceback
+            msg = f"""Reactive variable was set with a value of {store_value.private!r}, but was later mutated mutated to {store_value.set_value!r}.
+
+Mutation should not be done on the value of a reactive variable, as in production mode we would be unable to track changes.
+
+Bad:
+    mylist = reactive([]]
+    some_values = [1, 2, 3]
+    mylist.value = some_values  # you give solara a reference to your list
+    some_values.append(4)  # but later mutate it (solara cannot detect this change, so a render will not be triggered)
+    # if later on a re-render happens for a different reason, you will read of the mutated list.
+
+Good (if you want the reactive variable to be updated):
+    mylist = reactive([]]
+    some_values = [1, 2, 3]
+    mylist.value = some_values
+    mylist.value = some_values + [4]
+
+Good (if you want to keep mutating your own list):
+    mylist = reactive([]]
+    some_values = [1, 2, 3]
+    mylist.value = some_values.copy()  # this gives solara a copy of the list
+    some_values.append(4)  # you are free to mutate your own list, solara will not see this
+
+"""
+            if tb:
+                if tb.code_context:
+                    code = tb.code_context[0]
+                else:
+                    code = "<No code context available>"
+                msg += "The last time the value was set was at:\n" f"{tb.filename}:{tb.lineno}\n" f"{code}"
+            raise ValueError(msg)
+
+    def _ensure_public_exists(self):
+        store_value = self._storage.peek()
+        if store_value.public is None:
+            with self.lock:
+                if store_value.public is None:
+                    frame = _find_outside_solara_frame()
+                    if frame is not None:
+                        frame_info = inspect.getframeinfo(frame)
+                    else:
+                        frame_info = None
+                    store_value.public = copy.deepcopy(store_value.private)
+                    self._check_equals(store_value.public, store_value.private)
+                    store_value.get_traceback = frame_info
+
+    def _check_equals(self, a: S, b: S):
+        if not self._enabled:
+            return
+        if not self.equals(a, b):
+            frame = _find_outside_solara_frame()
+            if frame is not None:
+                frame_info = inspect.getframeinfo(frame)
+            else:
+                frame_info = None
+
+            warn = """The equals function for this reactive value returned False when comparing a deepcopy to itself.
+
+This reactive variable will not be able to detect mutations correctly, and is therefore disabled.
+
+To avoid this warning, and to ensure that mutation detection works correctly, please provide a better equals function to the reactive variable.
+A good choice for dataframes and numpy arrays might be solara.util.equals_pickle, which will also attempt to compare the pickled values of the objects.
+
+Example:
+df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+reactive_df = solara.reactive(df, equals=solara.util.equals_pickle)
+"""
+            tb = frame_info
+            if tb:
+                if tb.code_context:
+                    code = tb.code_context[0]
+                else:
+                    code = "<No code context available>"
+                warn += "This warning was triggered from:\n" f"{tb.filename}:{tb.lineno}\n" f"{code}"
+            warnings.warn(warn)
+            self._enabled = False
+
+    def subscribe(self, listener: Callable[[S], None], scope: Optional[ContextManager] = None):
+        def listener_wrapper(new: StoreValue[S], previous: StoreValue[S]):
+            self._ensure_public_exists()
+            assert new.public is not None
+            assert previous.public is not None
+            previous_value = previous.set_value if previous.set_value is not None else previous.private
+            new_value = new.set_value
+            assert new_value is not None
+            if not self.equals(new_value, previous_value):
+                listener(new_value)
+
+        return self._storage.subscribe_change(listener_wrapper, scope=scope)
+
+    def subscribe_change(self, listener: Callable[[S, S], None], scope: Optional[ContextManager] = None):
+        def listener_wrapper(new: StoreValue[S], previous: StoreValue[S]):
+            self._ensure_public_exists()
+            assert new.public is not None
+            assert previous.public is not None
+            previous_value = previous.set_value if previous.set_value is not None else previous.private
+            new_value = new.set_value
+            assert new_value is not None
+            if not self.equals(new_value, previous_value):
+                listener(new_value, previous_value)
+
+        return self._storage.subscribe_change(listener_wrapper, scope=scope)

--- a/solara/_stores.py
+++ b/solara/_stores.py
@@ -17,7 +17,7 @@ class StoreValue(Generic[S]):
 
 
 class MutateDetectorStore(ValueBase[S]):
-    def __init__(self, store: KernelStore[StoreValue[S]], equals=solara.util.equals):
+    def __init__(self, store: KernelStore[StoreValue[S]], equals=solara.util.equals_extra):
         self._storage = store
         self._enabled = True
         super().__init__(equals=equals)
@@ -27,7 +27,6 @@ class MutateDetectorStore(ValueBase[S]):
         return self._storage.lock
 
     def get(self) -> S:
-        print("check!")
         self.check_mutations()
         self._ensure_public_exists()
         value = self._storage.get()

--- a/solara/hooks/use_reactive.py
+++ b/solara/hooks/use_reactive.py
@@ -1,6 +1,7 @@
 from typing import Callable, Optional, TypeVar, Union
 
 import solara
+from solara.toestand import Equals
 
 T = TypeVar("T")
 
@@ -8,6 +9,7 @@ T = TypeVar("T")
 def use_reactive(
     value: Union[T, solara.Reactive[T]],
     on_change: Optional[Callable[[T], None]] = None,
+    equals: Equals = solara.util.equals,
 ) -> solara.Reactive[T]:
     """Creates a reactive variable with the a local component scope.
 
@@ -43,6 +45,12 @@ def use_reactive(
 
      * on_change (Optional[Callable[[T], None]]): An optional callback function
             that will be called when the reactive variable's value changes.
+
+     * equals: A function that return True if two values are considered equal, and False otherwise.
+            The default function is `solara.util.equals`, which performs a deep comparison of the two values
+            and is more forgiving than the default `==` operator.
+            You can provide a custom function if you need to define a different notion of equality.
+
 
     Returns:
         solara.Reactive[T]: A reactive variable with the specified initial value

--- a/solara/hooks/use_reactive.py
+++ b/solara/hooks/use_reactive.py
@@ -1,7 +1,6 @@
-from typing import Callable, Optional, TypeVar, Union
+from typing import Any, Callable, Optional, TypeVar, Union
 
 import solara
-from solara.toestand import Equals
 
 T = TypeVar("T")
 
@@ -9,7 +8,7 @@ T = TypeVar("T")
 def use_reactive(
     value: Union[T, solara.Reactive[T]],
     on_change: Optional[Callable[[T], None]] = None,
-    equals: Equals = solara.util.equals,
+    equals: Callable[[Any, Any], bool] = solara.util.equals_extra,
 ) -> solara.Reactive[T]:
     """Creates a reactive variable with the a local component scope.
 
@@ -46,7 +45,7 @@ def use_reactive(
      * on_change (Optional[Callable[[T], None]]): An optional callback function
             that will be called when the reactive variable's value changes.
 
-     * equals: A function that return True if two values are considered equal, and False otherwise.
+     * equals: A function that returns True if two values are considered equal, and False otherwise.
             The default function is `solara.util.equals`, which performs a deep comparison of the two values
             and is more forgiving than the default `==` operator.
             You can provide a custom function if you need to define a different notion of equality.

--- a/solara/reactive.py
+++ b/solara/reactive.py
@@ -1,13 +1,14 @@
 from typing import TypeVar
 
-from solara.toestand import Reactive
+from solara.toestand import Reactive, Equals
+import solara.util
 
 __all__ = ["reactive", "Reactive"]
 
 T = TypeVar("T")
 
 
-def reactive(value: T) -> Reactive[T]:
+def reactive(value: T, equals: Equals = solara.util.equals) -> Reactive[T]:
     """Creates a new Reactive object with the given initial value.
 
     Reactive objects are mostly used to manage global or application-wide state in
@@ -35,6 +36,11 @@ def reactive(value: T) -> Reactive[T]:
 
     Args:
         value (T): The initial value of the reactive variable.
+        equals: A function that return True if two values are considered equal, and False otherwise.
+            The default function is `solara.util.equals`, which performs a deep comparison of the two values
+            and is more forgiving than the default `==` operator.
+            You can provide a custom function if you need to define a different notion of equality.
+
 
     Returns:
         Reactive[T]: A new Reactive object with the specified initial value.
@@ -90,4 +96,4 @@ def reactive(value: T) -> Reactive[T]:
     Whenever the counter value changes, `CounterDisplay` automatically updates to display the new value.
 
     """
-    return Reactive(value)
+    return Reactive(value, equals=equals)

--- a/solara/reactive.py
+++ b/solara/reactive.py
@@ -1,6 +1,6 @@
-from typing import TypeVar
+from typing import Any, Callable, TypeVar
 
-from solara.toestand import Reactive, Equals
+from solara.toestand import Reactive
 import solara.util
 
 __all__ = ["reactive", "Reactive"]
@@ -8,7 +8,7 @@ __all__ = ["reactive", "Reactive"]
 T = TypeVar("T")
 
 
-def reactive(value: T, equals: Equals = solara.util.equals) -> Reactive[T]:
+def reactive(value: T, equals: Callable[[Any, Any], bool] = solara.util.equals_extra) -> Reactive[T]:
     """Creates a new Reactive object with the given initial value.
 
     Reactive objects are mostly used to manage global or application-wide state in
@@ -36,7 +36,7 @@ def reactive(value: T, equals: Equals = solara.util.equals) -> Reactive[T]:
 
     Args:
         value (T): The initial value of the reactive variable.
-        equals: A function that return True if two values are considered equal, and False otherwise.
+        equals: A function that returns True if two values are considered equal, and False otherwise.
             The default function is `solara.util.equals`, which performs a deep comparison of the two values
             and is more forgiving than the default `==` operator.
             You can provide a custom function if you need to define a different notion of equality.

--- a/solara/settings.py
+++ b/solara/settings.py
@@ -61,9 +61,23 @@ class MainSettings(BaseSettings):
         env_file = ".env"
 
 
+class Storage(BaseSettings):
+    mutation_detection: Optional[bool] = None  # True/False, or None to auto determine
+    factory: str = "solara.toestand.default_storage"
+
+    def get_factory(self):
+        return solara.util.import_item(self.factory)
+
+    class Config:
+        env_prefix = "solara_storage_"
+        case_sensitive = False
+        env_file = ".env"
+
+
 assets: Assets = Assets()
 cache: Cache = Cache()
 main = MainSettings()
+storage = Storage()
 
 if main.check_hooks not in ["off", "warn", "raise"]:
     raise ValueError(f"Invalid value for check_hooks: {main.check_hooks}, expected one of ['off', 'warn', 'raise']")

--- a/solara/toestand.py
+++ b/solara/toestand.py
@@ -1,9 +1,12 @@
 import contextlib
 import dataclasses
+import inspect
 import logging
 import sys
 import threading
+from types import FrameType
 import warnings
+import copy
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from operator import getitem
@@ -19,6 +22,7 @@ from typing import (
     TypeVar,
     Union,
     cast,
+    List,
     overload,
 )
 
@@ -35,6 +39,7 @@ S = TypeVar("S")  # used for state
 logger = logging.getLogger("solara.toestand")
 
 _DEBUG = False
+_CHECK_MUTATIONS = True
 
 
 class ThreadLocal(threading.local):
@@ -269,11 +274,67 @@ class KernelStore(ValueBase[S], ABC):
         pass
 
 
+@dataclasses.dataclass
+class ShouldNotMutate:
+    value: Any
+    original: Any
+    traceback: Optional[inspect.Traceback]
+
+
+should_not_mutate: List[ShouldNotMutate] = []
+
+
+def _track_initial_mutation(value):
+    frame = _find_outside_solara_frame()
+    if frame is not None:
+        frame_info = inspect.getframeinfo(frame)
+    else:
+        frame_info = None
+
+    if value is not None:
+        v = ShouldNotMutate(value, copy.deepcopy(value), frame_info)
+        should_not_mutate.append(v)
+
+
+def check_mutations():
+    for v in should_not_mutate:
+        if v.value != v.original:
+            tb = v.traceback
+            if tb:
+                if tb.code_context:
+                    code = tb.code_context[0].strip()
+                else:
+                    code = "No code context available"
+                msg = (
+                    f"Reactive variable initialized at {tb.filename}:{tb.lineno} was initialized with a value of {v.original!r}, but was mutated to {v.value!r}.\n"
+                    f"{code}"
+                )
+            else:
+                msg = f"Reactive variable was initialized with a value of {v.original!r}, but was mutated to {v.value!r} (unable to report the location in the source code)."
+            raise ValueError(msg)
+
+
+def _find_outside_solara_frame() -> Optional[FrameType]:
+    # the module where the call stack origined from
+    current_frame = inspect.currentframe()
+    module_frame = None
+
+    while current_frame is not None:
+        module = inspect.getmodule(current_frame)
+        if module is None or not module.__name__.startswith("solara"):
+            module_frame = current_frame
+            break
+        current_frame = current_frame.f_back
+
+    return module_frame
+
+
 class KernelStoreValue(KernelStore[S]):
     default_value: S
 
     def __init__(self, default_value: S, key=None):
         self.default_value = default_value
+        _track_initial_mutation(default_value)
         cls = type(default_value)
         if key is None:
             with KernelStoreValue.scope_lock:
@@ -283,7 +344,7 @@ class KernelStoreValue(KernelStore[S]):
         super().__init__(key=key)
 
     def initial_value(self) -> S:
-        return self.default_value
+        return copy.deepcopy(self.default_value)
 
 
 def _create_key_callable(f: Callable[[], S]):
@@ -311,18 +372,49 @@ class KernelStoreFactory(KernelStore[S]):
         return self.factory()
 
 
-class Reactive(ValueBase[S]):
-    _storage: ValueBase[S]
+@dataclasses.dataclass
+class StoreValue(Generic[S]):
+    private: S  # the internal private value, should never be mutated, when _CHECK_MUTATIONS is False, we expose this in .get()
+    public: Optional[S]  # when _CHECK_MUTATIONS is True, this is the value that is exposed in .get(), it is a deep copy of private
+    get_traceback: Optional[inspect.Traceback]
+    set_value: Optional[S]  # the value that was set using .set(..), we deepcopy this to set private when _CHECK_MUTATIONS is True
+    set_traceback: Optional[inspect.Traceback]
 
-    def __init__(self, default_value: Union[S, ValueBase[S]], key=None):
+
+def equals2(a, b):
+    """Compare two values for equality.
+
+    Avoid false negative, e.g. when comparing dataframes, we want to compare
+    the data, not the object identity.
+
+    TODO: how do we reconcile this with the original equals function?
+
+    """
+    if equals(a, b):
+        return True
+    import pickle
+
+    try:
+        if pickle.dumps(a) == pickle.dumps(b):
+            return True
+    except Exception:
+        pass
+    return False
+
+
+class Reactive(ValueBase[S]):
+    _storage: ValueBase[StoreValue[S]]
+
+    def __init__(self, default_value: Union[S, ValueBase[StoreValue[S]]], key=None, equals=equals2):
         super().__init__()
         if not isinstance(default_value, ValueBase):
-            self._storage = KernelStoreValue(default_value, key=key)
+            self._storage = KernelStoreValue(StoreValue[S](private=default_value, public=None, get_traceback=None, set_value=None, set_traceback=None), key=key)
         else:
             self._storage = default_value
         self.__post__init__()
         self._name = None
         self._owner = None
+        self.equals = equals
 
     def __set_name__(self, owner, name):
         self._name = name
@@ -354,25 +446,125 @@ class Reactive(ValueBase[S]):
     def set(self, value: S):
         if value is self:
             raise ValueError("Can't set a reactive to itself")
-        self._storage.set(value)
+        if _CHECK_MUTATIONS:
+            private = copy.deepcopy(value)
+            frame = _find_outside_solara_frame()
+            if frame is not None:
+                frame_info = inspect.getframeinfo(frame)
+            else:
+                frame_info = None
+            store_value = StoreValue[S](private=private, public=None, get_traceback=None, set_value=value, set_traceback=frame_info)
+        else:
+            store_value = StoreValue[S](private=value, public=None, get_traceback=None, set_value=None, set_traceback=None)
+        self._storage.set(store_value)
+
+    def check_mutations(self):
+        if not _CHECK_MUTATIONS:
+            return
+        store_value = self._storage.peek()
+        if store_value.public is not None and not self.equals(store_value.public, store_value.private):
+            tb = store_value.get_traceback
+            # TODO: make the error message as elaborate as below
+            msg = (
+                f"Reactive variable was read when it had the value of {store_value.private!r}, but was later mutated to {store_value.public!r}.\n"
+                "Mutation should not be done on the value of a reactive variable, as in production mode we would be unable to track changes.\n"
+            )
+            if tb:
+                if tb.code_context:
+                    code = tb.code_context[0]
+                else:
+                    code = "<No code context available>"
+                msg += f"The last value was read in the following code:\n" f"{tb.filename}:{tb.lineno}\n" f"{code}"
+            raise ValueError(msg)
+        elif store_value.set_value is not None and not self.equals(store_value.set_value, store_value.private):
+            tb = store_value.set_traceback
+            msg = f"""Reactive variable was set with a value of {store_value.private!r}, but was later mutated mutated to {store_value.set_value!r}.
+
+Mutation should not be done on the value of a reactive variable, as in production mode we would be unable to track changes.
+
+Bad:
+    mylist = reactive([]]
+    some_values = [1, 2, 3]
+    mylist.value = some_values  # you give solara a reference to your list
+    some_values.append(4)  # but later mutate it (solara cannot detect this change, so a render will not be triggered)
+    # if later on a re-render happens for a different reason, you will read of the mutated list.
+
+Good (if you want the reactive variable to be updated):
+    mylist = reactive([]]
+    some_values = [1, 2, 3]
+    mylist.value = some_values
+    mylist.value = some_values + [4]
+
+Good (if you want to keep mutating your own list):
+    mylist = reactive([]]
+    some_values = [1, 2, 3]
+    mylist.value = some_values.copy()  # this gives solara a copy of the list
+    some_values.append(4)  # you are free to mutate your own list, solara will not see this
+
+"""
+            if tb:
+                if tb.code_context:
+                    code = tb.code_context[0]
+                else:
+                    code = "<No code context available>"
+                msg += "The last time the value was set was at:\n" f"{tb.filename}:{tb.lineno}\n" f"{code}"
+            raise ValueError(msg)
 
     def get(self, add_watch=None) -> S:
+        self.check_mutations()
+        # peek also avoid parents also adding themselves to the reactive_used set
+        value = self.peek()
         if add_watch is not None:
             warnings.warn("add_watch is deprecated, use .peek()", DeprecationWarning)
         if thread_local.reactive_used is not None:
             thread_local.reactive_used.add(self)
-        # peek to avoid parents also adding themselves to the reactive_used set
-        return self._storage.peek()
+        return value
 
     def peek(self) -> S:
         """Return the value without automatically subscribing to listeners."""
-        return self._storage.peek()
+        store_value = self._storage.peek()
+        self._ensure_public_exists()
+        if _CHECK_MUTATIONS:
+            assert store_value.public is not None
+            return store_value.public
+        else:
+            return store_value.private
+
+    def _ensure_public_exists(self):
+        store_value = self._storage.peek()
+        if _CHECK_MUTATIONS and store_value.public is None:
+            with self.lock:
+                if store_value.public is None:
+                    frame = _find_outside_solara_frame()
+                    if frame is not None:
+                        frame_info = inspect.getframeinfo(frame)
+                    else:
+                        frame_info = None
+                    store_value.public = copy.deepcopy(store_value.private)
+                    store_value.get_traceback = frame_info
 
     def subscribe(self, listener: Callable[[S], None], scope: Optional[ContextManager] = None):
-        return self._storage.subscribe(listener, scope=scope)
+        def listener_wrapper(value: StoreValue[S]):
+            if _CHECK_MUTATIONS:
+                self._ensure_public_exists()
+                assert value.public is not None
+                listener(value.public)
+            else:
+                listener(value.private)
+
+        return self._storage.subscribe(listener_wrapper, scope=scope)
 
     def subscribe_change(self, listener: Callable[[S, S], None], scope: Optional[ContextManager] = None):
-        return self._storage.subscribe_change(listener, scope=scope)
+        def listener_wrapper(new: StoreValue[S], previous: StoreValue[S]):
+            if _CHECK_MUTATIONS:
+                self._ensure_public_exists()
+                assert new.public is not None
+                assert previous.public is not None
+                listener(new.public, previous.public)
+            else:
+                listener(new.private, previous.private)
+
+        return self._storage.subscribe_change(listener_wrapper, scope=scope)
 
     def computed(self, f: Callable[[S], T]) -> "Computed[T]":
         def func():

--- a/solara/toestand.py
+++ b/solara/toestand.py
@@ -324,7 +324,7 @@ class KernelStoreValue(KernelStore[S]):
         self.default_value = default_value
         self._unwrap = unwrap
         self.equals = equals
-        self._mutation_detection = True  # solara.settings.storage.mutation_detection
+        self._mutation_detection = solara.settings.storage.mutation_detection
         if self._mutation_detection:
             frame = _find_outside_solara_frame()
             if frame is not None:
@@ -410,10 +410,10 @@ class KernelStoreFactory(KernelStore[S]):
 
 def mutation_detection_storage(default_value: S, key=None, equals=None) -> ValueBase[S]:
     from solara.util import equals_pickle as default_equals
-    from ._stores import MutateDetectorStore, StoreValue
+    from ._stores import MutateDetectorStore, StoreValue, _PublicValueNotSet
 
     kernel_store = KernelStoreValue[StoreValue[S]](
-        StoreValue[S](private=default_value, public=None, get_traceback=None, set_value=None, set_traceback=None),
+        StoreValue[S](private=default_value, public=_PublicValueNotSet(), get_traceback=None, set_value=None, set_traceback=None),
         key=key,
         unwrap=lambda x: x.private,
     )

--- a/solara/util.py
+++ b/solara/util.py
@@ -31,7 +31,7 @@ except RuntimeError:
     has_threads = False
 
 
-from reacton.utils import equals as equals
+from reacton.utils import equals as equals_extra
 
 
 def equals_pickle(a, b):
@@ -41,7 +41,7 @@ def equals_pickle(a, b):
     the data, not the object identity.
 
     """
-    if equals(a, b):
+    if equals_extra(a, b):
         return True
     import pickle
 

--- a/solara/util.py
+++ b/solara/util.py
@@ -31,6 +31,28 @@ except RuntimeError:
     has_threads = False
 
 
+from reacton.utils import equals as equals
+
+
+def equals_pickle(a, b):
+    """Compare two values for equality.
+
+    Avoid false negative, e.g. when comparing dataframes, we want to compare
+    the data, not the object identity.
+
+    """
+    if equals(a, b):
+        return True
+    import pickle
+
+    try:
+        if pickle.dumps(a) == pickle.dumps(b):
+            return True
+    except Exception:
+        pass
+    return False
+
+
 def github_url(file):
     rel_path = os.path.relpath(file, Path(solara.__file__).parent.parent)
     github_url = solara.github_url + f"/blob/{solara.git_branch}/" + rel_path

--- a/solara/website/pages/roadmap/roadmap.md
+++ b/solara/website/pages/roadmap/roadmap.md
@@ -11,6 +11,9 @@ Exciting news! We aim to release Solara 2.0 by the end of the year. For the 2.0 
 
 - Elimination of common mistakes, such as detecting state mutations and avoiding misuse of hooks (e.g., using hooks in loops).
 
+    State mutation detection will be the default for Solara 2.0, but can be enabled in Solara 1.x by setting the environment variable `SOLARA_STORAGE_MUTATION_DETECTION=1`.
+
+
 - [See more details in the 2.0 milestone on GitHub.](https://github.com/widgetti/solara/milestone/1)
 
 

--- a/solara/website/pages/roadmap/roadmap.md
+++ b/solara/website/pages/roadmap/roadmap.md
@@ -11,7 +11,7 @@ Exciting news! We aim to release Solara 2.0 by the end of the year. For the 2.0 
 
 - Elimination of common mistakes, such as detecting state mutations and avoiding misuse of hooks (e.g., using hooks in loops).
 
-    State mutation detection will be the default for Solara 2.0, but can be enabled in Solara 1.x by setting the environment variable `SOLARA_STORAGE_MUTATION_DETECTION=1`.
+    State mutation detection will be the default for Solara 2.0, but can be enabled in Solara > 1.41.0 by setting the environment variable `SOLARA_STORAGE_MUTATION_DETECTION=1`.
 
 
 - [See more details in the 2.0 milestone on GitHub.](https://github.com/widgetti/solara/milestone/1)

--- a/tests/unit/toestand_test.py
+++ b/tests/unit/toestand_test.py
@@ -4,6 +4,8 @@ import unittest.mock
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Set, TypeVar
 
+import pytest
+
 import ipyvuetify as v
 import react_ipywidgets as react
 from typing_extensions import TypedDict
@@ -14,6 +16,7 @@ import solara.lab
 import solara.toestand as toestand
 from solara.server import kernel, kernel_context
 from solara.toestand import Reactive, Ref, State, use_sync_external_store
+import pandas as pd
 
 from .common import click
 
@@ -1233,3 +1236,45 @@ def test_pydantic_basic():
     assert person.get().height == 2.0
     assert Ref(person.fields.name).get() == "Maria"
     assert Ref(person.fields.height).get() == 2.0
+def test_mutate_initial_value():
+    initial_values = [1, 2, 3]
+    reactive = Reactive(initial_values)
+    assert reactive.value == initial_values
+    initial_values.append(4)
+    assert reactive.value != initial_values
+    with pytest.raises(ValueError):
+        toestand.check_mutations()
+
+
+def test_mutate_value_public_value():
+    values = [1, 2, 3]
+    reactive = Reactive(values)
+    reactive.value.append(4)
+    with pytest.raises(ValueError, match="Reactive variable was read when it had the value of \[1, 2, 3\].*"):
+        reactive.check_mutations()
+
+
+def test_mutate_value_set_value():
+    values = [1, 2, 3]
+    reactive = Reactive(values)
+    new_values = [1, 2, 3, 4]
+    reactive.value = new_values
+    new_values.append(5)
+    # print(reactive.value)
+    with pytest.raises(ValueError, match="Reactive variable was set.*"):
+        reactive.check_mutations()
+
+
+def test_mutate_value_set_value_dataframe():
+    # dataframes do not support simple equality checks
+    # and we cannot have false equals(a, b) == False result when they
+    # actually are equal
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    df_orig = df.copy()
+    reactive_df = Reactive[Optional[pd.DataFrame]](None)
+    assert reactive_df.equals(df, df_orig)
+    reactive_df.value = df
+    df["a"][0] = 100
+    assert not reactive_df.equals(df, df_orig)
+    with pytest.raises(ValueError, match="Reactive variable was set.*"):
+        reactive_df.check_mutations()


### PR DESCRIPTION
A common source of error is mutation of values in reactive vars. The reactive var cannot notice a change in its value (e.g. a list) if the list is mutated in place.

A user can be mislead that it is working correctly, when another reactive variable triggers a rerender, teaching bad habits.

Detecting mutations in Python without using proxies can be done by making a deepcopy of the object, and comparing the reference to the deepcopy.

This comes at the cost of performance and memory usage, therefore we should enabled this by default in development mode (tests run in this mode by default), so app builders are aware of mistakes while developing.
In production mode we can disable the mutation checks and behave as before.

TODO:
 - [ ] Trigger calls to check_mutations() from several places: after an event handler (requires a change in reacton) and after a component run.
 - [ ] We probably do not want two equals function in solara/reacton, reconcile this.
 - [ ] Give an option to opt out of the mutation check per reactive var (e.g. when equals fails), or for performance reasons.
 - [ ] support reactive.get(copy=True) to always get a copy, even when _CHECK_MUTATIONS is False
 - [ ] Do we need support reactive.get(reference=True) to always get a reference, or is the opt-out enough?