### PR TITLE
fix: if matplotlib was imported before solara, we set the backend

### DIFF
--- a/solara/server/patch.py
+++ b/solara/server/patch.py
@@ -466,6 +466,12 @@ def patch():
             os.environ["MPLBACKEND"] = "module://ipykernel.pylab.backend_inline"
         else:
             os.environ["MPLBACKEND"] = "module://matplotlib_inline.backend_inline"
+        # if matplotlib is already imported, we need to set the backend
+        # similar to how matplotlib does it in it's __init__.py
+        if "matplotlib" in sys.modules:
+            import matplotlib
+
+            matplotlib.rcParams["backend"] = os.environ.get("MPLBACKEND")
 
     # the ipyvue.Template module cannot be accessed like ipyvue.Template
     # because the import in ipvue overrides it


### PR DESCRIPTION
Normally, setting MPLBACKEND will set the backend because importing matplotlib will set the backend based on this environment variable. However, in the case where matplotlib is imported before solara, such as jdaviz is doing, we need to set the backend manually.

Related: https://github.com/spacetelescope/jdaviz/pull/2909