### PR TITLE
feat: allow connecting to a running kernel from a different browser

### DIFF
--- a/solara/server/kernel_context.py
+++ b/solara/server/kernel_context.py
@@ -383,7 +383,7 @@ def initialize_virtual_kernel(session_id: str, kernel_id: str, websocket: websoc
     if kernel_id in contexts:
         logger.info("reusing virtual kernel: %s", kernel_id)
         context = contexts[kernel_id]
-        if context.session_id != session_id:
+        if solara.server.settings.kernel.session_check and context.session_id != session_id:
             logger.critical("Session id mismatch when reusing kernel (hack attempt?): %s != %s", context.session_id, session_id)
             websocket.send_text("Session id mismatch when reusing kernel (hack attempt?)")
             # to avoid very fast reconnects (we are in a thread anyway)

--- a/solara/server/settings.py
+++ b/solara/server/settings.py
@@ -108,6 +108,7 @@ class Kernel(BaseSettings):
     cull_timeout: str = "24h"
     max_count: Optional[int] = None
     threaded: bool = solara.util.has_threads
+    session_check: bool = True
 
     class Config:
         env_prefix = "solara_kernel_"


### PR DESCRIPTION
This is useful for connecting external devices, such as smartphone or AR devices (Apple Vision pro and Meta Quest) to the running kernel using ipypopout.

This is normally not possible since we require the connecting client to have the same session id as the already kernel.

This this setting, we can disable the session check and the above use case.

Example usage:

SOLARA_KERNEL_SESSION_CHECK=False solara run ...
