### PR TITLE
fix: avoid closing a kernel twice by using a mutex

### DIFF
--- a/solara/server/flask.py
+++ b/solara/server/flask.py
@@ -162,8 +162,8 @@ def kernels_connection(ws: simple_websocket.Server, kernel_id: str, name: str):
 @blueprint.route("/_solara/api/close/<kernel_id>", methods=["GET", "POST"])
 def close(kernel_id: str):
     page_id = request.args["session_id"]
-    if kernel_id in kernel_context.contexts:
-        context = kernel_context.contexts[kernel_id]
+    context = kernel_context.contexts.get(kernel_id, None)
+    if context is not None:
         context.page_close(page_id)
     return ""
 

--- a/solara/server/starlette.py
+++ b/solara/server/starlette.py
@@ -311,8 +311,8 @@ async def _kernel_connection(ws: starlette.websockets.WebSocket):
 def close(request: Request):
     kernel_id = request.path_params["kernel_id"]
     page_id = request.query_params["session_id"]
-    if kernel_id in kernel_context.contexts:
-        context = kernel_context.contexts[kernel_id]
+    context = kernel_context.contexts.get(kernel_id, None)
+    if context is not None:
         context.page_close(page_id)
     response = HTMLResponse(content="", status_code=200)
     return response

--- a/tests/integration/lifecycle_test.py
+++ b/tests/integration/lifecycle_test.py
@@ -1,4 +1,3 @@
-import threading
 from pathlib import Path
 from typing import cast
 
@@ -81,12 +80,4 @@ def test_kernel_lifecycle_close_while_disconnected(
         page_session.locator("text=Clicks-1").click()
         page_session.locator("text=Clicks-2").wait_for()
         page_session.goto("about:blank")
-        # give a bit of time to make sure the cull task is started
-        page_session.wait_for_timeout(100)
-        cull_task_2 = context._last_kernel_cull_task
-        assert cull_task_2 is not None
-        # we can't mix do async, so we hook up an event to the Future
-        event = threading.Event()
-        cull_task_2.add_done_callback(lambda x: event.set())
-        event.wait()
-        assert context.closed_event.is_set()
+        assert context.closed_event.wait(timeout=20)


### PR DESCRIPTION
A kernel could be close multiple times if the websocket was closed at the same time as the close beacon was send. This caused in CI KeyError on custom_storage.py when the kernel cleanup function was called twice.
State managegment for pages is not protected by a mutex, so that it is thread safe.