### PR TITLE
fix: wrong data-base-url caused chunks and assets in extensions to fail

### DIFF
--- a/packages/solara-meta/pyproject.toml
+++ b/packages/solara-meta/pyproject.toml
@@ -62,6 +62,7 @@ dev = [
     "python-dotenv",
     "bqplot",
     "bqplot-image-gl",
+    "ipyaggrid",
     "ipyreact; python_version > '3.6'",
     "vaex-core",
     "vaex-hdf5",

--- a/solara/server/templates/solara.html.j2
+++ b/solara/server/templates/solara.html.j2
@@ -172,7 +172,7 @@
 </script>
 {% endraw -%}
 
-<body data-base-url="{{root_path}}/static/">
+<body data-base-url="{{root_path}}/jupyter/">
     {% if perform_check %}
     <iframe src="https://solara.dev/static/public/success.html?system=solara&check=html&version={{solara_version}}" style="display: none"></iframe>
     {% endif %}

--- a/tests/integration/widget_test.py
+++ b/tests/integration/widget_test.py
@@ -27,6 +27,43 @@ def test_widget_button_solara(solara_test, page_session: playwright.sync_api.Pag
     assert_solara_snapshot(page_session.locator("text=Tested event").screenshot(), postfix="-ipyvuetify3" if solara.util.ipyvuetify_major_version == 3 else "")
 
 
+def test_widget_ipyaggrid(solara_test, page_session: playwright.sync_api.Page):
+    # ipyaggrid >=0.5.2 uses the data-base-url on body
+    # introduced in https://github.com/widgetti/ipyaggrid/pull/64
+    # which we broke in https://github.com/widgetti/solara/pull/805 since
+    # we changed the nbextensions path, but didn't update the data-base-url
+    import ipyaggrid
+
+    cars = [
+        {"carName": "Chevelle", "origin": "US", "make": "Chevrolet", "price": 30415},
+        {"carName": "Skylark 320", "origin": "US", "make": "Buick", "price": 21042},
+        {"carName": "PL411", "origin": "Asia", "make": "Datsun", "price": 27676},
+    ]
+    column_defs = [{"field": c} for c in cars[0]]
+
+    grid_options = {
+        "columnDefs": column_defs,
+    }
+    g = ipyaggrid.Grid(grid_data=cars, grid_options=grid_options)
+
+    watermark_detected = False
+
+    def log(msg):
+        if "All AG Grid Enterprise features are unlocked" in msg.text:
+            nonlocal watermark_detected
+            watermark_detected = True
+
+    page_session.on("console", log)
+
+    display(g)
+
+    cell = page_session.locator(".ag-root-wrapper >> text=Chevrolet")
+    cell.click()
+    cell.wait_for()
+    assert watermark_detected
+    page_session.remove_listener("console", log)
+
+
 def test_solara_button_all(ipywidgets_runner, page_session: playwright.sync_api.Page, request, assert_solara_snapshot):
     if request.node.callspec.params["ipywidgets_runner"] != "solara" and request.node.callspec.params["solara_server"] != SERVERS[0]:
         pytest.skip("No need to run this test for all servers.")


### PR DESCRIPTION
This for instance broke ipyaggrid >=0.5.2 due to changes in https://github.com/widgetti/solara/pull/805