### PR TITLE
fix: solara.display not working on some mimetypes in production mode

### DIFF
--- a/packages/solara-vuetify-app/webpack.config.js
+++ b/packages/solara-vuetify-app/webpack.config.js
@@ -95,10 +95,7 @@ module.exports = [
                 "@widgetti/solara-widget-manager": "@widgetti/solara-widget-manager8",
                 // why would we need codemirror?
                 '@jupyterlab/codemirror': path.resolve(__dirname, "src", "empty.js"),
-                // used in @jupyterlab/rendermine/lib/registry
-                '@jupyterlab/apputils/lib/sanitizer': path.resolve(__dirname, "src", "empty.js"),
                 // do not think we use these
-                'htmlparser2': path.resolve(__dirname, "src", "empty.js"),
                 'postcss': path.resolve(__dirname, "src", "empty.js"),
                 'moment': path.resolve(__dirname, "src", "empty.js"),
             }


### PR DESCRIPTION
These dependencies were aliased to an empty file to save on bundle size in https://github.com/widgetti/solara/commit/242d7e29bfeeb5ea53bdcfa113bb5caf4626dde9, but turn out to be necessary for the rendering of some mimetypes. Because the aliasing takes place during the minification step, development mode still worked, but running in production mode would show a javascript error.

Fixes https://github.com/widgetti/solara/issues/500.
