### PR TITLE
docs: todo example to use a class for state

### DIFF
--- a/solara/website/pages/documentation/examples/utilities/todo.py
+++ b/solara/website/pages/documentation/examples/utilities/todo.py
@@ -22,7 +22,6 @@ from typing import Callable
 import reacton.ipyvuetify as v
 
 import solara
-from solara.lab.toestand import Ref
 
 
 class TodoItem:

--- a/solara/website/pages/documentation/examples/utilities/todo.py
+++ b/solara/website/pages/documentation/examples/utilities/todo.py
@@ -32,7 +32,7 @@ class TodoItem:
 
 
 @solara.component
-def TodoEdit(todo_item: solara.Reactive[TodoItem], on_delete: Callable[[], None], on_close: Callable[[], None]):
+def TodoEdit(todo_item: TodoItem, on_delete: Callable[[], None], on_close: Callable[[], None]):
     """Takes a reactive todo item and allows editing it. Will not modify the original item until 'save' is clicked."""
     copy = TodoItem(todo_item.text, todo_item.done)
 
@@ -50,7 +50,7 @@ def TodoEdit(todo_item: solara.Reactive[TodoItem], on_delete: Callable[[], None]
 
 
 @solara.component
-def TodoListItem(todo_item: solara.Reactive[TodoItem], on_delete: Callable[[TodoItem], None]):
+def TodoListItem(todo_item: TodoItem, on_delete: Callable[[TodoItem], None]):
     """Displays a single todo item, modifications are done 'in place'.
 
     For demonstration purposes, we allow editing the item in a dialog as well.


### PR DESCRIPTION
This PR updates the todo example to place all state in a (re-usable) `TodoItem` class, instead of a `dataclass`.  This allows avoiding the need for `Ref` and `.fields`.

If there is no other example for `Ref` and `fields` in the docs, then maybe this shouldn't be merged, but at least shows the difference between the two implementations.