### PR TITLE
fix: restore kernel context on reactive event handler

### DIFF
--- a/solara/toestand.py
+++ b/solara/toestand.py
@@ -239,7 +239,7 @@ class KernelStore(ValueBase[S], ABC):
     _type_counter: Dict[Any, int] = defaultdict(int)
     scope_lock = threading.RLock()
 
-    def __init__(self, key=None, equals: Callable[[Any, Any], bool] = equals_extra):
+    def __init__(self, key: str, equals: Callable[[Any, Any], bool] = equals_extra):
         super().__init__(equals=equals)
         self.storage_key = key
         self._global_dict = {}


### PR DESCRIPTION
If a reactive variable was set from a different (or no) kernel context,
the event handler would not restore the kernel context that was
active when the event handler was registered.

Fixes https://github.com/widgetti/solara/issues/961