### PR TITLE
fix: to redirect back after auth we used the wrong base url

### DIFF
--- a/packages/solara-enterprise/solara_enterprise/auth/starlette.py
+++ b/packages/solara-enterprise/solara_enterprise/auth/starlette.py
@@ -92,7 +92,7 @@ async def login(request: Request, redirect_uri: Optional[str] = None):
         # where it detect we the OAuth.required=True setting, leading to a redirect
         request.session["redirect_uri"] = str(request.url.path)
     request.session["client_id"] = settings.oauth.client_id
-    result = await oauth.oauth1.authorize_redirect(request, str(request.base_url) + "_solara/auth/authorize")
+    result = await oauth.oauth1.authorize_redirect(request, str(settings.main.base_url) + "_solara/auth/authorize")
     return result
 
 


### PR DESCRIPTION
settings.main.base_url should have been used, since that can be used to override the base url from starlette.

Note that this should always never be needed once a proxy and uvicorn are configured correctly (see also #745).

But starlette does not respect the x-forwarded-host header, so we might need to use this in the future in situations of proxies that need to set the Host header due to https communication.

Fixes #740