### PR TITLE
[Enhance]enhance_patch_thread_init_lp9052

### DIFF
--- a/solara/server/patch.py
+++ b/solara/server/patch.py
@@ -280,7 +280,7 @@ def WidgetContextAwareThread__init__(self, *args, **kwargs):
     self.current_context = None
     # if we do this for the dummy threads, we got into a recursion
     # since threading.current_thread will call the _DummyThread constructor
-    if not ("name" in kwargs and "Dummy-" in kwargs["name"]):
+    if not ("name" in kwargs and kwargs["name"] is not None and "Dummy-" in kwargs["name"]):
         try:
             self.current_context = kernel_context.get_current_context()
         except RuntimeError:


### PR DESCRIPTION
new anyio sometime does not populate this filed properly now. With latest anyio(4.10.0) and using fastapi test client, this line will throw exception because kwarg['name'] is None

### All Submissions:

<!-- You can erase any parts not applicable to your Pull Request. -->

* [ ] I installed `pre-commit` prior to committing my changes (see [development setup docs](https://solara.dev/documentation/advanced/development/setup#contributing)).
* [ ] My commit messages conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
* [ ] My PR title conforms to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
* [ ] I linked to any relevant issues.

### Changes to / New Features:

* [ ] I included docs for (the changes to) my feature.
* [ ] I wrote tests for (the changes to) my feature.

### Description of changes

<!-- Describe the changes in this PR -->
