### PR TITLE
pre-commit: Add auto-update schedule

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+ci:
+    autoupdate_schedule: 'weekly'
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0


### PR DESCRIPTION
To make sure the pre-commit configuration stays up to date, add auto-update schedule to the pre-commit configuration file.

[pre-commit.ci](https://pre-commit.ci/) needs to be enable for this (which I highly recommend). When enabled, it will check once a week if any pre-commit action can be updated, and will open a PR if so.