### PR TITLE
fix: if we hit a 404 in starlette, raise instead of render a 404

### DIFF
--- a/solara/server/starlette.py
+++ b/solara/server/starlette.py
@@ -352,7 +352,7 @@ async def root(request: Request, fullpath: str = ""):
     if content is None:
         if settings.oauth.private and not request.user.is_authenticated:
             raise HTTPException(status_code=401, detail="Unauthorized")
-        return HTMLResponse(content="Page not found by Solara router", status_code=404)
+        raise HTTPException(status_code=404, detail="Page not found by Solara router")
 
     if settings.oauth.private and not request.user.is_authenticated:
         from solara_enterprise.auth.starlette import login


### PR DESCRIPTION
This allows middleware or error handlers to catch the 404 and do something custom.

Example:

```python
import solara

clicks = solara.reactive(0)

added = False

def add_exception_handler():
    global added
    print("add_exception_handler", added)
    if not added:
        import solara.server.starlette
        from starlette.responses import HTMLResponse
        async def server_error(request, exc):
            return HTMLResponse(content="My custom 404", status_code=exc.status_code)

        solara.server.starlette.app.add_exception_handler(404, server_error)
        added = True

@solara.component
def Page():
    # add the handler after all the imports are done to avoid a circular import
    add_exception_handler()
    solara.Text("hello world")
```