### PR TITLE
fix: display port in runtime error when server is running

### DIFF
--- a/solara/test/pytest_plugin.py
+++ b/solara/test/pytest_plugin.py
@@ -334,7 +334,7 @@ class ServerVoila(ServerBase):
 
     def serve(self):
         if self.has_started():
-            raise RuntimeError("Jupyter server already running, use lsof -i :{self.port} to find the process and kill it")
+            raise RuntimeError(f"Jupyter server already running, use lsof -i :{self.port} to find the process and kill it")
         cmd = (
             "voila --no-browser --VoilaTest.log_level=DEBUG --Voila.port_retries=0 --VoilaExecutor.timeout=240"
             f' --Voila.port={self.port} --show_tracebacks=True "{self.notebook_path}" --enable_nbextensions=True'


### PR DESCRIPTION
### All Submissions:

<!-- You can erase any parts not applicable to your Pull Request. -->

* [x] I installed `pre-commit` prior to committing my changes (see [development setup docs](https://solara.dev/documentation/advanced/development/setup#contributing)).
* [x] My commit messages conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
* [x] My PR title conforms to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
* [ ] I linked to any relevant issues.

### Changes to / New Features:

* [ ] I included docs for (the changes to) my feature.
* [ ] I wrote tests for (the changes to) my feature.

### Description of changes

Small PR - evaluates the port as port of the runtime error when server is running
