### PR TITLE
fix(ci): ci fails because of vaex not supporting newest numpy

### DIFF
--- a/packages/solara-meta/pyproject.toml
+++ b/packages/solara-meta/pyproject.toml
@@ -48,6 +48,7 @@ documentation = [
     "vaex-core",
     "vaex-hdf5",
     "tiktoken",
+    "numpy<2",
 ]
 
 # for backwards compatibility to support solara[pytest]


### PR DESCRIPTION
vaex does not support numpy >= 2. We should be able to remove the restriction once vaex is compiled for numpy 2.0.