### PR TITLE
fix: more unique keys for tasks to reduce mixup during hot reloads

### DIFF
--- a/tests/unit/task_test.py
+++ b/tests/unit/task_test.py
@@ -72,6 +72,11 @@ def SquareButton(value, on_render=lambda: None):
             raise RuntimeError("should not happen")
 
 
+def test_task_key():
+    assert "something" in something._result._storage.storage_key  # type: ignore
+    assert "something" in something._instance._storage.storage_key  # type: ignore
+
+
 def test_task_basic():
     results = []
 


### PR DESCRIPTION
When used in use_task, this can create many keys, which after a next render can be mixed up with a global task.

Now the key include the function name, so it is more unique.