### PR TITLE
fix: no client side navigation for auth/login links

### DIFF
--- a/solara/components/markdown.py
+++ b/solara/components/markdown.py
@@ -119,7 +119,8 @@ module.exports = {
                 href = location.pathname + href.substr(1);
                 a.attributes['href'].href = href;
             }
-            if(href.startsWith("./") || href.startsWith("/")) {
+            let authLink = href.starswith("/_solara/auth/");
+            if( (href.startsWith("./") || href.startsWith("/")) && !authLink) {
                 a.onclick = e => {
                     console.log("clicked", href)
                     if(href.startsWith("./")) {


### PR DESCRIPTION
This was broken due to a fix in https://github.com/widgetti/solara/commit/f882941a6a4f76575a0b618c03c049ff39daa2e6 which unbroke client side navigation.