### PR TITLE
fix: support esm define when running under virtual kernel

### DIFF
--- a/solara/server/esm.py
+++ b/solara/server/esm.py
@@ -28,6 +28,8 @@ def define_module(name, module: Union[str, Path]):
     if name in _modules:
         old_module, dependencies = _modules[name]
     _modules[name] = (module, dependencies)
+    if kernel_context.has_current_context():
+        create_modules()
     return None
 
 

--- a/tests/integration/esm_test.py
+++ b/tests/integration/esm_test.py
@@ -14,16 +14,14 @@ solara.server.patch.patch()
 HERE = Path(__file__).parent
 
 
-ipyreact.define_module(
-    "solara-test",
-    """
+test_js_code = """
 import * as React from "react";
 
 export default function({value, setValue, ...children}) {
-return React.createElement("button", {onClick: () => setValue(value + 1), children: `clicked ${value || 0}`})
+    return React.createElement("button", {onClick: () => setValue(value + 1), children: `clicked ${value || 0}`})
 }
-""",
-)
+"""
+ipyreact.define_module("solara-test", test_js_code)
 
 
 @solara.component
@@ -32,9 +30,17 @@ def Page():
     ipyreact.ValueWidget.element(_module="solara-test", value=0, on_value=value.set)
 
 
+@solara.component
+def PageDefineDuringRun():
+    ipyreact.define_module("solara-test-dynamic", test_js_code)
+    value = solara.use_reactive(0)
+    ipyreact.ValueWidget.element(_module="solara-test-dynamic", value=0, on_value=value.set)
+
+
 @pytest.mark.skipif(sys.version_info < (3, 7, 0), reason="ipyreact requires python 3.7 or higher")
-def test_ipyreact(browser: playwright.sync_api.Browser, page_session: playwright.sync_api.Page, solara_server, solara_app, extra_include_path):
-    with extra_include_path(HERE), solara_app("esm_test:Page"):
+@pytest.mark.parametrize("app", ["esm_test:Page", "esm_test:PageDefineDuringRun"])
+def test_ipyreact(browser: playwright.sync_api.Browser, page_session: playwright.sync_api.Page, solara_server, solara_app, extra_include_path, app):
+    with extra_include_path(HERE), solara_app(app):
         page_session.goto(solara_server.base_url)
         page_session.locator("text=clicked 0").first.click()
         page_session.locator("text=clicked 1").first.click()


### PR DESCRIPTION
When we define a esm top level in a module, we don't need to create the module widget. However, if we do this during the running of the app under the context of a virtual kernel, we should directly create the esm widget.

Should fix the failing of https://github.com/widgetti/ipyantd/pull/4