### PR TITLE
fix: SelectMultiple is not using dense option

### DIFF
--- a/solara/components/select.py
+++ b/solara/components/select.py
@@ -174,7 +174,7 @@ def SelectMultiple(
             items=all_values,
             label=label,
             multiple=True,
-            dense=False,
+            dense=dense,
             disabled=disabled,
             class_=class_,
             style_=style_flat,


### PR DESCRIPTION
### All Submissions:

* [x] I installed `pre-commit` prior to committing my changes (see [development setup docs](https://solara.dev/documentation/advanced/development/setup#contributing)).
* [x] My commit messages conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
* [x] My PR title conforms to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
* [x] I linked to any relevant: issues https://github.com/widgetti/solara/issues/938

### Description of changes

dense option was hard coded to False in SelectMultiple component. I think it is a mistake. I've changed it so that the dense option can be passed to reacton.
