### PR TITLE
chore(ci): skip pycafe workflow on forks

### DIFF
--- a/.github/workflows/pycafe.yml
+++ b/.github/workflows/pycafe.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   create-status:
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
### All Submissions:

<!-- You can erase any parts not applicable to your Pull Request. -->

* [x] I installed `pre-commit` prior to committing my changes (see [development setup docs](https://solara.dev/documentation/advanced/development/setup#contributing)).
* [x] My commit messages conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
* [x] My PR title conforms to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
* [ ] I linked to any relevant issues.

### Changes to / New Features:

Update pycafe workflow 

### Description of changes

Adding one line to check if the repository is a fork to skip the "PyCafe Playground Link" job. 

I did this because I was getting an email about the failure of this workflow on my fork on a daily basis. I then figured out I could disable it (manually), but this change will hopefully make it skippable automatically on forks. 