### PR TITLE
pyproject.toml: Pin ipyvuetify to exclude 3.0.0 alpha pre-releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ packages = [
 dependencies = [
     "reacton>=1.9",
     "ipywidgets>=7.7",
-    "ipyvuetify>=1.6.10",
+    "ipyvuetify>=1.6.10,!=3.0.0a*",
     "ipyvue>=1.9.0",
     "requests",
     "humanize",


### PR DESCRIPTION
### Summary
Fixes failures caused by incompatible ipyvuetify 3.0.0 alpha pre-releases.

### Bug / Issue
The ipyvuetify 3.0.0 alpha versions (e.g., [`3.0.0a3`](https://pypi.org/project/ipyvuetify/3.0.0a3/)) remove the `TabsItems` component as part of the migration from Vuetify 2.x to 3.x, causing:
```
AttributeError: module 'reacton.ipyvuetify' has no attribute 'TabsItems'
```

### Implementation
Changed the ipyvuetify dependency constraint from `"ipyvuetify>=1.6.10"` to `"ipyvuetify>=1.6.10,!=3.0.0a*"`.

This excludes all 3.0.0 alpha pre-releases while allowing stable 3.0.0+ versions once released.

### Additional Notes
Once ipyvuetify 3.0.0 stable is released, the constraint can be relaxed after updating code to be compatible with Vuetify 3.x components. This issue was discovered through Mesa CI failures.