### PR TITLE
fix: InputText blur event not working when used together with tooltip

### DIFF
--- a/solara/components/input.py
+++ b/solara/components/input.py
@@ -11,7 +11,7 @@ from solara.alias import rv as v
 T = TypeVar("T")
 
 
-def use_change(el: reacton.core.Element, on_value: Callable[[Any], Any], enabled=True, update_events=["blur", "keyup.enter"]):
+def use_change(el: reacton.core.Element, on_value: Callable[[Any], Any], enabled=True, update_events=["focusout", "keyup.enter"]):
     """Trigger a callback when a blur events occurs or the enter key is pressed."""
     on_value_ref = solara.use_ref(on_value)
     on_value_ref.current = on_value
@@ -44,7 +44,7 @@ def InputText(
     disabled: bool = False,
     password: bool = False,
     continuous_update: bool = False,
-    update_events: List[str] = ["blur", "keyup.enter"],
+    update_events: List[str] = ["focusout", "keyup.enter"],
     error: Union[bool, str] = False,
     message: Optional[str] = None,
     classes: List[str] = [],

--- a/tests/unit/input_test.py
+++ b/tests/unit/input_test.py
@@ -25,13 +25,13 @@ def test_input_int_optional():
     input = rc.find(vw.TextField)
     input.widget.v_model = "43"
     assert on_value.call_count == 0
-    input.widget.fire_event("blur")
+    input.widget.fire_event("focusout")
     assert on_value.call_count == 1
     assert on_value.call_args[0][0] == 43
 
     input.widget.v_model = ""
     assert on_value.call_count == 1
-    input.widget.fire_event("blur")
+    input.widget.fire_event("focusout")
     assert on_value.call_count == 2
     assert on_value.call_args[0][0] is None
     rc.close()
@@ -57,7 +57,7 @@ def test_input_int():
     assert on_value.call_count == 0
     assert on_v_model.call_count == 1
     on_v_model.reset_mock()
-    input.widget.fire_event("blur")
+    input.widget.fire_event("focusout")
     assert on_value.call_count == 1
     assert on_value.call_args[0][0] == 43
     assert on_v_model.call_count == 0
@@ -66,7 +66,7 @@ def test_input_int():
     assert on_value.call_count == 1
     assert on_v_model.call_count == 1
     on_v_model.reset_mock()
-    input.widget.fire_event("blur")
+    input.widget.fire_event("focusout")
     assert on_value.call_count == 1
     assert on_value.call_args[0][0] == 43
     assert input.widget.error
@@ -76,7 +76,7 @@ def test_input_int():
     input.widget.v_model = "44"
     assert on_value.call_count == 1
     assert on_v_model.call_count == 1
-    input.widget.fire_event("blur")
+    input.widget.fire_event("focusout")
     assert on_v_model.call_count == 1
     assert on_value.call_count == 2
     assert on_value.call_args[0][0] == 44
@@ -105,7 +105,7 @@ def test_input_int_managed():
     input.widget.v_model = "1e3"
     assert on_value.call_count == 0
     assert on_v_model.call_count == 1
-    input.widget.fire_event("blur")
+    input.widget.fire_event("focusout")
     assert on_value.call_count == 0
     assert input.widget.error
     assert input.widget.label == "label (Value must be an integer)"
@@ -113,7 +113,7 @@ def test_input_int_managed():
     assert on_v_model.call_count == 1
 
     input.widget.v_model = "1"
-    input.widget.fire_event("blur")
+    input.widget.fire_event("focusout")
     assert on_value.call_count == 1
     assert on_v_model.call_count == 2
     assert not input.widget.error
@@ -122,7 +122,7 @@ def test_input_int_managed():
     assert on_value.call_count == 1
     assert on_v_model.call_count == 3
     assert not input.widget.error
-    input.widget.fire_event("blur")
+    input.widget.fire_event("focusout")
     # no change
     assert on_value.call_count == 1
     assert input.widget.error
@@ -156,7 +156,7 @@ def test_input_int_external():
     assert on_value.call_count == 0
     assert on_v_model_input.call_count == 1
     assert on_v_model_slider.call_count == 0
-    input.widget.fire_event("blur")
+    input.widget.fire_event("focusout")
     assert on_value.call_count == 1
     assert on_v_model_input.call_count == 1
     assert on_v_model_slider.call_count == 1
@@ -175,7 +175,7 @@ def test_input_int_external():
     assert on_v_model_input.call_count == 3
     assert on_v_model_slider.call_count == 2
     assert not input.widget.error
-    input.widget.fire_event("blur")
+    input.widget.fire_event("focusout")
     # No call to on_value or slider v_model, because the value is invalid
     assert on_value.call_count == 2
     assert on_v_model_slider.call_count == 2
@@ -209,7 +209,7 @@ def test_input_float_managed():
     input.widget.v_model = "1.1e3"
     assert on_value.call_count == 0
     assert on_v_model.call_count == 1
-    input.widget.fire_event("blur")
+    input.widget.fire_event("focusout")
     assert on_value.call_count == 1
     assert on_v_model.call_count == 1
     assert on_value.call_args[0][0] == 1100
@@ -220,7 +220,7 @@ def test_input_float_managed():
     input.widget.v_model = "1,1e3"
     assert on_value.call_count == 1
     assert on_v_model.call_count == 2
-    input.widget.fire_event("blur")
+    input.widget.fire_event("focusout")
     assert on_value.call_count == 1
     assert on_v_model.call_count == 2
     # assert on_value.call_args[0][0] == 1100
@@ -231,7 +231,7 @@ def test_input_float_managed():
     input.widget.v_model = "1.1e0"
     assert on_value.call_count == 1
     assert on_v_model.call_count == 3
-    input.widget.fire_event("blur")
+    input.widget.fire_event("focusout")
     assert on_value.call_count == 2
     assert on_v_model.call_count == 3
     assert on_value.call_args[0][0] == 1.1
@@ -243,7 +243,7 @@ def test_input_float_managed():
     input.widget.v_model = "1.1"
     assert on_v_model.call_count == 4
     assert on_value.call_count == 2
-    input.widget.fire_event("blur")
+    input.widget.fire_event("focusout")
     assert on_v_model.call_count == 4
     # no change
     assert on_value.call_count == 2


### PR DESCRIPTION
It seems like any of the events used here: https://github.com/vuetifyjs/vuetify/blob/342d75dddb6b85b437bb5b77e8ed0ec35d689b14/packages/vuetify/src/components/VTooltip/VTooltip.ts#L165-L181, i.e. `blur`, `keydown`, and `focus` won't work on children of `ipyvuetify.Tooltip`.

Fixes https://github.com/widgetti/solara/issues/683.