### PR TITLE
feat: add mhchem katex extension

### DIFF
--- a/solara/components/markdown.py
+++ b/solara/components/markdown.py
@@ -92,6 +92,7 @@ module.exports = {
         await this.loadRequire();
         this.mermaid = await this.loadMermaid();
         this.mermaid.init();
+        await this.loadMHchem();
         this.latexSettings = {
                 delimiters: [
                     {left: "$$", right: "$$", display: true},
@@ -157,6 +158,11 @@ module.exports = {
         async loadMermaid() {
             return (await this.import([`${this.getCdn()}/mermaid@10.8.0/dist/mermaid.min.js`]))[0]
         },
+        async loadMHchem() {
+            await this.loadKatex();
+            return (await this.import([`${this.getCdn()}/katex@0.16.9/dist/contrib/mhchem.min.js`]))[0];
+        },
+
         import(dependencies) {
             return this.loadRequire().then(
                 () => {

--- a/solara/components/markdown.py
+++ b/solara/components/markdown.py
@@ -152,7 +152,10 @@ module.exports = {
         },
         async loadKatexExt() {
             this.loadKatex();
-            return (await this.import([`${this.getCdn()}/katex@0.16.9/dist/contrib/auto-render.min.js`, `${this.getCdn()}/katex@0.16.9/dist/contrib/mhchem.min.js`]))[0]
+            return (await this.import([
+                `${this.getCdn()}/katex@0.16.9/dist/contrib/auto-render.min.js`, 
+                `${this.getCdn()}/katex@0.16.9/dist/contrib/mhchem.min.js`
+            ]))[0]
         },
         async loadMermaid() {
             return (await this.import([`${this.getCdn()}/mermaid@10.8.0/dist/mermaid.min.js`]))[0]

--- a/solara/components/markdown.py
+++ b/solara/components/markdown.py
@@ -92,7 +92,6 @@ module.exports = {
         await this.loadRequire();
         this.mermaid = await this.loadMermaid();
         this.mermaid.init();
-        await this.loadMHchem();
         this.latexSettings = {
                 delimiters: [
                     {left: "$$", right: "$$", display: true},
@@ -153,16 +152,11 @@ module.exports = {
         },
         async loadKatexExt() {
             this.loadKatex();
-            return (await this.import([`${this.getCdn()}/katex@0.16.9/dist/contrib/auto-render.min.js`]))[0]
+            return (await this.import([`${this.getCdn()}/katex@0.16.9/dist/contrib/auto-render.min.js`, `${this.getCdn()}/katex@0.16.9/dist/contrib/mhchem.min.js`]))[0]
         },
         async loadMermaid() {
             return (await this.import([`${this.getCdn()}/mermaid@10.8.0/dist/mermaid.min.js`]))[0]
         },
-        async loadMHchem() {
-            await this.loadKatex();
-            return (await this.import([`${this.getCdn()}/katex@0.16.9/dist/contrib/mhchem.min.js`]))[0];
-        },
-
         import(dependencies) {
             return this.loadRequire().then(
                 () => {

--- a/solara/components/markdown.py
+++ b/solara/components/markdown.py
@@ -153,7 +153,7 @@ module.exports = {
         async loadKatexExt() {
             this.loadKatex();
             return (await this.import([
-                `${this.getCdn()}/katex@0.16.9/dist/contrib/auto-render.min.js`, 
+                `${this.getCdn()}/katex@0.16.9/dist/contrib/auto-render.min.js`,
                 `${this.getCdn()}/katex@0.16.9/dist/contrib/mhchem.min.js`
             ]))[0]
         },


### PR DESCRIPTION
mhchem package provides commands for typesetting chemical molecular formulae and equations

mhchem katex extension docs are [here](https://github.com/KaTeX/KaTeX/blob/main/contrib/mhchem/README.md)

this contribution is a combination of copy-paste with suggestions from codeium

example:

```python
import solara

md_text = """
Normal math:

$$
1 + 1 = \sqrt{2}
$$

mhchem:

$$
\ce{6CO2 + 6H2O -> C6H12O6 + 6O2}
$$

"""

@solara.component
def Page():
    solara.Markdown(md_text)
```

output:
![image](https://github.com/widgetti/solara/assets/7881506/404c4946-c90c-4024-9a7d-381a1ac7c0a5)
