### PR TITLE
feat: add user_ns to our ipython replacement

### DIFF
--- a/solara/server/patch.py
+++ b/solara/server/patch.py
@@ -38,6 +38,7 @@ class FakeIPython:
         # needed for the pyplot interface of matplotlib
         # (although we don't really support it)
         self.events = mock.MagicMock()
+        self.user_ns: Dict[Any, Any] = {}
 
     def enable_gui(self, gui):
         logger.error("ignoring call to enable_gui(%s)", gui)


### PR DESCRIPTION
Needed for https://github.com/widgetti/glue-solara/pull/6 to work properly. Otherwise glue cleanup method (https://github.com/glue-viz/glue/blob/e7c2766d85aceea29aae1a51d95d1189f4444b55/glue/viewers/common/viewer.py#L426-L430) fails.