### PR TITLE
fix: still js console errors from typo in markdown template

### DIFF
--- a/solara/components/markdown.py
+++ b/solara/components/markdown.py
@@ -128,7 +128,7 @@ module.exports = {
                 href = location.pathname + href.substr(1);
                 a.attributes['href'].href = href;
             }
-            let authLink = href.startswith("/_solara/auth/");
+            let authLink = href.startsWith("/_solara/auth/");
             if( (href.startsWith("./") || href.startsWith("/")) && !authLink) {
                 a.onclick = e => {
                     console.log("clicked", href)


### PR DESCRIPTION
See d875ff5d9a767f738340cfbd674539a8e240e3bd. `startswith` should be `startsWith`.