### PR TITLE
fix: support Starlette 1.0 by using lifespan instead of on_startup/on_shutdown

### DIFF
--- a/solara/server/starlette.py
+++ b/solara/server/starlette.py
@@ -1,4 +1,5 @@
 import asyncio
+from contextlib import asynccontextmanager
 import json
 import logging
 import math
@@ -633,6 +634,14 @@ def on_shutdown():
     telemetry.server_stop()
 
 
+@asynccontextmanager
+async def lifespan(app):
+    """Lifespan context manager for Starlette (replaces on_startup/on_shutdown)."""
+    on_startup()
+    yield
+    on_shutdown()
+
+
 def readyz(request: Request):
     json, status = server.readyz()
     return JSONResponse(json, status_code=status)
@@ -767,7 +776,7 @@ routes = [
     Route("/{fullpath:path}", endpoint=root),
 ]
 
-app = Starlette(routes=routes, on_startup=[on_startup], on_shutdown=[on_shutdown], middleware=middleware)
+app = Starlette(routes=routes, lifespan=lifespan, middleware=middleware)
 
 # Uncomment the lines below to test solara mouted under a subpath
 # def myroot(request: Request):

--- a/tests/unit/starlette_lifespan_test.py
+++ b/tests/unit/starlette_lifespan_test.py
@@ -1,0 +1,23 @@
+"""Tests for Starlette lifespan context manager."""
+
+import asyncio
+from unittest import mock
+
+
+def test_lifespan_context_manager():
+    """Test that the lifespan context manager calls on_startup and on_shutdown."""
+    from solara.server.starlette import lifespan
+
+    startup_called = []
+    shutdown_called = []
+
+    with mock.patch("solara.server.starlette.on_startup", lambda: startup_called.append(True)):
+        with mock.patch("solara.server.starlette.on_shutdown", lambda: shutdown_called.append(True)):
+
+            async def test_lifespan():
+                async with lifespan(None):
+                    assert startup_called == [True], "on_startup should be called before yield"
+                    assert shutdown_called == [], "on_shutdown should not be called before yield"
+                assert shutdown_called == [True], "on_shutdown should be called after yield"
+
+            asyncio.run(test_lifespan())


### PR DESCRIPTION
## Summary

Starlette 1.0 removed the `on_startup` and `on_shutdown` parameters from `Starlette.__init__()`. This causes Solara to crash on import with Starlette 1.0.

Fixes #1143

## Changes

- Add `lifespan` async context manager that wraps existing `on_startup()` and `on_shutdown()` functions
- Use `lifespan` parameter instead of `on_startup`/`on_shutdown`
- Add unit test for lifespan context manager

The `lifespan` parameter has been supported since Starlette 0.13.5, so this change is backward compatible with all reasonably recent Starlette versions.

## Testing

Tested with both:
- **Starlette 0.52.1** ✅
- **Starlette 1.0.0rc1** ✅