### PR TITLE
Fixes pandas dataframe transpose display error

### DIFF
--- a/solara/components/datatable.py
+++ b/solara/components/datatable.py
@@ -10,7 +10,7 @@ import solara
 import solara.hooks.dataframe
 import solara.lab
 import traitlets
-from solara.lab.hooks.dataframe import use_df_column_names
+from solara.lab.hooks.dataframe import use_df_column_names, use_df_row_names
 from solara.lab.utils.dataframe import df_len, df_records, df_slice
 
 from .. import CellAction, ColumnAction
@@ -100,12 +100,12 @@ def DataTable(
     i2 = min(total_length, (page + 1) * items_per_page)
 
     columns = use_df_column_names(df)
-
+    rows = use_df_row_names(df)
     items = []
     dfs = df_slice(df, i1, i2)
     records = df_records(dfs)
     for i in range(i2 - i1):
-        item = {"__row__": i + i1}  # special key for the row number
+        item = {"__row__": rows[i + i1]}  # special key for the row number
         for column in columns:
             item[column] = format(dfs, column, i + i1, records[i][column])
         items.append(item)

--- a/solara/components/datatable.py
+++ b/solara/components/datatable.py
@@ -105,7 +105,7 @@ def DataTable(
     dfs = df_slice(df, i1, i2)
     records = df_records(dfs)
     for i in range(i2 - i1):
-        item = {"__row__": format(rows[i + i1])}  # special key for the row number
+        item = {"__row__": format(dfs, columns, i + 1, rows[i + i1])}  # special key for the row number
         for column in columns:
             item[column] = format(dfs, column, i + i1, records[i][column])
         items.append(item)

--- a/solara/components/datatable.py
+++ b/solara/components/datatable.py
@@ -10,7 +10,7 @@ import solara
 import solara.hooks.dataframe
 import solara.lab
 import traitlets
-from solara.lab.hooks.dataframe import use_df_column_names, use_df_row_names
+from solara.lab.hooks.dataframe import use_df_column_names, df_row_names
 from solara.lab.utils.dataframe import df_len, df_records, df_slice
 
 from .. import CellAction, ColumnAction
@@ -100,12 +100,12 @@ def DataTable(
     i2 = min(total_length, (page + 1) * items_per_page)
 
     columns = use_df_column_names(df)
-    rows = use_df_row_names(df)
+    rows = df_row_names(df)
     items = []
     dfs = df_slice(df, i1, i2)
     records = df_records(dfs)
     for i in range(i2 - i1):
-        item = {"__row__": rows[i + i1]}  # special key for the row number
+        item = {"__row__": format(rows[i + i1])}  # special key for the row number
         for column in columns:
             item[column] = format(dfs, column, i + i1, records[i][column])
         items.append(item)

--- a/solara/lab/hooks/dataframe.py
+++ b/solara/lab/hooks/dataframe.py
@@ -1,2 +1,2 @@
 from ..utils.dataframe import df_columns as use_df_column_names  # noqa: F401
-from ..utils.dataframe import df_rows as use_df_row_names  
+from ..utils.dataframe import df_row_names

--- a/solara/lab/hooks/dataframe.py
+++ b/solara/lab/hooks/dataframe.py
@@ -1,1 +1,2 @@
 from ..utils.dataframe import df_columns as use_df_column_names  # noqa: F401
+from ..utils.dataframe import df_rows as use_df_row_names  

--- a/solara/lab/hooks/dataframe.py
+++ b/solara/lab/hooks/dataframe.py
@@ -1,2 +1,2 @@
 from ..utils.dataframe import df_columns as use_df_column_names  # noqa: F401
-from ..utils.dataframe import df_row_names
+from ..utils.dataframe import df_row_names as df_row_names

--- a/solara/lab/utils/dataframe.py
+++ b/solara/lab/utils/dataframe.py
@@ -27,14 +27,12 @@ def df_columns(df) -> List[str]:
     else:
         raise TypeError(f"{type(df)} not supported")
 
-def df_rows(df) -> Union[List[str], List[int]]:
+def df_row_names(df) -> List[any]:
     """Return a list of row names from a dataframe."""
-    if df_type(df) == "vaex":
+    if df_type(df) == "vaex" or df_type(df) == "polars":
         return list(range(df_len(df)))
     elif df_type(df) == "pandas":
         return df.index.tolist()
-    elif df_type(df) == "polars":
-        return list(range(df_len(df)))
     else:
         raise TypeError(f"{type(df)} not supported")
 

--- a/solara/lab/utils/dataframe.py
+++ b/solara/lab/utils/dataframe.py
@@ -27,6 +27,16 @@ def df_columns(df) -> List[str]:
     else:
         raise TypeError(f"{type(df)} not supported")
 
+def df_rows(df) -> List[str]:
+    """Return a list of row names from a dataframe."""
+    if df_type(df) == "vaex":
+        return list(range(df_len(df)))
+    elif df_type(df) == "pandas":
+        return df.index.tolist()
+    elif df_type(df) == "polars":
+        return list(range(df_len(df)))
+    else:
+        raise TypeError(f"{type(df)} not supported")
 
 def df_slice(df, start: int, stop: int):
     """Return a subset of rows from a dataframe."""

--- a/solara/lab/utils/dataframe.py
+++ b/solara/lab/utils/dataframe.py
@@ -27,6 +27,7 @@ def df_columns(df) -> List[str]:
     else:
         raise TypeError(f"{type(df)} not supported")
 
+
 def df_row_names(df) -> List[Union[int, str]]:
     """Return a list of row names from a dataframe."""
     if df_type(df) == "vaex" or df_type(df) == "polars":
@@ -35,6 +36,7 @@ def df_row_names(df) -> List[Union[int, str]]:
         return df.index.tolist()
     else:
         raise TypeError(f"{type(df)} not supported")
+
 
 def df_slice(df, start: int, stop: int):
     """Return a subset of rows from a dataframe."""

--- a/solara/lab/utils/dataframe.py
+++ b/solara/lab/utils/dataframe.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Union
 
 
 def get_pandas_major():
@@ -27,7 +27,7 @@ def df_columns(df) -> List[str]:
     else:
         raise TypeError(f"{type(df)} not supported")
 
-def df_rows(df) -> List[str]:
+def df_rows(df) -> Union[List[str], List[int]]:
     """Return a list of row names from a dataframe."""
     if df_type(df) == "vaex":
         return list(range(df_len(df)))

--- a/solara/lab/utils/dataframe.py
+++ b/solara/lab/utils/dataframe.py
@@ -27,7 +27,7 @@ def df_columns(df) -> List[str]:
     else:
         raise TypeError(f"{type(df)} not supported")
 
-def df_row_names(df) -> List[any]:
+def df_row_names(df) -> List[Union[int, str]]:
     """Return a list of row names from a dataframe."""
     if df_type(df) == "vaex" or df_type(df) == "polars":
         return list(range(df_len(df)))


### PR DESCRIPTION
Fix for https://github.com/widgetti/solara/issues/526. 
Created a separate variable to store row names to display them correctly as per the index in the loop.
Also, created a new function in utils to cater for getting list of row index names just like for columns. 