### PR TITLE
fix: correctly handle expected websocket errors instead of logging

### DIFF
--- a/solara/server/kernel.py
+++ b/solara/server/kernel.py
@@ -227,8 +227,10 @@ def send_websockets(websockets: Set[websocket.WebsocketWrapper], binary_msg):
             logger.exception("Error sending message: %s, closing websocket", e)
             try:
                 ws.close()
-            except Exception as e:  # noqa
-                logger.exception("Error closing websocket: %s", e)
+            except websocket.WebSocketDisconnect:
+                pass  # was already closed, which triggered the original exception
+            except Exception as e2:  # noqa
+                logger.exception("Error closing websocket: %s %s", e, e2)
             try:
                 # websocket can be modified by another thread
                 websockets.remove(ws)

--- a/tests/integration/lifecycle_test.py
+++ b/tests/integration/lifecycle_test.py
@@ -45,9 +45,9 @@ def test_kernel_lifecycle_close_single(
         assert len(contexts) == 1
         context = contexts[0]
         assert not context.closed_event.is_set()
+        page_session.wait_for_timeout(500)
         page_session.goto("about:blank")
-        page_session.wait_for_timeout(100)
-        assert context.closed_event.is_set()
+        assert context.closed_event.wait(timeout=20)
 
 
 @pytest.mark.skip(reason="This test is flaky, re-enable when we have a more stable solution")


### PR DESCRIPTION
There was one more runtimeerror we had to catch, and also during
closing the websocket we could have expected errors.

Fixes https://github.com/widgetti/solara/issues/1013