### PR TITLE
ci: requirements.txt without editable mode to deploy to render.com

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
--e .[all]
--e ./packages/solara-server[all]
--e ./packages/solara-enterprise[all]
+.[all]
+./packages/solara-server[all]
+./packages/solara-enterprise[all]
+./packages/solara-meta[all]


### PR DESCRIPTION
render.com does not like the editable install.
```
==> Running build command 'pip install -r requirements.txt'...
ERROR: File "setup.py" or "setup.cfg" not found. Directory cannot be installed in editable mode: /opt/render/project/src
(A "pyproject.toml" file was found, but editable mode currently requires a setuptools-based build.)
```