### PR TITLE
ci: scheduled test runs pass because of wrong logic operation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -142,7 +142,7 @@ jobs:
           pip install pre-commit
           pip freeze --exclude solara --exclude solara-enterprise > ${{ env.LOCK_FILE_LOCATION }}
           git diff --exit-code | tee ${{ env.DIFF_FILE_LOCATION }}
-          [ -s ${{ env.DIFF_FILE_LOCATION }} ] || echo "HAS_DIFF=true" >> "$GITHUB_OUTPUT"
+          [ -s ${{ env.DIFF_FILE_LOCATION }} ] && echo "HAS_DIFF=true" >> "$GITHUB_OUTPUT"
 
       - name: Install
         if: github.event_name != 'schedule' && steps.prepare.outputs.LOCKS_EXIST == 'true'
@@ -289,7 +289,7 @@ jobs:
           pip freeze --exclude solara --exclude solara-ui --exclude solara-server > ${{ env.LOCK_FILE_LOCATION }}
           git diff --quiet || echo "HAS_DIFF=true" >> "$GITHUB_OUTPUT"
           git diff --exit-code | tee ${{ env.DIFF_FILE_LOCATION }}
-          [ -s ${{ env.DIFF_FILE_LOCATION }} ] || echo "HAS_DIFF=true" >> "$GITHUB_OUTPUT"
+          [ -s ${{ env.DIFF_FILE_LOCATION }} ] && echo "HAS_DIFF=true" >> "$GITHUB_OUTPUT"
 
       - name: Install
         if: github.event_name != 'schedule' && steps.prepare.outputs.LOCKS_EXIST == 'true'
@@ -400,7 +400,7 @@ jobs:
           pip install "jupyterlab<4"  "pydantic<2" "playwright==1.41.2" "ipywidgets~=${{ matrix.ipywidgets }}"
           pip freeze --exclude solara --exclude solara-ui --exclude solara-server --exclude pytest-ipywidgets --exclude solara-enterprise > ${{ env.LOCK_FILE_LOCATION }}
           git diff --exit-code | tee ${{ env.DIFF_FILE_LOCATION }}
-          [ -s ${{ env.DIFF_FILE_LOCATION }} ] || echo "HAS_DIFF=true" >> "$GITHUB_OUTPUT"
+          [ -s ${{ env.DIFF_FILE_LOCATION }} ] && echo "HAS_DIFF=true" >> "$GITHUB_OUTPUT"
 
       - name: Install
         if: github.event_name != 'schedule' && steps.prepare.outputs.LOCKS_EXIST == 'true'
@@ -507,7 +507,7 @@ jobs:
           pip install --pre ipyvue ipyvuetify
           pip freeze --exclude solara --exclude solara-ui --exclude solara-server --exclude pytest-ipywidgets --exclude solara-enterprise > ${{ env.LOCK_FILE_LOCATION }}
           git diff --exit-code | tee ${{ env.DIFF_FILE_LOCATION }}
-          [ -s ${{ env.DIFF_FILE_LOCATION }} ] || echo "HAS_DIFF=true" >> "$GITHUB_OUTPUT"
+          [ -s ${{ env.DIFF_FILE_LOCATION }} ] && echo "HAS_DIFF=true" >> "$GITHUB_OUTPUT"
 
       - name: Install
         if: github.event_name != 'schedule' && steps.prepare.outputs.LOCKS_EXIST == 'true'
@@ -608,7 +608,7 @@ jobs:
           pip install "jupyterlab<4" diskcache redis "ipywidgets~=${{ matrix.ipywidgets }}"
           pip freeze --exclude solara --exclude solara-ui --exclude solara-server --exclude pytest-ipywidgets --exclude solara-enterprise > ${{ env.LOCK_FILE_LOCATION }}
           git diff --exit-code | tee ${{ env.DIFF_FILE_LOCATION }}
-          [ -s ${{ env.DIFF_FILE_LOCATION }} ] || echo "HAS_DIFF=true" >> "$GITHUB_OUTPUT"
+          [ -s ${{ env.DIFF_FILE_LOCATION }} ] && echo "HAS_DIFF=true" >> "$GITHUB_OUTPUT"
 
       - name: Install
         if: github.event_name != 'schedule' && steps.prepare.outputs.LOCKS_EXIST == 'true'


### PR DESCRIPTION
Using `||` means that as long as there is a diff, test automatically pass without running. If there was no diff, all tests would have failed.