### PR TITLE
feat: with --log-level=info we can see where a reactive var was set

### DIFF
--- a/solara/toestand.py
+++ b/solara/toestand.py
@@ -971,6 +971,19 @@ class AutoSubscribeContextManagerReacton(AutoSubscribeContextManagerBase):
 
         def force_update():
             # can we do just x+1 to collapse multiple updates into one?
+            if logger.isEnabledFor(logging.INFO):
+                frame = _find_outside_solara_frame()
+                if frame is not None:
+                    tb = inspect.getframeinfo(frame)
+                else:
+                    tb = None
+                if tb is not None and tb.code_context:
+                    code = tb.code_context[0]
+                    hint = f"\n{tb.filename}:{tb.lineno}\n{code.rstrip()}"
+                else:
+                    hint = "<No code context available>"
+                logger.info("A rerender was triggered by: %s", hint)
+
             set_counter(lambda x: x + 1)
 
         super().__enter__()


### PR DESCRIPTION
Example:
```
$ solara run ../jdaviz/nogit/solara_app.py --no-open --log-level=info
....
INFO:     A rerender was triggered by: 
/Users/maartenbreddels/github/spacetelescope/jdaviz/jdaviz/core/loaders/resolvers/file/file.py:61
        self.filepath_reactive.value = Path(self.filepath)
```

This code hint can be clicked on by most editors (vscode/cursor works), to quickly navigate to where the reactive var was set.