### PR TITLE
feat: enable navigation to hashes

### DIFF
--- a/solara/website/pages/documentation/advanced/content/20-understanding/40-routing.md
+++ b/solara/website/pages/documentation/advanced/content/20-understanding/40-routing.md
@@ -219,6 +219,16 @@ def LinkToIpywidgets():
     return main
 ```
 
+### Linking to Sections of a Page
+
+The `solara.Link` component also supports linking to HTML elements identified by id. Although most Solara components don't directly support the id attribute, you can assign ids to all ipyvuetify components, using the `attributes` argument:
+
+```python
+solara.v.Btn(attributes={"id": "my-id"}, ...)
+```
+
+You can then link to a particular element by appending `#` followed by its id to your link, i.e. `solara.Link(route_or_path="/page#my-id")`.
+
 ## Fully manual routing
 
 If you want to do routing fully manually, you can use the [`solara.use_router`](/documentation/api/routing/use_router) hook, and use the `.path` attribute.

--- a/solara/widgets/vue/navigator.vue
+++ b/solara/widgets/vue/navigator.vue
@@ -37,7 +37,7 @@ modules.export = {
       window.history.replaceState(
         { top: document.documentElement.scrollTop },
         null,
-        this.makeFullRelativeUrl()
+        window.location.href
       );
     },
     onPopState(event) {


### PR DESCRIPTION
Previously this was not officially supported, and would only work when moving within a page, or when initially loading a page with SSG enabled.