### PR TITLE
ci, docs: mark fief oauth support as unmaintained, disable test

### DIFF
--- a/solara/website/pages/documentation/advanced/content/30-enterprise/10-oauth.md
+++ b/solara/website/pages/documentation/advanced/content/30-enterprise/10-oauth.md
@@ -56,7 +56,7 @@ def Page():
 ```
 ## How to configure OAuth
 
-Solara supports the following OAuth providers: [Auth0](https://auth0.com/) and [Fief](https://fief.dev/).
+Solara currently supports [Auth0](https://auth0.com/) as the sole OAuth provider. [Fief](https://fief.dev/) support is **deprecated** (currently untested), but is not planned to be removed. If you would like support for a different provider to be added, [contact us](/contact)
 
 
 ### Configuring Auth0
@@ -134,6 +134,8 @@ To create your own Auth0 application, follow these steps:
 
 ### Configuring Fief
 
+##### Note: Fief support is not maintained or tested. If you would like Fief to be supported, feel free to [contact us](/contact)
+
 You can also configure Solara to use our Fief test account. To do this, you need to set the following environment variables:
 
 ```bash
@@ -164,7 +166,7 @@ Solara provides two convenient components for creating a user interface for logi
  1. [Avatar](/documentation/components/enterprise/avatar): This component shows the user's avatar.
  2. [AvatarMenu](/documentation/components/enterprise/avatar_menu): This component shows a menu with the user's avatar and a logout button.
 
- ## Python version support
+## Python version support
 
 Please note that Python 3.6 is not supported for Solara OAuth.
 

--- a/tests/integration/enterprise/oauth_test.py
+++ b/tests/integration/enterprise/oauth_test.py
@@ -38,7 +38,7 @@ def test_oauth_from_app_auth0(page_session: playwright.sync_api.Page, solara_ser
         page_session.locator("_vue=v-btn >> text=Login").wait_for()
 
 
-@pytest.mark.skipif(not bool(os.environ.get("FIEF_PASSWORD")), reason="FIEF_PASSWORD not set")
+@pytest.mark.skip(reason="Fief support is deprecated for now")
 def test_oauth_from_app_fief(page_session: playwright.sync_api.Page, solara_server, solara_app):
     with solara_app("solara.website.pages"):
         settings.main.base_url = ""


### PR DESCRIPTION
### All Submissions:

<!-- You can erase any parts not applicable to your Pull Request. -->

* [x] I installed `pre-commit` prior to committing my changes (see [development setup docs](https://solara.dev/documentation/advanced/development/setup#contributing)).
* [x] My commit messages conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
* [x] My PR title conforms to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
* [x] I linked to any relevant issues.

### Changes to / New Features:

* [x] I included docs for (the changes to) my feature.
* [x] I wrote tests for (the changes to) my feature.

### Description of changes

Fief sunset Fief cloud, which we were using to support our tests, see [here](https://www.fief.dev/blog/a-new-step-in-fief-s-journey). Since supporting Fief is not a big priority right now, we mark it deprecated / unmaintained. As remarked in the docs, we aren't planning on removing support.

<!-- Describe the changes in this PR -->
