### PR TITLE
fix: incorrect type hints on memoize `key` #958

### DIFF
--- a/solara/cache.py
+++ b/solara/cache.py
@@ -1,3 +1,4 @@
+from collections.abc import Hashable
 import hashlib
 import inspect
 import logging
@@ -7,7 +8,6 @@ from typing import (
     Callable,
     Dict,
     Generic,
-    Hashable,
     MutableMapping,
     Optional,
     TypeVar,
@@ -51,6 +51,7 @@ if has_cachetools:
     class Memory(cachetools.LRUCache):
         def __init__(self, max_items=solara.settings.cache.memory_max_items):
             super().__init__(maxsize=max_items)
+
 else:
 
     class Memory(dict):  # type: ignore

--- a/solara/cache.py
+++ b/solara/cache.py
@@ -7,6 +7,7 @@ from typing import (
     Callable,
     Dict,
     Generic,
+    Hashable,
     MutableMapping,
     Optional,
     TypeVar,
@@ -64,7 +65,7 @@ def _default_key(*args, **kwargs):
 
 
 class MemoizedFunction(Generic[P, R]):
-    def __init__(self, function: Callable[P, R], key: Callable[P, R], storage: Optional[Storage], allow_nonlocals=False):
+    def __init__(self, function: Callable[P, R], key: Callable[P, Hashable], storage: Optional[Storage], allow_nonlocals=False):
         self.function = function
         f: Callable = self.function
         if not allow_nonlocals:
@@ -170,7 +171,7 @@ def memoize(
 @overload
 def memoize(
     function: None = None,
-    key: Callable[P, R] = ...,
+    key: Callable[P, Hashable] = ...,
     storage: Optional[Storage] = None,
     allow_nonlocals=False,
 ) -> Callable[[Callable[P, R]], MemoizedFunction[P, R]]: ...
@@ -187,7 +188,7 @@ def memoize(
 
 def memoize(
     function: Union[None, Callable[P, R]] = None,
-    key: Union[None, Callable[P, R]] = None,
+    key: Union[None, Callable[P, Hashable]] = None,
     storage: Optional[Storage] = None,
     allow_nonlocals: bool = False,
 ) -> Union[Callable[[Callable[P, R]], MemoizedFunction[P, R]], MemoizedFunction[P, R]]:
@@ -249,7 +250,7 @@ def memoize(
     def wrapper(func: Callable[P, R]) -> MemoizedFunction[P, R]:
         return MemoizedFunction[P, R](
             func,
-            cast(Callable[P, R], key or _default_key),
+            cast(Callable[P, Hashable], key or _default_key),
             storage,
             allow_nonlocals,
         )


### PR DESCRIPTION
### All Submissions:

<!-- You can erase any parts not applicable to your Pull Request. -->

* [x] I installed `pre-commit` prior to committing my changes (see [development setup docs](https://solara.dev/documentation/advanced/development/setup#contributing)).
* [ ] My commit messages conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). _(Future commits will, oops)_
* [x] My PR title conforms to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
* [x] I linked to any relevant issues.

### Description of changes
Type hints now make code editors happy when caching non-hashable function inputs (fixes #958)