### PR TITLE
fix: false positive for returns in async defs for hook use

### DIFF
--- a/tests/unit/hook_use_invalid_test.py
+++ b/tests/unit/hook_use_invalid_test.py
@@ -120,6 +120,13 @@ def test_hook_use_early_return():
         return
         solara.use_state(1)
 
+    @solara.component
+    def Page4():
+        async def inner_function():
+            return
+
+        solara.use_state(1)
+
 
 def test_hook_use_nested_function():
     # sometimes we know that the use of a hook is stable, even when in a loop


### PR DESCRIPTION
This avoids false positives like:
```
tests/unit/hook_use_invalid_test.py::test_hook_use_early_return
  /Users/maartenbreddels/github/widgetti/solara/solara/validate_hooks.py:122: UserWarning: /Users/maartenbreddels/github/widgetti/solara/tests/unit/hook_use_invalid_test.py:128: test_hook_use_early_return.<locals>.Page4: `use_state` found despite early return on line 126
  To suppress this check, replace the line with:
          solara.use_state(1)  # noqa: SH101
  
  Make sure you understand the consequences of this, by reading about the rules of hooks at:
      https://solara.dev/documentation/advanced/understanding/rules-of-hooks
  
    warnings.warn(str(e))
```

which happened in async defs