### PR TITLE
refactor: change the order of importing/executing solara script

### DIFF
--- a/solara/server/flask.py
+++ b/solara/server/flask.py
@@ -291,3 +291,7 @@ if has_solara_enterprise:
 
 if __name__ == "__main__":
     app.run(debug=False, port=8765)
+
+# we can only call this at the module level, which means that the solara script cannot import this
+# module. This is a difference with the asgi standard, which provides a lifecycle hook (see starlette.py)
+appmod.ensure_apps_initialized()

--- a/solara/server/jupyter/server_extension.py
+++ b/solara/server/jupyter/server_extension.py
@@ -14,6 +14,7 @@ def _load_jupyter_server_extension(server_app):
     import solara.server.app
 
     solara.server.app.apps["__default__"] = solara.server.app.AppScript("solara.server.jupyter.solara:Page")
+    solara.server.app.apps["__default__"].init()
 
     web_app = server_app.web_app
 

--- a/solara/server/patch.py
+++ b/solara/server/patch.py
@@ -1,4 +1,3 @@
-import functools
 import logging
 import os
 import pdb
@@ -14,6 +13,8 @@ import IPython.display
 import ipywidgets
 import ipywidgets.widgets.widget_output
 from IPython.core.interactiveshell import InteractiveShell
+
+import solara
 
 from . import app, kernel_context, reload, settings
 from .utils import pdb_guard
@@ -354,24 +355,7 @@ def patch_ipyreact():
     ipyreact.importmap._update_import_map = lambda: None
 
 
-def once(f):
-    called = False
-    return_value = None
-
-    @functools.wraps(f)
-    def wrapper():
-        nonlocal called
-        nonlocal return_value
-        if called:
-            return return_value
-        called = True
-        return_value = f()
-        return return_value
-
-    return wrapper
-
-
-@once
+@solara.util.once
 def patch_matplotlib():
     import matplotlib
     import matplotlib._pylab_helpers

