### PR TITLE
ci: restrict OS versions when testing on python 3.6

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -161,7 +161,7 @@ jobs:
 
   test-install:
     needs: [build]
-    runs-on: ${{ matrix.os }}-${{matrix.os == 'ubuntu' && '20.04' || 'latest' }}
+    runs-on: ${{ matrix.os }}-${{(matrix.os == 'ubuntu' && matrix.python == '3.6') && '20.04' || (matrix.os == 'macos' && matrix.python == '3.6') && '13' || 'latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -424,7 +424,7 @@ jobs:
 
   unit-test:
     needs: [build]
-    runs-on: ${{ matrix.os }}-${{matrix.os == 'ubuntu' && '20.04' || 'latest' }}
+    runs-on: ${{ matrix.os }}-${{(matrix.os == 'ubuntu' && matrix.python == '3.6') && '20.04' || (matrix.os == 'macos' && matrix.python == '3.6') && '13' || 'latest' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Github actions recently upgraded macos latest to be version 14. However, github runners only provides [python 3.11 and 3.12](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md) for this macos version, while the `setup-python` action only provides [python 3.8, 3.9, 3.10](https://github.com/actions/setup-python/issues/852#issuecomment-2077757197) in addition to the default ones.

Previously we were restricting ubuntu to version 20.04 for all python versions. This PR also releases that restriction for python versions other than 3.6, which is [not available for ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md).