### PR TITLE
fix: numpy scalars were serialized to a string, instead of a number

### DIFF
--- a/solara/server/kernel.py
+++ b/solara/server/kernel.py
@@ -54,7 +54,7 @@ def json_default(obj):
         import numpy as np
 
         if isinstance(obj, np.number):
-            return repr(obj.item())
+            return obj.item()
         else:
             raise TypeError("%r is not JSON serializable" % obj)
     else:

--- a/solara/server/starlette.py
+++ b/solara/server/starlette.py
@@ -131,9 +131,7 @@ class WebsocketWrapper(websocket.WebsocketWrapper):
         # and re-raise it as a websocket.WebSocketDisconnect
         try:
             await self.ws.send_bytes(data)
-        except websockets.exceptions.ConnectionClosed as e:
-            raise websocket.WebSocketDisconnect() from e
-        except RuntimeError as e:
+        except (websockets.exceptions.ConnectionClosed, starlette.websockets.WebSocketDisconnect, RuntimeError) as e:
             # starlette throws a RuntimeError once you call send after the connection is closed
             raise websocket.WebSocketDisconnect() from e
 
@@ -142,9 +140,7 @@ class WebsocketWrapper(websocket.WebsocketWrapper):
         # and re-raise it as a websocket.WebSocketDisconnect
         try:
             await self.ws.send_text(data)
-        except websockets.exceptions.ConnectionClosed as e:
-            raise websocket.WebSocketDisconnect() from e
-        except RuntimeError as e:
+        except (websockets.exceptions.ConnectionClosed, starlette.websockets.WebSocketDisconnect, RuntimeError) as e:
             # starlette throws a RuntimeError once you call send after the connection is closed
             raise websocket.WebSocketDisconnect() from e
 

--- a/tests/unit/kernel_test.py
+++ b/tests/unit/kernel_test.py
@@ -1,7 +1,9 @@
+import json
 from datetime import datetime
 from unittest.mock import Mock
 
 from solara.server.kernel import SessionWebsocket
+import numpy as np
 
 
 def test_session_datetime():
@@ -16,3 +18,20 @@ def test_session_datetime():
     session.websockets.add(websocket)
     session.send(stream, {"msg_type": "test", "content": {"data": "test"}, "somedate": datetime.now()})  # type: ignore
     websocket.send.assert_called_once()
+
+
+def test_numpy_scalar():
+    class Dummy:
+        pass
+
+    websocket = Mock()
+    stream = Dummy()
+    stream.channel = "iopub"  # type: ignore
+    session = SessionWebsocket()
+    session.websockets.add(websocket)
+    v = np.int64(42)
+    session.send(stream, {"msg_type": "test", "content": {"a_numpy_scalar": v}})  # type: ignore
+    websocket.send.assert_called_once()
+    json_string = websocket.send.call_args[0][0]
+    json_data = json.loads(json_string)
+    assert json_data["content"]["a_numpy_scalar"] == 42


### PR DESCRIPTION
@jfoster17 indeed, what we saw yesterday is a bug in solara. It also explains why you did not see this happening in the notebook.