### PR TITLE
fix: allow usage of use_reactive from outside kernel_context

### DIFF
--- a/solara/toestand.py
+++ b/solara/toestand.py
@@ -225,6 +225,9 @@ class ValueBase(Generic[T]):
 
         return cast(Callable[[TS], None], setter)
 
+    def _check_mutation(self):
+        pass
+
 
 # the default store for now, stores in a global dict, or when in a solara
 # context, in the solara user context
@@ -316,7 +319,8 @@ def _is_internal_module(file_name: str):
     return (
         file_name_parts[-2:] == ["solara", "toestand.py"]
         or file_name_parts[-2:] == ["solara", "reactive.py"]
-        or file_name_parts[-2:] == ["solara", "use_reactive.py"]
+        or file_name_parts[-2:] == ["solara", "_stores.py"]
+        or file_name_parts[-3:] == ["solara", "hooks", "use_reactive.py"]
         or file_name_parts[-2:] == ["reacton", "core.py"]
         # If we use SomeClass[K](...) we go via the typing module, so we need to skip that as well
         or (file_name_parts[-2].startswith("python") and file_name_parts[-1] == "typing.py")


### PR DESCRIPTION
If the reactive variable return from use_reactive is set from outside a kernel_context, the reactive variable would not be set.

This bug is demonstrated in:
  https://py.cafe/maartenbreddels/solara-shared-state

Where we had to force use_trait_observe to use use_state in of use_reactive.
