### PR TITLE
fix: FileBrowser could go two directories up if ".." was selected

### DIFF
--- a/solara/components/file_browser.py
+++ b/solara/components/file_browser.py
@@ -137,7 +137,9 @@ def FileBrowser(
             # if we select a file, we need to make sure the directory is correct
             # NOTE: although we expect a Path, abuse might make it a string
             if isinstance(selected_private, Path):
-                current_dir.value = selected_private.resolve().parent
+                # Note that we do not call .resolve() before using .parent, otherwise /some/path/.. will
+                # set the current directory to /, moving up two levels.
+                current_dir.value = selected_private.parent.resolve()
 
     solara.use_effect(sync_directory_from_selected, [selected_private])
 

--- a/tests/unit/file_browser_test.py
+++ b/tests/unit/file_browser_test.py
@@ -241,6 +241,7 @@ def test_file_browser_relative_path():
 def test_file_browser_programmatic_select():
     # using a reactive value to select a file
     selected = solara.reactive(cast(Optional[Path], None))
+    current_dir = solara.reactive(HERE.parent)
 
     @solara.component
     def Test():
@@ -258,6 +259,7 @@ def test_file_browser_programmatic_select():
     assert selected.value is None
 
     selected.value = None
+    rc.close()
 
     # passing selected as a value (non reactive)
     @solara.component
@@ -274,3 +276,17 @@ def test_file_browser_programmatic_select():
     list.test_click("..", double_click=True)
     assert list.files != files
     assert selected.value is None
+    rc.close()
+
+    @solara.component
+    def Test3():
+        return solara.FileBrowser(current_dir, selected=selected.value, on_path_select=selected.set, can_select=True)
+
+    div, rc = solara.render_fixed(Test3(), handle_error=False)
+    assert current_dir.value == HERE.parent
+    list.test_click("..", double_click=False)
+    assert current_dir.value == HERE.parent
+    # this will trigger the sync_directory_from_selected
+    selected.value = current_dir.value / ".." / "unit" / ".."
+    assert current_dir.value == HERE.parent
+    rc.close()


### PR DESCRIPTION
cc @kecnry @rosteen 
This should resolve the issue in jdaviz where you go two directories up