### PR TITLE
fix: fetch javascript assets correcly when SOLARA_ASSETS_PROXY=False

### DIFF
--- a/packages/solara-enterprise/solara_enterprise/search/search.vue
+++ b/packages/solara-enterprise/solara_enterprise/search/search.vue
@@ -137,10 +137,7 @@ module.exports = {
                 document.head.appendChild(script);
             });
         },
-        getBaseUrl() {
-            if (window.solara && window.solara.rootPath !== undefined) {
-                return solara.rootPath + "/";
-            }
+        getJupyterBaseUrl() {
             // if base url is set, we use ./ for relative paths compared to the base url
             if (document.getElementsByTagName("base").length) {
                 return document.baseURI;
@@ -157,7 +154,7 @@ module.exports = {
             return base
         },
         getCdn() {
-            return (typeof solara_cdn !== "undefined" && solara_cdn) || `${this.getBaseUrl()}_solara/cdn`;
+            return window.solara ? window.solara.cdn : `${this.getJupyterBaseUrl()}_solara/cdn`;
         },
     }
 }

--- a/solara/components/echarts.vue
+++ b/solara/components/echarts.vue
@@ -93,10 +93,7 @@ module.exports = {
         document.head.appendChild(script);
       });
     },
-    getBaseUrl() {
-      if (window.solara && window.solara.rootPath !== undefined) {
-        return solara.rootPath + "/";
-      }
+    getJupyterBaseUrl() {
       // if base url is set, we use ./ for relative paths compared to the base url
       if (document.getElementsByTagName("base").length) {
         return "./";
@@ -113,10 +110,7 @@ module.exports = {
       return base;
     },
     getCdn() {
-      return (
-        (typeof solara_cdn !== "undefined" && solara_cdn) ||
-        `${this.getBaseUrl()}_solara/cdn`
-      );
+      return window.solara ? window.solara.cdn : `${this.getJupyterBaseUrl()}_solara/cdn`
     },
   },
 };

--- a/solara/components/markdown_editor.vue
+++ b/solara/components/markdown_editor.vue
@@ -247,10 +247,7 @@ module.exports = {
         document.head.appendChild(script);
       });
     },
-    getBaseUrl() {
-      if (window.solara && window.solara.rootPath !== undefined) {
-        return solara.rootPath + "/";
-      }
+    getJupyterBaseUrl() {
       // if base url is set, we use ./ for relative paths compared to the base url
       if (document.getElementsByTagName("base").length) {
         return "./";
@@ -267,7 +264,7 @@ module.exports = {
       return base
     },
     getCdn() {
-      return (typeof solara_cdn !== "undefined" && solara_cdn) || `${this.getBaseUrl()}_solara/cdn`;
+      return window.solara ? window.solara.cdn : `${this.getJupyterBaseUrl()}_solara/cdn`;
     },
   },
 };

--- a/solara/components/sql_code.vue
+++ b/solara/components/sql_code.vue
@@ -83,10 +83,7 @@
           document.head.appendChild(script);
         });
       },
-      getBaseUrl() {
-        if (window.solara && window.solara.rootPath !== undefined) {
-          return solara.rootPath + "/";
-        }
+      getJupyterBaseUrl() {
         // if base url is set, we use ./ for relative paths compared to the base url
         if (document.getElementsByTagName("base").length) {
           return document.baseURI;
@@ -103,7 +100,7 @@
         return base
       },
       getCdn() {
-        return (typeof solara_cdn !== "undefined" && solara_cdn) || `${this.getBaseUrl()}_solara/cdn`;
+        return window.solara ? window.solara.cdn : `${this.getJupyterBaseUrl()}_solara/cdn`;
       },
     }
   }

--- a/solara/server/templates/solara.html.j2
+++ b/solara/server/templates/solara.html.j2
@@ -237,6 +237,11 @@
     {% endif %}
     <script>
         solara.rootPath = {{ root_path | tojson | safe}};
+        solara.cdn = {{ cdn | tojson | safe }};
+        // the vue templates expect it to not have a trailing slash
+        solara.cdn = solara.cdn.replace(/\/$/, '');
+        // keep this for backwards compatibility
+        window.solara_cdn = solara.cdn;
         console.log("rootPath", solara.rootPath);
 
         async function changeThemeCSS(theme) {

--- a/solara/website/components/algolia_api.vue
+++ b/solara/website/components/algolia_api.vue
@@ -151,10 +151,7 @@ module.exports = {
                 document.head.appendChild(script);
             });
         },
-        getBaseUrl() {
-            if (window.solara && window.solara.rootPath !== undefined) {
-                return solara.rootPath + "/";
-            }
+        getJupyterBaseUrl() {
             // if base url is set, we use ./ for relative paths compared to the base url
             if (document.getElementsByTagName("base").length) {
                 return document.baseURI;
@@ -171,7 +168,7 @@ module.exports = {
             return base
         },
         getCdn() {
-            return (typeof solara_cdn !== "undefined" && solara_cdn) || `${this.getBaseUrl()}_solara/cdn`;
+            return window.solara ? window.solara.cdn : `${this.getJupyterBaseUrl()}_solara/cdn`;
         },
     },
     data(){

--- a/solara/widgets/vue/gridlayout.vue
+++ b/solara/widgets/vue/gridlayout.vue
@@ -78,10 +78,7 @@ module.exports = {
             document.head.appendChild(script);
           });
         },
-        getBaseUrl() {
-          if (window.solara && window.solara.rootPath !== undefined) {
-                return solara.rootPath + "/";
-          }
+        getJupyterBaseUrl() {
           if (document.getElementsByTagName("base").length) {
             return "./";
           }
@@ -97,7 +94,7 @@ module.exports = {
           return base
         },
         getCdn() {
-          return (typeof solara_cdn !== "undefined" && solara_cdn) || `${this.getBaseUrl()}_solara/cdn`;
+          return window.solara ? window.solara.cdn : `${this.getJupyterBaseUrl()}_solara/cdn`;
         },
     }
 }

--- a/solara/widgets/vue/vegalite.vue
+++ b/solara/widgets/vue/vegalite.vue
@@ -88,10 +88,7 @@ module.exports = {
                 document.head.appendChild(script);
             });
         },
-        getBaseUrl() {
-            if (window.solara && window.solara.rootPath !== undefined) {
-                return solara.rootPath + "/";
-            }
+        getJupyterBaseUrl() {
             // if base url is set, we use ./ for relative paths compared to the base url
             if (document.getElementsByTagName("base").length) {
                 return "./";
@@ -108,7 +105,7 @@ module.exports = {
             return base
         },
         getCdn() {
-            return this.cdn || (typeof solara_cdn !== "undefined" && solara_cdn) || `${this.getBaseUrl()}_solara/cdn`;
+            return this.cdn || (window.solara ? window.solara.cdn : `${this.getJupyterBaseUrl()}_solara/cdn`);
         }
     },
 }


### PR DESCRIPTION
We did not set what was previously named `solara_cdn`. That caused vue template to not use the right cdn when we did not proxy. This also simplied the login, and motivated a rename of getBaseUrl -> getJupyterBaseUrl since that is only used in Jupyter notebook, Lab and Voila.