### PR TITLE
feat: add create_reload_checker() for detecting hot reloads in long-running tasks

### DIFF
--- a/solara/__init__.py
+++ b/solara/__init__.py
@@ -65,6 +65,7 @@ from .routing import use_route, use_router, use_route_level, find_route, use_pat
 from .autorouting import generate_routes, generate_routes_directory, RenderPage, RoutingProvider, DefaultLayout
 from .checks import check_jupyter
 from .scope import get_kernel_id, get_session_id
+from .server.reload import create_reload_checker
 
 
 def display(*objs, **kwargs):

--- a/solara/tasks.py
+++ b/solara/tasks.py
@@ -770,6 +770,28 @@ def task(
             solara.Text("Click the button to fetch data")
     ```
 
+    ## Hot reload
+
+    During development, Solara's hot reload feature may reload your app when you save changes.
+    Long-running tasks started before the reload will continue running with references to old module state,
+    which can cause issues.
+
+    Use [`solara.create_reload_checker()`](/documentation/advanced/reference/reloading#long-running-tasks-and-hot-reload)
+    to detect when a reload has occurred and exit your task gracefully:
+
+    ```python
+    did_reload = solara.create_reload_checker()
+
+    @task
+    async def my_long_running_task():
+        while not did_reload():
+            # do work...
+            await asyncio.sleep(1)
+    ```
+
+    Note: Hot reload only occurs in development mode. In production mode (`solara run --production`),
+    file watching is disabled and this is not a concern.
+
     ## Arguments
 
     - `f`: Function to turn into task or None

--- a/tests/unit/reload_test.py
+++ b/tests/unit/reload_test.py
@@ -54,3 +54,27 @@ def test_on_kernel_start_cleanup(kernel_context, no_kernel_context):
     assert test_callback_cleanup in [k.callback for k in solara.lifecycle._on_kernel_start_callbacks]
     cleanup()
     assert test_callback_cleanup not in [k.callback for k in solara.lifecycle._on_kernel_start_callbacks]
+
+
+def test_create_reload_checker():
+    from solara.server.reload import reloader
+
+    # Create a checker before any reload
+    did_reload = solara.create_reload_checker()
+    assert did_reload() is False
+
+    # Simulate a reload by incrementing the counter
+    reloader._reload_count += 1
+
+    # The checker should now detect a reload
+    assert did_reload() is True
+
+    # A new checker created after the reload should not detect a reload
+    did_reload_new = solara.create_reload_checker()
+    assert did_reload_new() is False
+
+    # But the old checker still detects it
+    assert did_reload() is True
+
+    # Clean up: reset the counter for other tests
+    reloader._reload_count -= 1


### PR DESCRIPTION
## Summary

- Adds `solara.create_reload_checker()` which returns a function that detects when a hot reload has occurred
- Useful for long-running tasks (threads, async tasks) that need to exit gracefully after a reload to avoid issues with stale references to old module state
- Added documentation in the reloading reference page and in the task decorator docstring

## Usage

```python
import solara

did_reload = solara.create_reload_checker()

while not did_reload():
    # do work...
    await asyncio.sleep(1)
# Task exits gracefully after hot reload
```

## Test plan

- [x] Added unit test for `create_reload_checker()`
- [x] All existing reload tests pass

Closes #1103

🤖 Generated with [Claude Code](https://claude.ai/code)