### PR TITLE
fix: send str using send_bytes in websocket for starlette server

### DIFF
--- a/solara/server/starlette.py
+++ b/solara/server/starlette.py
@@ -148,7 +148,7 @@ class WebsocketWrapper(websocket.WebsocketWrapper):
         if self.portal is None:
             asyncio.ensure_future(self.ws.close())
         else:
-            self.portal.call(self.ws.close)  # type: ignore
+            self.portal.call(self.ws.close)
 
     def send_text(self, data: str) -> None:
         if self.portal is None:
@@ -159,7 +159,7 @@ class WebsocketWrapper(websocket.WebsocketWrapper):
             if settings.main.experimental_performance:
                 self.to_send.append(data)
             else:
-                self.portal.call(self._send_text_exc, data)  # type: ignore
+                self.portal.call(self._send_bytes_exc, data)
 
     def send_bytes(self, data: bytes) -> None:
         if self.portal is None:
@@ -170,7 +170,7 @@ class WebsocketWrapper(websocket.WebsocketWrapper):
             if settings.main.experimental_performance:
                 self.to_send.append(data)
             else:
-                self.portal.call(self._send_bytes_exc, data)  # type: ignore
+                self.portal.call(self._send_bytes_exc, data)
 
     async def receive(self):
         if self.portal is None:
@@ -178,9 +178,9 @@ class WebsocketWrapper(websocket.WebsocketWrapper):
         else:
             if hasattr(self.portal, "start_task_soon"):
                 # version 3+
-                fut = self.portal.start_task_soon(self.ws.receive)  # type: ignore
+                fut = self.portal.start_task_soon(self.ws.receive)
             else:
-                fut = self.portal.spawn_task(self.ws.receive)  # type: ignore
+                fut = self.portal.spawn_task(self.ws.receive)
 
             message = await asyncio.wrap_future(fut)
         if "text" in message:

--- a/solara/server/starlette.py
+++ b/solara/server/starlette.py
@@ -159,7 +159,7 @@ class WebsocketWrapper(websocket.WebsocketWrapper):
             if settings.main.experimental_performance:
                 self.to_send.append(data)
             else:
-                self.portal.call(self._send_bytes_exc, data)  # type: ignore
+                self.portal.call(self._send_text_exc, data)  # type: ignore
 
     def send_bytes(self, data: bytes) -> None:
         if self.portal is None:


### PR DESCRIPTION
.send_text called .send_bytes

Bug introduced in #400, released since v1.25.0

This showed up when deploying with Modal with the error:
```
Traceback (most recent call last):
  File "/pkg/modal/_runtime/container_io_manager.py", line 764, in handle_input_exception
    yield
  File "/pkg/modal/_container_entrypoint.py", line 210, in run_input_async
    await generator_output_task  # Wait to finish sending generator outputs.
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/pkg/synchronicity/async_wrap.py", line 29, in wrapper
    return await user_wrapper(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/pkg/synchronicity/async_wrap.py", line 29, in wrapper
    return await user_wrapper(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/pkg/synchronicity/async_wrap.py", line 32, in wrapper
    raise uc_exc.exc
  File "/pkg/modal/_runtime/container_io_manager.py", line 549, in generator_output_task
    messages_bytes = [serialize_data_format(message, data_format)]
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/pkg/modal/_serialization.py", line 346, in serialize_data_format
    return _serialize_asgi(obj).SerializeToString(deterministic=True)
           ^^^^^^^^^^^^^^^^^^^^
  File "/pkg/modal/_serialization.py", line 217, in _serialize_asgi
    websocket_send=api_pb2.Asgi.WebsocketSend(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: expected bytes, str found
```

cc @Ben-Epstein 
