### PR TITLE
fix(ci): test-install fails on macos with python3.10

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -205,7 +205,7 @@ jobs:
 
       - name: Wait for Solara server to get online
         run: |
-          curl --head -X GET --retry 35 --retry-connrefused --retry-delay 5 http://localhost:8765
+          curl --head --retry 35 --retry-connrefused --retry-delay 5 http://localhost:8765
 
       - name: Install
         run: pip install packages/solara-enterprise/dist/*.whl


### PR DESCRIPTION
Since I can't replicate the error locally, I'm using this PR to test potential issues.

To test:
- [x] Diff in solara-server dependencies installed -- Dependencies were identical
- [x] Diff in solara-ui dependencies installed -- Only one package, `requests` 2.32.2 --> 2.32.3
- [x] Python version? Trying with python 3.9. Also fails on python 3.9.
- [x] Github macos runners? Moved from macos 14.4.1 to 14.5.
- [ ] curl options

Issue turned out to be with the `-X GET` option to `curl`.

Usual response to `curl` is 
```
% Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
HTTP/1.1 200 OK
  0 47845    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
date: Wed, 29 May 2024 06:11:26 GMT
  0 47845    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
server: uvicorn
content-length: 47845
content-type: text/html; charset=utf-8
set-cookie: solara-session-id=486c5bbc-564a-44[14](https://github.com/widgetti/solara/actions/runs/9281107458/job/25536575550#step:11:15)-a4c7-c32182ef8659; expires=Fri, 01 Jan 2038 00:00:00 GMT; Path=/; SameSite=none; Secure
```

With requests 2.32.3 we get
```
% Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
HTTP/1.1 200 OK
                                 Dload  Upload   Total   Spent    Left  Speed
date: Fri, 31 May 2024 07:57:42 GMT

server: uvicorn
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
content-length: 47845
  0 47845    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
content-type: text/html; charset=utf-8
curl: (8) Weird server reply
set-cookie: solara-session-id=0634a[14](https://github.com/widgetti/solara/actions/runs/9314848422/job/25639887222?pr=662#step:11:15)2-c7ac-4c5b-ae09-d6d8af05c0ba; expires=Fri, 01 Jan 2038 00:00:00 GMT; Path=/; SameSite=none; Secure
```

And with requests 2.32.2
```
% Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
HTTP/1.1 200 OK
  0 47845    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
curl: (8) Weird server reply
date: Fri, 31 May 2024 09:23:59 GMT
server: uvicorn
content-length: 47845
content-type: text/html; charset=utf-8
set-cookie: solara-session-id=6856bdf3-5ade-4f4b-a5a7-7e[16](https://github.com/widgetti/solara/actions/runs/9315907793/job/25643193560?pr=663#step:11:17)1d3622c0; expires=Fri, 01 Jan 2038 00:00:00 GMT; Path=/; SameSite=none; Secure
```