### PR TITLE
feat: configure the initial title before the app runs/loads

### DIFF
--- a/solara/server/server.py
+++ b/solara/server/server.py
@@ -371,7 +371,7 @@ def read_root(
     pre_rendered_html = ""
     pre_rendered_css = ""
     pre_rendered_metas = ""
-    title = "Solara ☀️"
+    title = settings.theme.title
     if ssg_data is not None:
         pre_rendered_html = ssg_data["html"]
         pre_rendered_css = "\n".join(ssg_data["styles"])

--- a/solara/server/settings.py
+++ b/solara/server/settings.py
@@ -38,6 +38,7 @@ class ThemeSettings(BaseSettings):
     variant: ThemeVariant = ThemeVariant.light
     loader: str = "solara"
     show_banner: bool = True
+    title: str = "Solara ☀️"
 
     class Config:
         env_prefix = "solara_theme_"


### PR DESCRIPTION
Use it like:
```
SOLARA_THEME_TITLE="foobar" solara run sol.py
```