### PR TITLE
feat: improve customization of filedrop components

### DIFF
--- a/solara/components/file_drop.vue
+++ b/solara/components/file_drop.vue
@@ -1,17 +1,28 @@
 <template>
-  <div ref="dropzone" class="solara-file-drop" effectAllowed="move">
-    <template v-if="file_info && file_info.length > 0">
-      <template v-if="multiple">
-        <div v-for="file in file_info">
-          {{ file.name }}
-        </div>
-      </template>
-      <template v-else>
-        {{ file_info[0].name }}
-      </template>
+  <div ref="dropzone" effectAllowed="move" style="position: relative;">
+    <div ref="dropIndicator" style="display: none; position: absolute; top: 0; left: 0; width: 100%; height: 100%; z-index: 31;">
+      <jupyter-widget v-if="file_hover_indicator" :widget="file_hover_indicator"></jupyter-widget>
+    </div>
+    <template v-if="children && children.length > 0">
+      <jupyter-widget v-for="child in children" :widget="child" :key="child.model_id"></jupyter-widget>
     </template>
     <template v-else>
-      {{ label }}
+      <!-- Default content -->
+       <div class="solara-file-drop">
+        <template v-if="file_info && file_info.length > 0">
+          <template v-if="multiple">
+            <div v-for="file in file_info">
+              {{ file.name }}
+            </div>
+          </template>
+          <template v-else>
+            {{ file_info[0].name }}
+          </template>
+        </template>
+        <template v-else>
+          {{ label }}
+        </template>
+      </div>
     </template>
   </div>
 </template>
@@ -21,7 +32,12 @@ module.exports = {
   mounted() {
     this.chunk_size = 2 * 1024 * 1024;
     this.$refs.dropzone.addEventListener('dragover', event => {
-      event.preventDefault();
+      this.$refs.dropIndicator.style.display = 'unset';
+    });
+    this.$refs.dropzone.addEventListener('dragleave', event => {
+      if (!event.relatedTarget || !this.$refs.dropzone.contains(event.relatedTarget)) {
+        this.$refs.dropIndicator.style.display = 'none';
+      }
     });
 
     this.$refs.dropzone.addEventListener('drop', async event => {

--- a/solara/website/pages/documentation/components/input/file_drop.py
+++ b/solara/website/pages/documentation/components/input/file_drop.py
@@ -74,3 +74,27 @@ __doc__ += "# FileDrop"
 __doc__ += apidoc(solara.FileDrop.f)  # type: ignore
 __doc__ += "# FileDropMultiple"
 __doc__ += apidoc(solara.FileDropMultiple.f)  # type: ignore
+__doc__ += """# Customization Example
+
+```solara
+import solara
+
+@solara.component
+def CustomHoverIndicator():
+    style = {"height": "100%", "width": "100%", "align-items": "center", "border": "2px dashed limegreen", "opacity": "0.85"}
+    with solara.Row(justify="center", style=style):
+        solara.HTML(tag="h3", unsafe_innerHTML="Drop file here")
+        solara.SpinnerSolara()
+
+@solara.component
+def Page():
+    number_of_files = solara.use_reactive(1)
+
+    with solara.FileDropMultiple(file_hover_indicator=CustomHoverIndicator()):
+        with solara.Card("Upload your file(s) here"):
+            solara.InputInt("Number of files", value=number_of_files)
+            for i in range(number_of_files.value):
+                solara.InputText("File name")
+
+```
+"""


### PR DESCRIPTION
### All Submissions:

<!-- You can erase any parts not applicable to your Pull Request. -->

* [x] I installed `pre-commit` prior to committing my changes (see [development setup docs](https://solara.dev/documentation/advanced/development/setup#contributing)).
* [x] My commit messages conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
* [x] My PR title conforms to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
* [x] I linked to any relevant issues.

### Changes to / New Features:

* [x] I included docs for (the changes to) my feature.

### Description of changes

Includes two changes:
- Allows custom children to be passed to FileDrop components to override the default looks
- Allows a custom hover indicator

Edit:  apologies for the monstrous branch name (again)