### PR TITLE
chore: remove unnecessary version pin from jupyter_client

### DIFF
--- a/packages/solara-server/pyproject.toml
+++ b/packages/solara-server/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "filelock",
     "ipykernel",
     "nbformat",
-    "jupyter_client>=7.0.0",
+    "jupyter_client",
 ]
 
 [project.urls]


### PR DESCRIPTION
This will take us most of the way towards supporting Python 3.13, see https://github.com/widgetti/solara/issues/797 for progress.