### PR TITLE
fix: catch PermissionError from checking if directory exists

### DIFF
--- a/solara/server/server.py
+++ b/solara/server/server.py
@@ -431,8 +431,12 @@ def get_nbextensions() -> Tuple[List[str], Dict[str, Optional[str]]]:
 
     def exists(name):
         for directory in nbextensions_directories:
-            if (directory / (name + ".js")).exists():
-                return True
+            try:
+                file_path = directory / (name + ".js")
+                if file_path.exists():
+                    return True
+            except PermissionError:
+                logger.warning(f"Caught PermissionError while checking for existence of nbextension {name!r} at path: {file_path}. This path will be ignored.")
         logger.info(f"nbextension {name} not found")
         return False
 
@@ -444,10 +448,14 @@ def get_nbextensions() -> Tuple[List[str], Dict[str, Optional[str]]]:
             h = hashlib.new("md5", usedforsecurity=False)  # type: ignore
 
         for directory in nbextensions_directories:
-            if (directory / (name + ".js")).exists():
-                for file in directory.glob("**/*.*"):
-                    data = file.read_bytes()
-                    h.update(data)
+            try:
+                file_path = directory / (name + ".js")
+                if file_path.exists():
+                    for file in directory.glob("**/*.*"):
+                        data = file.read_bytes()
+                        h.update(data)
+            except PermissionError:
+                logger.warning(f"Caught PermissionError while checking for existence of nbextension {name!r} at path: {file_path}. This path will be ignored.")
 
         return h.hexdigest()
 


### PR DESCRIPTION
Fix for https://github.com/widgetti/solara/issues/611

# Overview

Calls to `jupyter_core.paths.jupyter_path("nbextensions")` (see [here](https://github.com/widgetti/solara/blob/bb109068e51a0434eff88e36e67f889cad36cf94/solara/server/server.py#L428)) may return directories that do not exist. However, the user may not have permission to read some of these paths, leading to a `PermissionError` when calling `pathlib.Path.exists()` (see [here](https://github.com/widgetti/solara/blob/bb109068e51a0434eff88e36e67f889cad36cf94/solara/server/server.py#L434) and [here](https://github.com/widgetti/solara/blob/bb109068e51a0434eff88e36e67f889cad36cf94/solara/server/server.py#L447)). The `PermissionError` ends up crashing the application.

## Fix

This change catches the `PermissionError` and logs it as a warning, preventing the application from crashing. Essentially: if the user does not have permission to the path, it might as well not exist.