### PR TITLE
fix: typo in `solara.components.tooltip.Tooltip`

### DIFF
--- a/solara/components/tooltip.py
+++ b/solara/components/tooltip.py
@@ -7,7 +7,7 @@ import solara
 
 @solara.component
 def Tooltip(
-    tooltip=Union[str, solara.Element],
+    tooltip: Union[str, solara.Element],
     children=[],
     color: Optional[str] = None,
 ):


### PR DESCRIPTION
I noticed a typo in `solara.components.tooltip.Tooltip`, which turned the type annotation into a default value.

Fixes #685 