### PR TITLE
fix: mirror matplotlib bug in our virtual kernel patch

### DIFF
--- a/solara/server/patch.py
+++ b/solara/server/patch.py
@@ -407,6 +407,13 @@ def patch_matplotlib():
             # same as _get
             return self[key]
 
+        def clear(self):
+            # in matplotlib .clear is effectively a no-op
+            # see https://github.com/matplotlib/matplotlib/issues/25855
+            pass
+            # in the future, we may want to clear the context dict if this is fixed
+            # self._get_context_dict().clear()
+
         def _get_context_dict(self) -> dict:
             if not self._was_initialized:
                 # since we monkey patch the class after __init__ was called

--- a/tests/unit/matplotlib_test.py
+++ b/tests/unit/matplotlib_test.py
@@ -1,8 +1,15 @@
 from matplotlib.figure import Figure
+from matplotlib import pyplot as plt
+import matplotlib
+from pathlib import Path
+
 
 import solara
 import solara.server.patch
 from solara.server import kernel
+from solara.server.app import AppScript
+
+HERE = Path(__file__).parent
 
 
 @solara.component
@@ -75,3 +82,17 @@ def test_pylab(no_kernel_context):
         cleanup()
         context_1.close()
         context_2.close()
+
+
+def test_clear_bug_in_matplotlib(no_kernel_context, kernel_context):
+    name = str(HERE / "solara_test_apps" / "single_file.py")
+    app = AppScript(name)
+    app.init()
+    try:
+        with kernel_context:
+            # see https://github.com/matplotlib/matplotlib/issues/25855
+            with plt.style.context({}, after_reset=True):
+                pass
+            matplotlib.get_backend().lower()
+    finally:
+        app.close()


### PR DESCRIPTION
Our .clear on RcParams was working, while matplotlib was a no-op:
   https://github.com/matplotlib/matplotlib/issues/25855

We now mirror this behavior.

Fixes #606

