### PR TITLE
fix: resolve logger warnings

### DIFF
--- a/solara/server/app.py
+++ b/solara/server/app.py
@@ -136,7 +136,7 @@ class AppScript:
             routes = solara.generate_routes_directory(self.path)
 
             if any(name for name in sys.modules.keys() if name.startswith(self.name)):
-                logger.warn(
+                logger.warning(
                     f"Directory {self.name} is also used as a package. This can cause modules to be loaded twice, and might "
                     "cause unexpected behavior. If you run solara from a different directory (e.g. the parent directory) you "
                     "can avoid this ambiguity."


### PR DESCRIPTION
### All Submissions:

<!-- You can erase any parts not applicable to your Pull Request. -->

* [x] I installed `pre-commit` prior to committing my changes (see [development setup docs](https://solara.dev/documentation/advanced/development/setup#contributing)).
* [x] My commit messages conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
* [x] My PR title conforms to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
* [ ] I linked to any relevant issues.

### Changes to / New Features:

* [ ] I included docs for (the changes to) my feature.
* [ ] I wrote tests for (the changes to) my feature.

### Description of changes
## PR Summary
This small PR migrates from the deprecated `logger.warn` to the recommended `logger.warning` method to solve:
```python
/tmp/solara/solara/server/app.py:139: DeprecationWarning: The 'warn' function is deprecated, use 'warning' instead
```
