### PR TITLE
Docs fix for self-hosted solara instances

### DIFF
--- a/solara/website/pages/documentation/getting_started/content/07-deploying/10-self-hosted.md
+++ b/solara/website/pages/documentation/getting_started/content/07-deploying/10-self-hosted.md
@@ -255,7 +255,7 @@ server {
 An alternative to using the `X-Script-Name` header with uvicorn, would be to pass the `--root-path` flag, e.g.:
 
 ```
-$ SOLARA_APP=sol.py uvicorn --workers 1 --root-path /solara -b 0.0.0.0:8765 solara.server.starlette:app
+$ SOLARA_APP=sol.py uvicorn --workers 2 --root-path /solara --host 0.0.0.0 --port 8765 solara.server.starlette:app
 ```
 
 In the case of an [OAuth setup](https://solara.dev/documentation/advanced/enterprise/oauth) it is important to make sure that the `X-Forwarded-Proto` and `Host` headers are forwarded correctly.


### PR DESCRIPTION
### Description of changes

This is a fix for two bugs in the uvicorn call in the self-hosted docs. The syntax in this call follows the conventions for `gunicorn` rather than `uvicorn`, so I've added the `host` and `port` flags needed to be specified. 

I was also surprised and confused that using one worker caused the server to shutdown when connections were closed. I've changed to `workers = 2` in the docs to prevent similar confusion.