### PR TITLE
fix: do not remove the solara cli tool when upgrading solara to 1.30

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,3 +93,7 @@ timeout = 180
 
 [tool.codespell]
 skip='equis-in-vidi.md,substiterat-vati.md,.*,solara/website/build,*.svg,highlight-dark.css,packages/**/dist/*,node_modules,packages/solara-assets,package*.json,tsconfig.tsbuildinfo,*.csv'
+
+
+[project.scripts]
+solara = "solara.__main__:main"


### PR DESCRIPTION
In solara version < 1.29, the cli tool was defined in the solara package. While now it is in the solara-server package.

It seems when pip upgrade to 1.30, it removes the solara package after installing solara-server (which just installed the cli tool), thereby removing the cli tool again.
By also including the cli tool in the solara package, the cli tool will again be installed when it is installed after the older solara package.

pip does not seem to complain about this, but I wonder if we should do this, since I can also imagine that other systems may not like this. (e.g. pycafe?)