### PR TITLE
check for _create_comm attribute in comm

### DIFF
--- a/solara/comm.py
+++ b/solara/comm.py
@@ -9,7 +9,7 @@ except ImportError:
 orphan_comm_stacks: Dict[Any, str] = {}
 
 
-if comm is not None and (hasattr(comm, '_create_comm') and comm.create_comm is comm._create_comm):
+if comm is not None and (hasattr(comm, "_create_comm") and comm.create_comm is comm._create_comm):
     # only when nobody else has monkey-patched comm.create_comm
     class DummyComm(comm.base_comm.BaseComm):  # type: ignore
         def publish_msg(self, msg_type, data=None, metadata=None, buffers=None, **keys):

--- a/solara/comm.py
+++ b/solara/comm.py
@@ -9,7 +9,7 @@ except ImportError:
 orphan_comm_stacks: Dict[Any, str] = {}
 
 
-if comm is not None and comm.create_comm is comm._create_comm:
+if comm is not None and (hasattr(comm, '_create_comm') and comm.create_comm is comm._create_comm):
     # only when nobody else has monkey-patched comm.create_comm
     class DummyComm(comm.base_comm.BaseComm):  # type: ignore
         def publish_msg(self, msg_type, data=None, metadata=None, buffers=None, **keys):


### PR DESCRIPTION
I'm working on using solara in jupyterlite. When `comm` is imported there, `comm is not None` but the `comm._create_comm` attribute doesn't exist. Adding a check for the attr before getting the value.

```python
>>> import solara
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[4], line 1
----> 1 import solara

File /lib/python3.13/site-packages/solara/__init__.py:8
      4 github_url = "https://github.com/widgetti/solara"
      5 git_branch = "master"
----> 8 from . import comm  # noqa: F401
     11 def _using_solara_server():
     12     import sys

File /lib/python3.13/site-packages/solara/comm.py:12
      7     comm = None  # type: ignore
      9 orphan_comm_stacks: Dict[Any, str] = {}
---> 12 if comm is not None and comm.create_comm is comm._create_comm:
     13     # only when nobody else has monkey-patched comm.create_comm
     14     class DummyComm(comm.base_comm.BaseComm):  # type: ignore
     15         def publish_msg(self, msg_type, data=None, metadata=None, buffers=None, **keys):

AttributeError: module 'comm' has no attribute '_create_comm'
```
