### PR TITLE
fix: do not call use_side_effect, which is deprecated

### DIFF
--- a/solara/components/dataframe.py
+++ b/solara/components/dataframe.py
@@ -76,7 +76,7 @@ def Table(df, n=5):
             output_real.outputs = tuple()
             output_real.append_display_data(df)
 
-    solara.use_side_effect(output)
+    solara.use_effect(output)
     return output_c
 
 

--- a/solara/components/file_drop.py
+++ b/solara/components/file_drop.py
@@ -58,7 +58,7 @@ def _FileDrop(
 
         set_wired_files(cast(typing.List[FileInfo], real.get_files()))
 
-    solara.use_side_effect(wire_files, [file_info])
+    solara.use_effect(wire_files, [file_info])
 
     def handle_file(cancel: threading.Event):
         if not wired_files:

--- a/solara/website/pages/documentation/examples/ipycanvas.py
+++ b/solara/website/pages/documentation/examples/ipycanvas.py
@@ -43,7 +43,7 @@
 #                 radius = width // 3
 #                 polygon(canvas, width // 2, height // 2, radius * radius_inner / 100, radius * radius_outer / 100, n_points)
 
-#         solara.use_side_effect(real_drawing, [fill, stroke, line_width, n_points, view_count, radius_inner, radius_outer])
+#         solara.use_effect(real_drawing, [fill, stroke, line_width, n_points, view_count, radius_inner, radius_outer])
 #         canvas_element = c.Canvas(width=width, height=height)
 
 #     return main


### PR DESCRIPTION
This can trigger pytest failures in situations where warnings are considered errors.

cc @rosteen 
