### PR TITLE
fix: support pydantic 1 and 2 in reactive vars

### DIFF
--- a/solara/toestand.py
+++ b/solara/toestand.py
@@ -77,7 +77,12 @@ def merge_state(d1: S, **kwargs) -> S:
     if dataclasses.is_dataclass(d1):
         return dataclasses.replace(d1, **kwargs)  # type: ignore
     if "pydantic" in sys.modules and isinstance(d1, sys.modules["pydantic"].BaseModel):
-        return type(d1)(**{**d1.dict(), **kwargs})  # type: ignore
+        module = sys.modules["pydantic"]
+        version_major = int(module.__version__.split(".")[0])
+        if version_major >= 2:
+            return d1.model_copy(update=kwargs)
+        else:
+            return d1.copy(update=kwargs)
     return cast(S, {**cast(dict, d1), **kwargs})
 
 

--- a/tests/unit/toestand_test.py
+++ b/tests/unit/toestand_test.py
@@ -1204,3 +1204,32 @@ def test_computed_reload(no_kernel_context):
             assert text.widget.v_model == "4.0"
     finally:
         app.close()
+
+
+def test_pydantic_basic():
+    from pydantic import BaseModel
+
+    class Person(BaseModel):
+        name: str
+        height: float
+
+    person = Reactive[Person](Person(name="Jos", height=1.8))
+    assert person.get() == Person(name="Jos", height=1.8)
+    assert person.get().name == "Jos"
+    assert person.get().height == 1.8
+    assert Ref(person.fields.name).get() == "Jos"
+    assert Ref(person.fields.height).get() == 1.8
+
+    person.set(Person(name="Maria", height=1.7))
+    assert person.get() == Person(name="Maria", height=1.7)
+    assert person.get().name == "Maria"
+    assert person.get().height == 1.7
+    assert Ref(person.fields.name).get() == "Maria"
+    assert Ref(person.fields.height).get() == 1.7
+
+    Ref(person.fields.height).set(2.0)
+    assert person.get() == Person(name="Maria", height=2.0)
+    assert person.get().name == "Maria"
+    assert person.get().height == 2.0
+    assert Ref(person.fields.name).get() == "Maria"
+    assert Ref(person.fields.height).get() == 2.0


### PR DESCRIPTION
We supported pydantic 1 and 2, using .dict() which was deprecated in pydantic 2.
It is also semantically more correct to use .copy, which in pydantic 2 is model_copy.
We now use copy/model_copy depending on the pydantic version.