### PR TITLE
ci: release process would fail due to old hatchling version

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -709,10 +709,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: "3.10"
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ on:
   pull_request:
   workflow_dispatch:
   schedule:
-    - cron: '0 6 * * *'  # at 06:00 UTC every day
+    - cron: "0 6 * * *" # at 06:00 UTC every day
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -112,7 +112,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.12"]  # 3.9 is the lowest version pre-commit supports
+        python-version: ["3.9", "3.12"] # 3.9 is the lowest version pre-commit supports
     env:
       LOCK_FILE_LOCATION: .ci-package-locks/code-quality/python${{ matrix.python-version }}.txt
       DIFF_FILE_LOCATION: diff-code-quality-python${{ matrix.python-version }}.txt
@@ -200,15 +200,13 @@ jobs:
         run: ls -R dist
 
       - name: Install solara-ui
-        run:
-          pip install dist/*.whl
+        run: pip install dist/*.whl
 
       - name: Test import
         run: python -c "import solara"
 
       - name: Install solara-server
-        run:
-          pip install `echo packages/solara-server/dist/*.whl`[starlette]
+        run: pip install `echo packages/solara-server/dist/*.whl`[starlette]
 
       - name: Run solara create
         run: solara create button test.py
@@ -227,8 +225,7 @@ jobs:
         run: python -c "import solara_enterprise"
 
       - name: Install solara-meta
-        run:
-          pip install packages/solara-meta/dist/*.whl
+        run: pip install packages/solara-meta/dist/*.whl
 
   pyinstaller-test:
     needs: [build]
@@ -661,7 +658,8 @@ jobs:
           include-hidden-files: true
 
   update-ci-package-locks:
-    needs: [build, code-quality, integration-test, integration-test-vue3, unit-test]
+    needs:
+      [build, code-quality, integration-test, integration-test-vue3, unit-test]
     runs-on: ubuntu-latest
 
     steps:
@@ -695,10 +693,18 @@ jobs:
           git push
 
   release:
-    needs: [build, code-quality, test-install, integration-test, integration-test-vue3, unit-test]
+    needs:
+      [
+        build,
+        code-quality,
+        test-install,
+        integration-test,
+        integration-test-vue3,
+        unit-test,
+      ]
     runs-on: ubuntu-latest
     permissions:
-      id-token: write  # this permission is mandatory for trusted publishing
+      id-token: write # this permission is mandatory for trusted publishing
 
     steps:
       - uses: actions/checkout@v4

--- a/packages/pytest-ipywidgets/pyproject.toml
+++ b/packages/pytest-ipywidgets/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling==1.22.2"]
+requires = ["hatchling==1.26.3"]
 build-backend = "hatchling.build"
 
 

--- a/packages/solara-assets/pyproject.toml
+++ b/packages/solara-assets/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling >=0.25"]
+requires = ["hatchling==1.26.3"]
 build-backend = "hatchling.build"
 
 [project]

--- a/packages/solara-enterprise/pyproject.toml
+++ b/packages/solara-enterprise/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling==1.22.2"]
+requires = ["hatchling==1.26.3"]
 build-backend = "hatchling.build"
 
 [project]

--- a/packages/solara-meta/pyproject.toml
+++ b/packages/solara-meta/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling==1.22.2"]
+requires = ["hatchling==1.26.3"]
 build-backend = "hatchling.build"
 
 

--- a/packages/solara-server/pyproject.toml
+++ b/packages/solara-server/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling==1.22.2"]
+requires = ["hatchling==1.26.3"]
 build-backend = "hatchling.build"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling==1.22.2"]
+requires = ["hatchling==1.26.3"]
 build-backend = "hatchling.build"
 
 

--- a/solara/template/portal/pyproject.toml
+++ b/solara/template/portal/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling >=0.25"]
+requires = ["hatchling==1.26.3"]
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
### All Submissions:

<!-- You can erase any parts not applicable to your Pull Request. -->

* [x] I installed `pre-commit` prior to committing my changes (see [development setup docs](https://solara.dev/documentation/advanced/development/setup#contributing)).
* [x] My commit messages conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
* [x] My PR title conforms to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

### Description of changes

PEP 639 adds support for `license-file` metadata field (see [here](https://discuss.python.org/t/pep-639-round-3-improving-license-clarity-with-better-package-metadata/53020)), which seems to now be the default on PyPI. We need to upgrade hatchling in order for this to be correctly accounted for when releasing, see [this comment](https://github.com/pypa/hatch/issues/1786#issuecomment-2469293644).

<!-- Describe the changes in this PR -->
