### PR TITLE
Restrict ipykernel version to <7 in pyproject.toml

### DIFF
--- a/packages/solara-server/pyproject.toml
+++ b/packages/solara-server/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "click>=7.1.0",
     "rich_click",
     "filelock",
-    "ipykernel",
+    "ipykernel<7",  # See https://github.com/widgetti/solara/issues/1110
     "nbformat",
     "jupyter_client",
 ]


### PR DESCRIPTION
Updated ipykernel dependency to restrict version to less than 7, since 7 and higher is breaking.

- See https://github.com/widgetti/solara/issues/1110

This is a temporary workaround, a proper fix of the underlying issue with ipykernel 7 should be worked on.

@maartenbreddels please review and merge with high urgency!