--- a/solara/server/server.py
+++ b/solara/server/server.py
@@ -282,6 +282,7 @@ def read_root(
             return content
 
     default_app = app.apps["__default__"]
+    default_app.check()
     routes = default_app.routes
     router = solara.routing.Router(path, routes)
     if not router.possible_match:

--- a/solara/server/starlette.py
+++ b/solara/server/starlette.py
@@ -572,6 +572,7 @@ class StaticCdn(StaticFilesOptionalAuth):
 
 
 def on_startup():
+    appmod.ensure_apps_initialized()
     # TODO: configure and set max number of threads
     # see https://github.com/encode/starlette/issues/1724
     telemetry.server_start()

--- a/solara/test/pytest_plugin.py
+++ b/solara/test/pytest_plugin.py
@@ -150,6 +150,7 @@ def solara_app(solara_server):
             solara.server.app.apps["__default__"].close()
         if isinstance(app, str):
             app = solara.server.app.AppScript(app)
+            app.init()
         used_app = app
         solara.server.app.apps["__default__"] = app
         try:

--- a/solara/util.py
+++ b/solara/util.py
@@ -1,5 +1,6 @@
 import base64
 import contextlib
+import functools
 import gzip
 import hashlib
 import json
@@ -328,3 +329,20 @@ def is_running_in_vscode():
 
 def is_running_in_voila():
     return os.environ.get("SERVER_SOFTWARE", "").startswith("voila")
+
+
+def once(f):
+    called = False
+    return_value = None
+
+    @functools.wraps(f)
+    def wrapper():
+        nonlocal called
+        nonlocal return_value
+        if called:
+            return return_value
+        called = True
+        return_value = f()
+        return return_value
+
+    return wrapper

--- a/tests/unit/app_test.py
+++ b/tests/unit/app_test.py
@@ -23,6 +23,7 @@ reload.reloader.start()
 def test_notebook_element(kernel_context, no_kernel_context):
     name = str(HERE / "solara_test_apps" / "notebookapp_element.ipynb")
     app = AppScript(name)
+    app.init()
     try:
         with kernel_context:
             el = app.run()
@@ -36,6 +37,7 @@ def test_notebook_element(kernel_context, no_kernel_context):
 def test_notebook_component(kernel_context, no_kernel_context):
     name = str(HERE / "solara_test_apps" / "notebookapp_component.ipynb")
     app = AppScript(name)
+    app.init()
     try:
         with kernel_context:
             el = app.run()
@@ -49,6 +51,7 @@ def test_notebook_component(kernel_context, no_kernel_context):
 def test_notebook_widget(kernel_context, no_kernel_context):
     name = str(HERE / "solara_test_apps" / "notebookapp_widget.ipynb")
     app = AppScript(name)
+    app.init()
     try:
         with kernel_context:
             el = app.run()
@@ -66,6 +69,7 @@ def test_notebook_widget(kernel_context, no_kernel_context):
 def test_sidebar_single_file_multiple_routes(kernel_context, no_kernel_context):
     name = str(HERE / "solara_test_apps" / "single_file_multiple_routes.py")
     app = AppScript(name)
+    app.init()
     try:
         with kernel_context:
             c = app.run()
@@ -79,6 +83,7 @@ def test_sidebar_single_file_multiple_routes(kernel_context, no_kernel_context):
 def test_sidebar_single_file(kernel_context, no_kernel_context):
     name = str(HERE / "solara_test_apps" / "single_file.py")
     app = AppScript(name)
+    app.init()
     try:
         with kernel_context:
             c = app.run()
@@ -92,6 +97,7 @@ def test_sidebar_single_file(kernel_context, no_kernel_context):
 def test_sidebar_single_file_missing(kernel_context, no_kernel_context):
     name = str(HERE / "solara_test_apps" / "single_file.py:doesnotexist")
     app = AppScript(name)
+    app.init()
     try:
         with kernel_context:
             c = app.run()
@@ -119,6 +125,7 @@ def test_watch_module_reload(tmpdir, kernel_context, extra_include_path, no_kern
         logger.info("wrote files")
 
         app = AppScript(f"{py_file}")
+        app.init()
         try:
             result = app.run()
             assert "somemod" in sys.modules

--- a/tests/unit/autorouting_test.py
+++ b/tests/unit/autorouting_test.py
@@ -267,6 +267,7 @@ def test_routes_regular_widgets():
 def test_single_file_routes_as_file(kernel_context, no_kernel_context):
     name = str(HERE / "solara_test_apps" / "single_file_routes.py")
     app = AppScript(name)
+    app.init()
     assert len(app.routes) == 2
     assert app.routes[0].path == "/"
     assert app.routes[0].layout is not None
@@ -289,6 +290,7 @@ def test_single_file_routes_as_file(kernel_context, no_kernel_context):
 def test_single_file_routes_as_module(kernel_context, no_kernel_context, extra_include_path):
     with extra_include_path(HERE / "solara_test_apps"):
         app = AppScript("single_file_routes")
+        app.init()
         assert len(app.routes) == 2
         assert app.routes[0].path == "/"
         assert app.routes[0].layout is not None

--- a/tests/unit/reload_test.py
+++ b/tests/unit/reload_test.py
@@ -24,6 +24,7 @@ def test_script_reload_component(tmpdir, kernel_context, extra_include_path, no_
             app = AppScript(f"{target.stem}")
         else:
             app = AppScript(f"{target}")
+        app.init()
         try:
             app.run()
             callback = app.routes[0].module.test_callback  # type: ignore

--- a/tests/unit/toestand_test.py
+++ b/tests/unit/toestand_test.py
@@ -1193,6 +1193,7 @@ def test_computed_reload(no_kernel_context):
     # the reactive variable id's
     solara.toestand.KernelStore._type_counter.clear()
     app = AppScript(name)
+    app.init()
     try:
         assert len(app.routes) == 1
         route = app.routes[0]


### PR DESCRIPTION
We now do this after solara.server.starlette is imported, making the starlette app variable accessible from the solara script or module. This makes it easier to add custom endpoints to a solara app.

This will make the script in #841 much simpler, as well as #670