### PR TITLE
Feature: InputDate and InputDateRange Enhancements

### DIFF
--- a/solara/lab/components/input_date.py
+++ b/solara/lab/components/input_date.py
@@ -181,6 +181,7 @@ def InputDateRange(
     date_picker_type: str = "date",
     min_date: Optional[str] = None,
     max_date: Optional[str] = None,
+    sort: Optional[bool] = False,
 ):
     """
     Show a textfield, which when clicked, opens a datepicker that allows users to select a range of dates by choosing a starting and ending date.
@@ -221,6 +222,8 @@ def InputDateRange(
     * date_picker_type: Sets the type of the datepicker. Use `"date"` for date selection or `"month"` for month selection. Defaults to `"date"`.
     * min_date: Earliest allowed date/month (ISO 8601 format). If not specified, there is no limit.
     * max_date: Latest allowed date/month (ISO 8601 format). If not specified, there is no limit.
+    * sort: If True, selected dates will be sorted in ascending order, regardless of the order they were picked. If False, preserves the order the
+    dates were selected.
 
     ## A More Advanced Example
 
@@ -292,6 +295,10 @@ def InputDateRange(
         )
         if len(date_value) > 1 and date_value[1] is not None:
             datepicker_is_open.set(False)
+
+            if sort:
+                date_value = cast(Tuple[dt.date, dt.date], tuple(sorted(date_value)))
+
         value_reactive.value = date_value
 
     string_dates, error_message = dates_to_string(value_reactive.value)

--- a/solara/lab/components/input_date.py
+++ b/solara/lab/components/input_date.py
@@ -194,8 +194,8 @@ def InputDateRange(
     Intended to be used in conjunction with a custom set of controls to close the datepicker.
     * on_open_value: a callback function for when open_value changes. Also receives the new value as an argument.
     * date_format: Sets the format of the date displayed in the text field. Defaults to `"%Y/%m/%d"`. For more information,
-    * optional: Determines whether go show an error when value is `None`. If `True`, no error is shown.
     see <a href="https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes" target="_blank">the Python documentation</a>.
+    * optional: Determines whether go show an error when value is `None`. If `True`, no error is shown.
     * first_day_of_the_week: Sets the first day of the week, as an `int` starting count from Sunday (`=0`). Defaults to `1`, which is Monday.
     * style: CSS style to apply to the text field. Either a string or a dictionary of CSS properties (i.e. `{"property": "value"}`).
     * classes: List of CSS classes to apply to the text field.

--- a/solara/lab/components/input_date.py
+++ b/solara/lab/components/input_date.py
@@ -44,6 +44,8 @@ def InputDate(
     style: Optional[Union[str, Dict[str, str]]] = None,
     classes: Optional[List[str]] = None,
     date_picker_type: str = "date",
+    min_date: Optional[str] = None,
+    max_date: Optional[str] = None,
 ):
     """
     Show a textfield, which when clicked, opens a datepicker. The input date should be of type `datetime.date`.
