### PR TITLE
fix: add missing /api/details redirect

### DIFF
--- a/solara/website/pages/__init__.py
+++ b/solara/website/pages/__init__.py
@@ -174,6 +174,7 @@ _redirects = {
     "/api/hbox": "/documentation/components/layout/hbox",
     "/api/vbox": "/documentation/components/layout/vbox",
     "/api/sidebar": "/documentation/components/layout/sidebar",
+    "/api/details": "/documentation/components/layout/details",
     "/api/row": "/documentation/components/layout/row",
     "/api/error": "/documentation/components/status/error",
     "/api/info": "/documentation/components/status/info",


### PR DESCRIPTION
## Summary

Fixes #222

The  component documentation page exists at , but the old API path  was missing from the redirects dictionary. This meant users visiting  would get a 404 instead of being redirected to the documentation.

## Changes

- Added  to 

This is a minimal fix that aligns with how all other component API paths are handled.