### PR TITLE
ci: downgrade setup-redis action to fix missing shared library

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -500,7 +500,7 @@ jobs:
 
       - name: Start Redis
         if: ( github.event_name != 'schedule' || steps.install_no_lock.outputs.HAS_DIFF == 'true' ) && matrix.os != 'windows'
-        uses: shogo82148/actions-setup-redis@v1
+        uses: shogo82148/actions-setup-redis@v1.34.0
 
       - name: test
         if: github.event_name != 'schedule' || steps.install_no_lock.outputs.HAS_DIFF == 'true'


### PR DESCRIPTION
With `actions-setup-redis@v1.35.0` tests on Ubuntu-20.04 fail because of a missing shared library `libssl.so.3`. Pin version to `v1.24.0` until https://github.com/shogo82148/actions-setup-redis/issues/958 is resolved.