### PR TITLE
CI: Test with Python 3.13

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -482,6 +482,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
           cache: "pip"
 
       - uses: actions/download-artifact@v4
@@ -710,6 +711,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.13"
+          allow-prereleases: true
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -250,6 +250,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
           cache: "pip"
 
       - uses: actions/download-artifact@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,7 +33,8 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.13"
+          allow-prereleases: true
 
       - uses: actions/setup-node@v4
         with:
@@ -112,7 +113,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.12"]  # 3.9 is the lowest version pre-commit supports
+        python-version: ["3.9", "3.13"]  # 3.9 is the lowest version pre-commit supports
     env:
       LOCK_FILE_LOCATION: .ci-package-locks/code-quality/python${{ matrix.python-version }}.txt
       DIFF_FILE_LOCATION: diff-code-quality-python${{ matrix.python-version }}.txt
@@ -124,6 +125,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Prepare
         id: prepare
@@ -174,21 +176,19 @@ jobs:
 
   test-install:
     needs: [build]
-    runs-on: ${{ matrix.os }}-${{(matrix.os == 'ubuntu' && matrix.python == '3.6') && '20.04' || (matrix.os == 'macos' && matrix.python == '3.6') && '13' || 'latest' }}
+    runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        python: ["3.6", "3.10"]
-        exclude:
-          - os: windows
-            python: 3.6
+        python: ["3.9", "3.13"]
 
     steps:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
+          allow-prereleases: true
 
       - uses: actions/checkout@v4
 
@@ -239,7 +239,7 @@ jobs:
       matrix:
         os: [ubuntu, macos, windows]
         # just 1 version, it's heavy
-        python-version: ["3.10"]
+        python-version: ["3.13"]
     env:
       LOCK_FILE_LOCATION: .ci-package-locks/pyinstaller/os${{ matrix.os }}-python${{ matrix.python-version }}.txt
 
@@ -348,7 +348,7 @@ jobs:
         # osx should work fine (and we test that locally often)
         os: [ubuntu, windows]
         # just 1 version, it's heavy
-        python-version: [3.8]
+        python-version: ["3.13"]
         ipywidgets_major: ["7", "8"]
         include:
           - ipywidgets_major: "7"
@@ -366,6 +366,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
           cache: "pip"
 
       - uses: actions/download-artifact@v4
@@ -464,7 +465,7 @@ jobs:
         # osx should work fine (and we test that locally often)
         os: [ubuntu]
         # just 1 version, it's heavy
-        python-version: [3.8]
+        python-version: ["3.13"]
         ipywidgets_major: ["8"]
         include:
           - ipywidgets_major: "8"
@@ -564,21 +565,21 @@ jobs:
 
   unit-test:
     needs: [build]
-    runs-on: ${{ matrix.os }}-${{(matrix.os == 'ubuntu' && matrix.python == '3.6') && '20.04' || (matrix.os == 'macos' && matrix.python == '3.6') && '13' || 'latest' }}
+    runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        python: [3.6, 3.9]
+        python: ["3.9", "3.13"]
         ipywidgets: ["7.7", "8.0"]
         exclude:
           - os: windows
-            python: 3.6
+            python: "3.9"
           - os: ubuntu
-            python: 3.6
+            python: "3.9"
             ipywidgets: "8.0"
           - os: macos
-            python: 3.6
+            python: "3.9"
             ipywidgets: "8.0"
     env:
       LOCK_FILE_LOCATION: .ci-package-locks/unit/os${{ matrix.os }}-python${{ matrix.python }}-ipywidgets${{ matrix.ipywidgets }}.txt
@@ -591,6 +592,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
+          allow-prereleases: true
           cache: "pip"
 
       - uses: actions/download-artifact@v4
@@ -703,10 +705,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.13
         uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: "3.13"
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/webdeploy.yml
+++ b/.github/workflows/webdeploy.yml
@@ -37,7 +37,8 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.13"
+          allow-prereleases: true
 
       - name: Install solara
         run: |


### PR DESCRIPTION
Update the CI to use Python 3.9 as lowest and Python 3.13 as highest version.

This is mainly a test PR to help you discover if you're ready for Python 3.13, which has its stable release is this Tuesday (2024-10-01).

You can also merge it if you like.

See
- https://github.com/widgetti/solara/issues/797.