### PR TITLE
fix: automatically init app if not intialized yet

### DIFF
--- a/solara/server/app.py
+++ b/solara/server/app.py
@@ -90,6 +90,7 @@ class AppScript:
             self.path = Path(spec.origin)
             self.directory = self.path.parent
         self._initialized = False
+        self._lock = threading.Lock()
 
     def init(self):
         try:
@@ -225,7 +226,9 @@ class AppScript:
 
     def check(self):
         if not self._initialized:
-            raise RuntimeError("Call solara.server.app.ensure_apps_initialized() first")
+            with self._lock:
+                if not self._initialized:
+                    self.init()
 
     def run(self):
         self.check()

--- a/solara/test/pytest_plugin.py
+++ b/solara/test/pytest_plugin.py
@@ -144,13 +144,14 @@ def solara_app(solara_server):
     used_app = None
 
     @contextlib.contextmanager
-    def run(app: Union[solara.server.app.AppScript, str]):
+    def run(app: Union[solara.server.app.AppScript, str], init=True):
         nonlocal used_app
         if "__default__" in solara.server.app.apps:
             solara.server.app.apps["__default__"].close()
         if isinstance(app, str):
             app = solara.server.app.AppScript(app)
-            app.init()
+            if init:
+                app.init()
         used_app = app
         solara.server.app.apps["__default__"] = app
         try:

--- a/tests/integration/starlette_test.py
+++ b/tests/integration/starlette_test.py
@@ -45,7 +45,7 @@ def test_starlette_mount(page_session: playwright.sync_api.Page, solara_app, ext
         server = solara.server.starlette.ServerStarlette(port=port, starlette_app=starlette_app)
         server.serve_threaded()
         server.wait_until_serving()
-        with extra_include_path(HERE), solara_app("starlette_test"):
+        with extra_include_path(HERE), solara_app("starlette_test", init=False):
             page_session.goto(f"{server.base_url}/solara_mount/")
             page_session.locator("text=Mounted in starlette").wait_for()
     finally:


### PR DESCRIPTION
https://github.com/widgetti/solara/pull/924 broke cases where solara was mounted in starlette or fastapi as a app, because the lifecycle method are not called in this case.

