### PR TITLE
fix: close kernels on shutdown of asgi/starlette server

### DIFF
--- a/solara/server/starlette.py
+++ b/solara/server/starlette.py
@@ -576,6 +576,12 @@ def on_startup():
 
 
 def on_shutdown():
+    # shutdown all kernels
+    for context in list(kernel_context.contexts.values()):
+        try:
+            context.close()
+        except:  # noqa
+            logger.exception("error closing kernel on shutdown")
     telemetry.server_stop()
 
 


### PR DESCRIPTION
Since Flask does not have lifecycle management, we cannot do the same for Flask.

We could implement this for Flask by listening to signals, but that's not the responsibility of the solara server.

Fixes #929