### PR TITLE
fix: allow calling async tasks from threaded tasks

### DIFF
--- a/solara/server/kernel_context.py
+++ b/solara/server/kernel_context.py
@@ -77,6 +77,7 @@ class VirtualKernelContext:
     closed_event: threading.Event = dataclasses.field(default_factory=threading.Event)
     _on_close_callbacks: List[Callable[[], None]] = dataclasses.field(default_factory=list)
     lock: threading.RLock = dataclasses.field(default_factory=threading.RLock)
+    event_loop: asyncio.AbstractEventLoop = dataclasses.field(default_factory=asyncio.get_event_loop)
 
     def __post_init__(self):
         with self:


### PR DESCRIPTION
Instead of assuming an event loop to exist, we use the event loop of the main thread in solara server (the one that starlette created for the websocket).
In the case of IPython/Jupyter, we use the main event loop.
