### PR TITLE
fix: widget-box would hide overflowing content

### DIFF
--- a/solara/server/assets/style.css
+++ b/solara/server/assets/style.css
@@ -143,6 +143,14 @@ div.highlight {
   display: none !important;
 }
 
+.widget-box, /* </DEPRECATED> */
+.jupyter-widget-box {
+  box-sizing: border-box;
+  display: flex;
+  margin: 0;
+  overflow: auto;
+}
+
 .lm-AccordionPanel[data-orientation='horizontal'] > .lm-AccordionPanel-title {
   /* Title is rotated for horizontal accordion panel using CSS */
   display: block;


### PR DESCRIPTION
### All Submissions:

<!-- You can erase any parts not applicable to your Pull Request. -->

* [x] I installed `pre-commit` prior to committing my changes (see [development setup docs](https://solara.dev/documentation/advanced/development/setup#contributing)).
* [x] My commit messages conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
* [x] My PR title conforms to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
* [x] I linked to any relevant issues.

### Description of changes

Add missing CSS for `widget-box` that ensures overflow is correctly shown

<!-- Describe the changes in this PR -->