@@ -80,6 +82,8 @@ def InputDate(
     * style: CSS style to apply to the text field. Either a string or a dictionary of CSS properties (i.e. `{"property": "value"}`).
     * classes: List of CSS classes to apply to the text field.
     * date_picker_type: Sets the type of the datepicker. Use `"date"` for date selection or `"month"` for month selection. Defaults to `"date"`.
+    * min_date: Earliest allowed date/month (ISO 8601 format). If not specified, there is no limit.
+    * max_date: Latest allowed date/month (ISO 8601 format). If not specified, there is no limit.
     """
     value_reactive = solara.use_reactive(value, on_value)  # type: ignore
     del value, on_value
@@ -153,6 +157,8 @@ def InputDate(
             on_v_model=set_date_cast,
             first_day_of_week=first_day_of_the_week,
             style_="width: 100%;",
+            max=max_date,
+            min=min_date,
             type=date_picker_type,
         ):
             if len(children) > 0:
@@ -173,6 +179,8 @@ def InputDateRange(
     style: Optional[Union[str, Dict[str, str]]] = None,
     classes: Optional[List[str]] = None,
     date_picker_type: str = "date",
+    min_date: Optional[str] = None,
+    max_date: Optional[str] = None,
 ):
     """
     Show a textfield, which when clicked, opens a datepicker that allows users to select a range of dates by choosing a starting and ending date.
@@ -211,6 +219,8 @@ def InputDateRange(
     * style: CSS style to apply to the text field. Either a string or a dictionary of CSS properties (i.e. `{"property": "value"}`).
     * classes: List of CSS classes to apply to the text field.
     * date_picker_type: Sets the type of the datepicker. Use `"date"` for date selection or `"month"` for month selection. Defaults to `"date"`.
+    * min_date: Earliest allowed date/month (ISO 8601 format). If not specified, there is no limit.
+    * max_date: Latest allowed date/month (ISO 8601 format). If not specified, there is no limit.
 
     ## A More Advanced Example
 
@@ -313,6 +323,8 @@ def InputDateRange(
             range=True,
             first_day_of_week=first_day_of_the_week,
             style_="width: 100%;",
+            max=max_date,
+            min=min_date,
             type=date_picker_type,
         ):
             if len(children) > 0:


### PR DESCRIPTION
# Overview

This change adds a few enhancements to the `InputDate` and `InputDateRange` components:

- Adds support for controlling the minimum/maximum allowed dates.
- Adds support for a date picker that has monthly granularity.
- Adds support for sorting the selected dates (for the `InputDateRange` component only).

See [here](https://github.com/widgetti/solara/issues/653) for the full discussion.

## Usage

### Daily granularity, with limits the min/max allowed date

Using the `min_date` and `max_date` parameters to limit selection to dates in the next two weeks:

```python
import datetime as dt
import solara

@solara.component
def Page():
    min_date = dt.date.today()
    max_date = min_date + dt.timedelta(days=14)

    selected_date = solara.use_reactive(min_date)
    solara.lab.InputDate(
        value=selected_date,
        min_date=min_date.isoformat(),
        max_date=max_date.isoformat(),
    )
    solara.Text(f"Selected date: {selected_date.value}")

Page()
```

<img width="296" alt="image" src="https://github.com/widgetti/solara/assets/30533489/23fa11d2-fede-42f5-b454-f5f0377124a8">

### Monthly granularity, with limits on the min/max allowed date

Use `date_picker_type="month"` to have an input with monthly granularity:

```python
import datetime as dt
import solara

@solara.component
def Page():
    
    min_date = dt.date.today().replace(day=1)
    max_date = (min_date + dt.timedelta(days=62)).replace(day=1)

    selected_date = solara.use_reactive(min_date)
    
    solara.lab.InputDate(
        value=selected_date,
        min_date=min_date.isoformat(),
        max_date=max_date.isoformat(),
        date_picker_type="month",
    )
    solara.Text(f"Selected date: {selected_date.value}")
    
Page()
```
<img width="298" alt="image" src="https://github.com/widgetti/solara/assets/30533489/1fbbcb74-a684-4187-9abe-1868398ed0aa">

## Daily granularity, with limits the min/max allowed dates, where the output is sorted

Use `sort=True` to automatically sort the output in ascending order:

```python
import datetime as dt
import solara

@solara.component
def Page():
    min_date = dt.date.today()
    max_date = min_date + dt.timedelta(days=14)

    selected_date = solara.use_reactive((min_date, min_date + dt.timedelta(days=1)))
    solara.lab.InputDateRange(
        value=selected_date,
        min_date=min_date.isoformat(),
        max_date=max_date.isoformat(),
        sort=True,
    )
    solara.Text(f"Selected dates: {selected_date.value}")
    
Page()
```

### Monthly granularity, with limits the min/max allowed dates, where the output is sorted

Use `date_picker_type="month"` to have an input with monthly granularity and `sort=True` to automatically sort the output in ascending order:

```python
import datetime as dt
import solara

@solara.component
def Page():
    
    min_date = dt.date.today().replace(day=1)
    max_date = (min_date + dt.timedelta(days=62)).replace(day=1)

    selected_date = solara.use_reactive(
        (min_date, (min_date + dt.timedelta(days=30)).replace(day=1))
    )
    
    solara.lab.InputDateRange(
        value=selected_date,
        min_date=min_date.isoformat(),
        max_date=max_date.isoformat(),
        date_picker_type="month",
        sort=True,
    )
    solara.Text(f"Selected date: {selected_date.value}")
    
Page()
```

## Vuetify 3 Upgrade Path

From what I can tell, in Vuetify 3, the `min` and `max` parameters are still supported by the `VDatePicker` object (see [here](https://vuetifyjs.com/en/api/v-date-picker/#props)).


I don't see a clear example of a date picker with monthly granularity on the component documentation [here](https://vuetifyjs.com/en/components/date-pickers/). Based on the API, it looks like they have split the "Monthly Date Picker" into a separate component, called `VDatePickerMonth` (see [here](https://vuetifyjs.com/en/api/v-date-picker-month/#props)). There is also a `VDatePickerMonths` in the API (see [here](https://vuetifyjs.com/en/api/v-date-picker-months/#props)), though it appears to have fewer parameters -- I am not sure how that component differs from or `VDatePickerMonth`.

As a result, when upgrading to Vuetify 3, these components would probably be split into something like `InputDate`/`InputMonth` and `InputDateRange`/`InputMonthRange`, based on the `VDatePicker` and `VDatePickerMonth` components, respectively.