### PR TITLE
fix: follow asgi spec and also check if text or bytes are None (Modal fix)

### DIFF
--- a/solara/server/starlette.py
+++ b/solara/server/starlette.py
@@ -230,9 +230,9 @@ await to_thread.run_sync(my_update)
                 fut = self.portal.spawn_task(self.ws.receive)
 
             message = await asyncio.wrap_future(fut)
-        if "text" in message:
+        if message.get("text") is not None:
             return message["text"]
-        elif "bytes" in message:
+        elif message.get("bytes") is not None:
             return message["bytes"]
         elif message.get("type") == "websocket.disconnect":
             raise websocket.WebSocketDisconnect()


### PR DESCRIPTION
We assumed when the text or bytes were None that it was a missing value, but on Modal we do see a message like that, e.g.:
{'type': 'websocket.receive', 'bytes': b'...', 'text': None}}

See https://asgi.readthedocs.io/en/latest/specs/www.html#receive-receive-event which explain that None and missing are equivalent.