### PR TITLE
feat: add `on_layout_updated` to GridLayout

### DIFF
--- a/solara/widgets/vue/gridlayout.vue
+++ b/solara/widgets/vue/gridlayout.vue
@@ -11,6 +11,7 @@
             :vertical-compact="true"
             :margin="[10, 10]"
             :use-css-transforms="true"
+            @layout-updated="onLayoutUpdated"
     >
 
         <grid-item v-for="item in grid_layout"
@@ -48,6 +49,9 @@ module.exports = {
         resizedEvent(i, newH, newW, newHPx, newWPx) {
           // this will cause bqplot to layout itself
           window.dispatchEvent(new Event('resize'));
+        },
+        onLayoutUpdated(layout) {
+          this.layout_updated(layout);
         },
         import(deps) {
           return this.loadRequire().then(

--- a/solara/widgets/widgets.py
+++ b/solara/widgets/widgets.py
@@ -52,6 +52,11 @@ class GridLayout(v.VuetifyTemplate):
     draggable = traitlets.CBool(True).tag(sync=True)
     resizable = traitlets.CBool(True).tag(sync=True)
     cdn = traitlets.Unicode(None, allow_none=True).tag(sync=True)
+    on_layout_updated = traitlets.traitlets.Callable(None, allow_none=True)
+
+    def vue_layout_updated(self, *args):
+        if self.on_layout_updated is not None:
+            self.on_layout_updated(*args)
 
     @traitlets.default("cdn")
     def _cdn(self):


### PR DESCRIPTION
### All Submissions:

<!-- You can erase any parts not applicable to your Pull Request. -->

* [x] I installed `pre-commit` prior to committing my changes (see [development setup docs](https://solara.dev/documentation/advanced/development/setup#contributing)).
* [x] My commit messages conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
* [x] My PR title conforms to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
* [x] I linked to any relevant issues.

### Changes to / New Features:

* [ ] I included docs for (the changes to) my feature.
* [ ] I wrote tests for (the changes to) my feature.

### Description of changes

This PR adds an optional `on_layer_updated` trait to GridLayout which can be used to handle the event when the layout finally changes (i.e. when the "drag" of the items has ended). This could be desirable (see #1040) to use instead of the `on_grid_layout`, which triggers the event for every change when the drag is still ongoing.  

<!-- Describe the changes in this PR -->
