### PR TITLE
Added a httponly option for HTMLResponse.set_cookie

### DIFF
--- a/solara/server/settings.py
+++ b/solara/server/settings.py
@@ -132,6 +132,7 @@ OAUTH_TEST_CLIENT_IDs = [AUTH0_TEST_CLIENT_ID, FIEF_TEST_CLIENT_ID]
 
 class Session(BaseSettings):
     secret_key: str = SESSION_SECRET_KEY_DEFAULT
+    http_only: Optional[bool] = None
     https_only: Optional[bool] = None
     same_site: str = "lax"
 

--- a/solara/server/settings.py
+++ b/solara/server/settings.py
@@ -132,7 +132,7 @@ OAUTH_TEST_CLIENT_IDs = [AUTH0_TEST_CLIENT_ID, FIEF_TEST_CLIENT_ID]
 
 class Session(BaseSettings):
     secret_key: str = SESSION_SECRET_KEY_DEFAULT
-    http_only: Optional[bool] = None
+    http_only: bool = False
     https_only: Optional[bool] = None
     same_site: str = "lax"
 

--- a/solara/server/starlette.py
+++ b/solara/server/starlette.py
@@ -463,6 +463,7 @@ See also https://solara.dev/documentation/getting_started/deploying/self-hosted
     session_id = request.cookies.get(server.COOKIE_KEY_SESSION_ID) or str(uuid4())
     samesite = "lax"
     secure = False
+    httponly = settings.session.http_only
     # we want samesite, so we can set a cookie when embedded in an iframe, such as on huggingface
     # however, samesite=none requires Secure https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
     # when hosted on the localhost domain we can always set the Secure flag
@@ -488,6 +489,7 @@ Also check out the following Solara documentation:
         expires="Fri, 01 Jan 2038 00:00:00 GMT",
         samesite=samesite,  # type: ignore
         secure=secure,  # type: ignore
+        httponly=httponly,  # type: ignore
     )  # type: ignore
     return response
 

--- a/solara/website/pages/documentation/advanced/content/20-understanding/50-solara-server.md
+++ b/solara/website/pages/documentation/advanced/content/20-understanding/50-solara-server.md
@@ -51,6 +51,7 @@ browser pages. This can be used to store state that outlives a page refresh.
 We recommend storing the state in an external database, especially in the case of multiple workers/nodes. If you want to store state associated to a session in-memory, make sure to set up sticky sessions.
 
 
+The `solara-session-id` cookie is accessible in the browser using JavaScript. If you deem this a security risk, you can disable the cookie by setting the `SOLARA_SESSION_HTTP_ONLY` environment variable to `True`.
 
 
 ## Readiness check


### PR DESCRIPTION
Following the discussion in #799, I added an option configurable through an environment variable `SOLARA_SESSION_HTTP_ONLY`, and passing this to the `httponly` option in [HTMLResponse](https://www.starlette.io/responses/). 

As discussed, this change is backwards compatible because it defaults to False.

Here we can verify the httpOnly attribute of the `solara-session-id` cookie using Developer tools:

![image](https://github.com/user-attachments/assets/c7c7ef2f-b852-4fd7-8e46-a5b7507ce04d)

and here's another screenshot showing the behavior when setting the environment variable `SOLARA_SESSION_HTTP_ONLY=True`:

![image](https://github.com/user-attachments/assets/6a839d2f-9295-45c5-9ab7-ad2361939958)

Note that the cookie no longer appears in `document.cookie`. 

Thus, this PR makes it possible for a solara-based application to comply with [cwe 402](https://cwe.mitre.org/data/definitions/402.html)
