### PR TITLE
refactor!: streamline and improve applayout api

### DIFF
--- a/solara/components/__init__.py
+++ b/solara/components/__init__.py
@@ -73,5 +73,4 @@ else:
     logger = logging.getLogger("solara.components")
     logger.warning(f"Default container {main.default_container} not found in solara.components. Defaulting to Column.")
 
-# TODO: When Solara 2.0 releases Column should be replaced with Fragment
-reacton.core._default_container = _container or Column  # noqa: F405
+reacton.core._default_container = _container or Fragment  # noqa: F405

--- a/solara/components/head_tag.vue
+++ b/solara/components/head_tag.vue
@@ -1,4 +1,5 @@
-<template><span></span></template>
+<template>
+</template>
 
 <script>
 module.exports = {

--- a/solara/settings.py
+++ b/solara/settings.py
@@ -54,9 +54,8 @@ class Assets(BaseSettings):
 
 class MainSettings(BaseSettings):
     check_hooks: str = "warn"
-    allow_reactive_boolean: bool = True
-    # TODO: also change default_container in solara/components/__init__.py
-    default_container: Optional[str] = "Column"
+    allow_reactive_boolean: bool = False
+    default_container: Optional[str] = "Fragment"
 
     class Config:
         env_prefix = "solara_"

--- a/solara/website/pages/documentation/getting_started/content/04-tutorials/60-jupyter-dashboard-part1.py
+++ b/solara/website/pages/documentation/getting_started/content/04-tutorials/60-jupyter-dashboard-part1.py
@@ -10,56 +10,54 @@ title = "Jupyter Dashboard (1/3)"
 
 @solara.component
 def Page():
-    with solara.Column(gap=0):
-        title = "Build your Jupyter dashboard using Solara"
-        solara.Meta(property="og:title", content=title)
-        solara.Meta(name="twitter:title", content=title)
-        solara.Title(title)
+    title = "Build your Jupyter dashboard using Solara"
+    solara.Meta(property="og:title", content=title)
+    solara.Meta(name="twitter:title", content=title)
+    solara.Title(title)
 
-        img = "https://dxhl76zpt6fap.cloudfront.net/public/docs/tutorial/jupyter-dashboard1.webp"
-        solara.Meta(name="twitter:image", content=img)
-        solara.Meta(property="og:image", content=img)
+    img = "https://dxhl76zpt6fap.cloudfront.net/public/docs/tutorial/jupyter-dashboard1.webp"
+    solara.Meta(name="twitter:image", content=img)
+    solara.Meta(property="og:image", content=img)
 
-        description = "Learn how to build a Jupyter dashboard and deploy it as a web app using Solara."
-        solara.Meta(name="description", property="og:description", content=description)
-        solara.Meta(name="twitter:description", content=description)
-        tags = [
-            "jupyter",
-            "jupyter dashboard",
-            "dashboard",
-            "web app",
-            "deploy",
-            "solara",
-        ]
-        solara.Meta(name="keywords", content=", ".join(tags))
-        with solara.Column():
-            Notebook(
-                Path(HERE / "_jupyter_dashboard_1.ipynb"),
-                show_last_expressions=True,
-                execute=False,
-                outputs={
-                    "a7d17a84": None,  # empty output (7)
-                    # original: https://github.com/widgetti/solara/assets/1765949/e844acdb-c77d-4df4-ba4c-a629f92f18a3
-                    "82f1d2f7": solara.Image("https://dxhl76zpt6fap.cloudfront.net/pages/docs/content/60-jupyter-dashboard-part1/map.webp"),  # map (11)
-                    "3e7ea361": None,  # (13)
-                    # original: https://github.com/widgetti/solara/assets/1765949/daaa3a46-61f5-431f-8003-b42b5915da4b
-                    "56055643": solara.Image("https://dxhl76zpt6fap.cloudfront.net/pages/docs/content/60-jupyter-dashboard-part1/view.webp"),  # View (15)
-                    # original: https://github.com/widgetti/solara/assets/1765949/2f4daf0f-b7d8-4f70-b04a-c27542cffdb0
-                    "c78010ec": solara.Image("https://dxhl76zpt6fap.cloudfront.net/pages/docs/content/60-jupyter-dashboard-part1/page.webp"),  # Page (20)
-                    # original: https://github.com/widgetti/solara/assets/1765949/a691d9f1-f07b-4e06-b21b-20980476ad64
-                    "18290364": solara.Image("https://dxhl76zpt6fap.cloudfront.net/pages/docs/content/60-jupyter-dashboard-part1/controls.webp"),  # Controls
-                    "0ca68fe8": None,
-                    "fef5d187": None,
-                    # original: https://github.com/widgetti/solara/assets/1765949/f0075ad1-808d-458c-8797-e460ce4dc06d
-                    "af686391": solara.Image("https://dxhl76zpt6fap.cloudfront.net/pages/docs/content/60-jupyter-dashboard-part1/full-app.webp"),  # Full app
-                },
-            )
-            solara.Markdown(
-                """
-                Explore this app live at [solara.dev](/apps/jupyter-dashboard-1).
+    description = "Learn how to build a Jupyter dashboard and deploy it as a web app using Solara."
+    solara.Meta(name="description", property="og:description", content=description)
+    solara.Meta(name="twitter:description", content=description)
+    tags = [
+        "jupyter",
+        "jupyter dashboard",
+        "dashboard",
+        "web app",
+        "deploy",
+        "solara",
+    ]
+    solara.Meta(name="keywords", content=", ".join(tags))
+    Notebook(
+        Path(HERE / "_jupyter_dashboard_1.ipynb"),
+        show_last_expressions=True,
+        execute=False,
+        outputs={
+            "a7d17a84": None,  # empty output (7)
+            # original: https://github.com/widgetti/solara/assets/1765949/e844acdb-c77d-4df4-ba4c-a629f92f18a3
+            "82f1d2f7": solara.Image("https://dxhl76zpt6fap.cloudfront.net/pages/docs/content/60-jupyter-dashboard-part1/map.webp"),  # map (11)
+            "3e7ea361": None,  # (13)
+            # original: https://github.com/widgetti/solara/assets/1765949/daaa3a46-61f5-431f-8003-b42b5915da4b
+            "56055643": solara.Image("https://dxhl76zpt6fap.cloudfront.net/pages/docs/content/60-jupyter-dashboard-part1/view.webp"),  # View (15)
+            # original: https://github.com/widgetti/solara/assets/1765949/2f4daf0f-b7d8-4f70-b04a-c27542cffdb0
+            "c78010ec": solara.Image("https://dxhl76zpt6fap.cloudfront.net/pages/docs/content/60-jupyter-dashboard-part1/page.webp"),  # Page (20)
+            # original: https://github.com/widgetti/solara/assets/1765949/a691d9f1-f07b-4e06-b21b-20980476ad64
+            "18290364": solara.Image("https://dxhl76zpt6fap.cloudfront.net/pages/docs/content/60-jupyter-dashboard-part1/controls.webp"),  # Controls
+            "0ca68fe8": None,
+            "fef5d187": None,
+            # original: https://github.com/widgetti/solara/assets/1765949/f0075ad1-808d-458c-8797-e460ce4dc06d
+            "af686391": solara.Image("https://dxhl76zpt6fap.cloudfront.net/pages/docs/content/60-jupyter-dashboard-part1/full-app.webp"),  # Full app
+        },
+    )
+    solara.Markdown(
+        """
+        Explore this app live at [solara.dev](/apps/jupyter-dashboard-1).
 
-                Don’t miss the next tutorial and stay updated with the latest techniques and insights by subscribing to our newsletter.
-            """
-            )
-            location = solara.use_router().path
-            MailChimp(location=location)
+        Don’t miss the next tutorial and stay updated with the latest techniques and insights by subscribing to our newsletter.
+    """
+    )
+    location = solara.use_router().path
+    MailChimp(location=location)

--- a/solara/widgets/vue/navigator.vue
+++ b/solara/widgets/vue/navigator.vue
@@ -1,5 +1,4 @@
 <template>
-  <span></span>
 </template>
 ​
 <script>

--- a/tests/unit/toestand_test.py
+++ b/tests/unit/toestand_test.py
@@ -759,13 +759,13 @@ def test_dataframe():
 
     box, rc = solara.render(Test(), handle_error=False)
 
-    if solara.settings.storage.mutation_detection:
+    if solara.settings.storage.mutation_detection is not False:
         # a copy is made, so get a reference to the actual used object
         df = get_storage(store).value.public
     assert rc.find(v.Alert).widget.children[0] == repr(id(df))
     df2 = df2.copy()
     store.set(df2)
-    if solara.settings.storage.mutation_detection:
+    if solara.settings.storage.mutation_detection is not False:
         df2 = get_storage(store).value.public
     assert rc.find(v.Alert).widget.children[0] == repr(id(df2))
 


### PR DESCRIPTION
Fixes #584.

Includes four breaking changes:
- A change in the default color of the `AppBar` from `"primary"` to the Vuetify default (light/dark grey depending on theme)
- Changes the behaviour of the `navigation` argument, where previously it would hide the entire `AppBar` it now correctly only hides the tab navigation (if present)
- Changes the default behaviour of `show_app_bar` (which is now also available as an argument) to where it no longer requires the `title`-argument to be set for `show_app_bar` to be true.
- Do not turn the first non-`AppBar` child of `AppLayout` into a sidebar element.
