### PR TITLE
fix: a failing websocket.send would drop the connection silently

### DIFF
--- a/solara/server/flask.py
+++ b/solara/server/flask.py
@@ -65,11 +65,17 @@ class WebsocketWrapper(websocket.WebsocketWrapper):
 
     def send_text(self, data: str) -> None:
         with self.lock:
-            self.ws.send(data)
+            try:
+                self.ws.send(data)
+            except simple_websocket.ws.ConnectionClosed:
+                raise websocket.WebSocketDisconnect()
 
     def send_bytes(self, data: bytes) -> None:
         with self.lock:
-            self.ws.send(data)
+            try:
+                self.ws.send(data)
+            except simple_websocket.ws.ConnectionClosed:
+                raise websocket.WebSocketDisconnect()
 
     async def receive(self):
         from anyio import to_thread


### PR DESCRIPTION
Instead of assuming all exceptions are due to a closed connection, we only ignored the exception when it is due to a closed connection.

This caused issues in #841 where we called from the same thread as the websocket's portal, which caused the connection to be ignored without any error message.

