### PR TITLE
fix!: unexpected margins on widgets

### DIFF
--- a/solara/server/assets/style.css
+++ b/solara/server/assets/style.css
@@ -158,6 +158,11 @@ div.highlight {
   font-family: var(--jp-ui-font-family);
 }
 
+.jupyter-widgets.solara-image {
+  /* Remove default margin from the ipywidgets image, it caused unexpected (and often difficult to change) visual behaviour */
+  margin: 0;
+}
+
 
 :root {
   --jp-warn-color0: var(--md-orange-700);


### PR DESCRIPTION
### All Submissions:

<!-- You can erase any parts not applicable to your Pull Request. -->

* [x] I installed `pre-commit` prior to committing my changes (see [development setup docs](https://solara.dev/documentation/advanced/development/setup#contributing)).
* [x] My commit messages conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
* [x] My PR title conforms to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
* [x] I linked to any relevant issues.

### Description of changes

Fixes https://github.com/widgetti/solara/issues/691.

A visually breaking change to the way widgets are rendered. By default they get a margin as determined by `--jp-widgets-margin: 2px`, but I think in combination with Vuetify this is often unexpected.
Overall I don't think there would be very many cases where this would be worse than the current implementation.

In the end I think the underlying issue is that ipywidgets based components are quite difficult to style, since they don't accept a style argument like we usually use.

However, I get if we prefer to stick as close as possible to vanilla jupyter widgets settings, in which case we could do one of two other things:
* Use `solara.HTML(tag='img', ...)` in our Image component, as opposed to `ipywidgets.Image`
* Scope the change to just Solara's Image component via a custom class

@maartenbreddels and @mariobuikhuizen (and others) feel free to offer your opinions on the matter.

<!-- Describe the changes in this PR -->
