### PR TITLE
fix: wrong condition when determining which files to reload

### DIFF
--- a/solara/__main__.py
+++ b/solara/__main__.py
@@ -344,10 +344,9 @@ def run(
         app_path = Path(app)
         if app_path.exists():
             # if app is not a child of the current working directory
-            # uvcorn crashes
-            if str(app_path.resolve()).startswith(str(Path.cwd().resolve())):
+            # uvicorn crashes
+            if not str(app_path.resolve()).startswith(str(Path.cwd().resolve())):
                 reload_excludes.append(str(app_path.resolve()))
-            print("reload_excludes", reload_excludes)
         del app_path
         del solara_root
         reload = True


### PR DESCRIPTION
069a205c88a8cbcb0b0ca23f4d56889c8ad6134a Caused the paths outside of working directory to be the only ones included instead of being excluded