### PR TITLE
feat: warn if task is being called from a component

### DIFF
--- a/solara/tasks.py
+++ b/solara/tasks.py
@@ -868,17 +868,7 @@ def use_task(
     dependencies: Literal[None] = ...,
     raise_error=...,
     prefer_threaded=...,
-) -> Callable[[Callable[[], R]], "Task[[], R]"]: ...
-
-
-@overload
-def use_task(
-    f: Callable[[], R],
-    *,
-    dependencies: Literal[None] = ...,
-    raise_error=...,
-    prefer_threaded=...,
-) -> "Task[[], R]": ...
+) -> Callable[[Callable[P, R]], "Task[P, R]"]: ...
 
 
 @overload
@@ -901,13 +891,23 @@ def use_task(
 ) -> "Task[[], R]": ...
 
 
+@overload
 def use_task(
-    f: Union[None, Callable[[], R]] = None,
+    f: Callable[P, R],
+    *,
+    dependencies: Literal[None] = ...,
+    raise_error=...,
+    prefer_threaded=...,
+) -> "Task[P, R]": ...
+
+
+def use_task(
+    f: Union[None, Callable[P, R]] = None,
     *,
     dependencies: Union[None, List] = [],
     raise_error=True,
     prefer_threaded=True,
-) -> Union[Callable[[Callable[[], R]], "Task[[], R]"], "Task[[], R]"]:
+) -> Union[Callable[[Callable[P, R]], "Task[P, R]"], "Task[P, R]"]:
     """A hook that runs a function or coroutine function as a task and returns the result.
 
     Allows you to run code in the background, with the UI available to the user. This is useful for long running tasks,

--- a/solara/toestand.py
+++ b/solara/toestand.py
@@ -343,6 +343,7 @@ def _is_internal_module(file_name: str):
     return (
         file_name_parts[-2:] == ["solara", "toestand.py"]
         or file_name_parts[-2:] == ["solara", "reactive.py"]
+        or file_name_parts[-2:] == ["solara", "tasks.py"]
         or file_name_parts[-2:] == ["solara", "_stores.py"]
         or file_name_parts[-3:] == ["solara", "hooks", "use_reactive.py"]
         or file_name_parts[-2:] == ["reacton", "core.py"]


### PR DESCRIPTION
This is a footgun, and we should warn the user about it. Although task does kind of work from a component, it will lead to unexpected behavior, (e.g. the task will not be re-run when the task finishes, or errors).

So we now give a useful message to educate the user about this. Also, you can opt-out of this warning by passing
check_for_render_context=False.
By default we also skip the warning if the task is called from a use_memo function (since that is good behavior).

