### PR TITLE
feat: Added CITATION.cff to allow for easy citation of Solara Software

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,18 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+- family-names: "Breddels"
+  given-names: "Maarten"
+title: "Solara: A Pure Python, React-style Framework for Scaling Your Jupyter and Web Apps"
+abstract:  >-
+  While there are many Python web frameworks out there, most are designed for small data apps or use paradigms unproven for larger scale. Code organization, reusability, and state tend to suffer as apps grow in complexity, resulting in either spaghetti code or offloading to a React application.
+  Solara addresses this gap. Using a React-like API, we don't need to worry about scalability. React has already proven its ability to support the world's largest web apps.
+  Solara uses a pure Python implementation of React (Reacton), creating ipywidget-based applications. These apps work both inside the Jupyter Notebook and as standalone web apps with frameworks like FastAPI. This paradigm enables component-based code and incredibly simple state management.
+  By building on top of ipywidgets, we automatically leverage an existing ecosystem of widgets and run on many platforms, including JupyterLab, Jupyter Notebook, Voilà, Google Colab, DataBricks, JetBrains Datalore, and more.
+  We care about developer experience. Solara will give your hot code reloading and type hints for faster development.
+license: MIT
+license-url: "https://github.com/widgetti/solara/blob/master/LICENSE"
+repository-code: "https://github.com/widgetti/solara"
+date-released: 2022-04-2
+type: software
+url: "https://solara.dev/"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,6 +13,6 @@ abstract:  >-
 license: MIT
 license-url: "https://github.com/widgetti/solara/blob/master/LICENSE"
 repository-code: "https://github.com/widgetti/solara"
-date-released: 2022-04-2
+date-released: 2022-04-02
 type: software
 url: "https://solara.dev/"


### PR DESCRIPTION
### All Submissions:

<!-- You can erase any parts not applicable to your Pull Request. -->

* [ ] I installed `pre-commit` prior to committing my changes (see [development setup docs](https://solara.dev/documentation/advanced/development/setup#contributing)).
* [x] My commit messages conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
* [x] My PR title conforms to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
* [ ] I linked to any relevant issues.

### Changes to / New Features:

* [ ] I included docs for (the changes to) my feature.
* [ ] I wrote tests for (the changes to) my feature.

### Description of changes

<!-- Describe the changes in this PR -->

Added `CITATION.cff`. 
The `CITATION.cff` file makes citing the Solara-Software easy via GitHub.
It adds the `Cite this repository` option to the github-repository dropdown (see image).

Also the Zotero Browser Extension has access to the `CIATION.cff` files in GitHub repositories.
This allows users to easily cite this Repository using Zotero.

(See the official [GitHub-Documentation](https://docs.github.com/de/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files) for how to use `CITATION.cff` files.)

This particular `CITATION.cff` file contains basic information about the repository like the title, author, abstract, licence, release-date, urls to both the official [Solara Webpage](https://solara.dev/) as well as the [GitHub-Repository](https://github.com/widgetti/solara)
I got this data by looking around the repository.

<img width="533" height="589" alt="image" src="https://github.com/user-attachments/assets/cd3412f3-a9d6-4c79-83fd-968e80f06437" />


