### PR TITLE
fix: get_ipython should dispatch to original if not in virtual kernel

### DIFF
--- a/solara/server/patch.py
+++ b/solara/server/patch.py
@@ -174,6 +174,8 @@ def display_solara(
 # if display_id:
 #     return DisplayHandle(display_id)
 
+get_ipython_original = IPython.get_ipython
+
 
 def get_ipython():
     if kernel_context.has_current_context():
@@ -181,7 +183,7 @@ def get_ipython():
         our_fake_ipython = FakeIPython(context)
         return our_fake_ipython
     else:
-        return None
+        return get_ipython_original()
 
 
 class context_dict(MutableMapping):


### PR DESCRIPTION
We do this with all the other methods, so it makes sense to do it here as well. This should fix #965 and is an alternative to https://github.com/astropy/astropy/pull/17683

Easy way to test/confirm:
```
python -c "import solara.server.app; import astropy;
```