### PR TITLE
Define custom_exceptions on FakeIPython

### DIFF
--- a/solara/server/patch.py
+++ b/solara/server/patch.py
@@ -39,6 +39,7 @@ class FakeIPython:
         # (although we don't really support it)
         self.events = mock.MagicMock()
         self.user_ns: Dict[Any, Any] = {}
+        self.custom_exceptions = ()
 
     def enable_gui(self, gui):
         logger.error("ignoring call to enable_gui(%s)", gui)


### PR DESCRIPTION
Without this I am running into the following when trying to launch glue-solara:

```
Solara server is starting at http://localhost:8765
Traceback (most recent call last):
  File "/home/tom/python/dev/bin/solara", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/tom/Code/solara/solara/__main__.py", line 750, in main
    cli(args[1:])
  File "/home/tom/python/dev/lib/python3.11/site-packages/rich_click/rich_command.py", line 367, in __call__
    return super().__call__(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tom/python/dev/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tom/python/dev/lib/python3.11/site-packages/rich_click/rich_command.py", line 152, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/tom/python/dev/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tom/python/dev/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tom/python/dev/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tom/Code/solara/solara/__main__.py", line 474, in run
    start_server()
  File "/home/tom/Code/solara/solara/__main__.py", line 440, in start_server
    server.run()
  File "/home/tom/python/dev/lib/python3.11/site-packages/uvicorn/server.py", line 65, in run
    return asyncio.run(self.serve(sockets=sockets))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/asyncio/base_events.py", line 653, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/home/tom/python/dev/lib/python3.11/site-packages/uvicorn/server.py", line 69, in serve
    await self._serve(sockets)
  File "/home/tom/python/dev/lib/python3.11/site-packages/uvicorn/server.py", line 76, in _serve
    config.load()
  File "/home/tom/python/dev/lib/python3.11/site-packages/uvicorn/config.py", line 434, in load
    self.loaded_app = import_from_string(self.app)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tom/python/dev/lib/python3.11/site-packages/uvicorn/importer.py", line 19, in import_from_string
    module = importlib.import_module(module_str)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1206, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1178, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1149, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/tom/Code/solara/solara/server/starlette.py", line 56, in <module>
    from . import app as appmod
  File "/home/tom/Code/solara/solara/server/app.py", line 491, in <module>
    apps["__default__"] = AppScript(os.environ.get("SOLARA_APP", "solara.website.pages:Page"))
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tom/Code/solara/solara/server/app.py", line 73, in __init__
    app = self._execute()
          ^^^^^^^^^^^^^^^
  File "/home/tom/Code/solara/solara/server/app.py", line 152, in _execute
    mod = importlib.import_module(self.name)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tom/Code/glue-solara/glue_solara/app.py", line 5, in <module>
    import glue.core.hub
  File "/home/tom/Code/glue/glue/__init__.py", line 19, in <module>
    from .config import load_configuration
  File "/home/tom/Code/glue/glue/config.py", line 836, in <module>
    from astropy.visualization import (LinearStretch, SqrtStretch, AsinhStretch,
  File "/home/tom/python/dev/lib/python3.11/site-packages/astropy/__init__.py", line 176, in <module>
    log = _init_log()
          ^^^^^^^^^^^
  File "/home/tom/python/dev/lib/python3.11/site-packages/astropy/logger.py", line 122, in _init_log
    log._set_defaults()
  File "/home/tom/python/dev/lib/python3.11/site-packages/astropy/logger.py", line 499, in _set_defaults
    if self.exception_logging_enabled():
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tom/python/dev/lib/python3.11/site-packages/astropy/logger.py", line 321, in exception_logging_enabled
    return _AstLogIPYExc in get_ipython().custom_exceptions
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'FakeIPython' object has no attribute 'custom_exceptions'
```