### PR TITLE
feat: add multiple file browser selection

### DIFF
--- a/solara/components/__init__.py
+++ b/solara/components/__init__.py
@@ -12,7 +12,7 @@ from .cross_filter import (  # noqa: F401
 )
 from .datatable import DataTable, DataFrame  # noqa: F401 F403
 from .details import Details  # noqa: F401 F403
-from .file_browser import FileBrowser  # noqa: F401 F403
+from .file_browser import FileBrowser, FileBrowserMultiple  # noqa: F401 F403
 from .image import Image  # noqa: F401 F403
 from .markdown import Markdown, MarkdownIt  # noqa: F401 F403
 from .slider import (  # noqa: F401 F403

--- a/solara/components/file_browser.py
+++ b/solara/components/file_browser.py
@@ -1,9 +1,10 @@
 import asyncio
+import logging
 import os
+from dataclasses import dataclass
 from os.path import isfile, join
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, TypeVar, Union, cast
-import logging
+from typing import Any, Callable, Dict, Generic, List, Optional, TypeVar, Union, cast
 
 import humanize
 import ipyvuetify as vy
@@ -19,6 +20,40 @@ from solara.components import Div
 
 T = TypeVar("T")
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _FileBrowserEntry(Generic[T]):
+    name: str
+    value: T
+    is_file: bool
+    size: Optional[str] = None
+
+
+class _FileBrowserSource(Generic[T]):
+    def list(self, location: T) -> List[_FileBrowserEntry[T]]:
+        raise NotImplementedError
+
+    def parent(self, location: T) -> Optional[T]:
+        raise NotImplementedError
+
+    def can_read(self, location: T) -> bool:
+        return True
+
+    def location_name(self, location: T) -> str:
+        return str(location)
+
+    def value_name(self, value: T) -> str:
+        return str(value)
+
+    def is_visible(self, location: T, value: T) -> bool:
+        return any(entry.value == value for entry in self.list(location))
+
+    def sync_location_from_value(self, value: T) -> Optional[T]:
+        return None
+
+    def watch(self, location: T, refresh: Callable[[], None]) -> Optional[Callable[[], None]]:
+        return None
 
 
 def list_dir(path, filter: Callable[[Path], bool] = lambda x: True, directory_first: bool = False) -> List[dict]:
@@ -39,6 +74,10 @@ class FileListWidget(vy.VuetifyTemplate):
     files = traitlets.List(cast(List[Dict], [])).tag(sync=True)
     clicked = traitlets.Dict(allow_none=True, default_value=None).tag(sync=True)
     double_clicked = traitlets.Dict(allow_none=True, default_value=None).tag(sync=True)
+    click_event = traitlets.Dict(allow_none=True, default_value=None).tag(sync=True)
+    double_click_event = traitlets.Dict(allow_none=True, default_value=None).tag(sync=True)
+    selected_names = traitlets.List(cast(List[str], [])).tag(sync=True)
+    use_selected_names = traitlets.Bool(False).tag(sync=True)
     scroll_pos = traitlets.Int(allow_none=True).tag(sync=True)
 
     def test_click(self, path: Union[Path, str], double_click=False):
@@ -47,11 +86,16 @@ class FileListWidget(vy.VuetifyTemplate):
         if len(matches) == 0:
             names = [k["name"] for k in self.files]
             raise NameError(f"Could not find {path}, possible filenames: {names}")
-        item = matches[0]
+        item = {"name": matches[0]["name"], "is_file": matches[0]["is_file"]}
+        event = dict(item)
+        self._test_click_counter = getattr(self, "_test_click_counter", 0) + 1
+        event["_click_id"] = self._test_click_counter
         if double_click:
             self.double_clicked = item
+            self.double_click_event = event
         else:
             self.clicked = item
+            self.click_event = event
 
     def __contains__(self, name):
         """Test if filename/directory name is in the current directory."""
@@ -76,6 +120,376 @@ def use_reactive_or_value(
     else:
         logger.warning("You should provide an %s callback if you are not using a reactive value, otherwise %s input will not update", on_value_name, value_name)
         return value, lambda x: None
+
+
+def _validate_selection_list(paths: List[T], validate: Optional[Callable[[List[T]], None]] = None) -> None:
+    if validate:
+        validate(paths)
+
+
+def _FileBrowserBase(
+    source: _FileBrowserSource[T],
+    location: Union[T, solara.Reactive[T]],
+    selected: Union[None, T, solara.Reactive[Optional[T]]] = None,
+    selected_multiple: Union[None, List[T], solara.Reactive[List[T]]] = None,
+    on_location_change: Optional[Callable[[T], None]] = None,
+    on_select: Optional[Callable[[Optional[T]], None]] = None,
+    on_select_multiple: Optional[Callable[[List[T]], None]] = None,
+    on_open: Optional[Callable[[T], None]] = None,
+    selection_mode: str = "open",
+    validate_multiple: Optional[Callable[[List[T]], None]] = None,
+    watch_key: Any = None,
+    on_select_name: str = "on_select",
+):
+    if selection_mode not in {"open", "single", "multiple"}:
+        raise ValueError("selection_mode must be 'open', 'single', or 'multiple'")
+
+    current_location = solara.use_reactive(location)
+    double_clicked, set_double_clicked = solara.use_state(cast(Optional[Dict[str, Any]], None))
+    warning, set_warning = solara.use_state(cast(Optional[str], None))
+    scroll_pos_stack, set_scroll_pos_stack = solara.use_state(cast(List[int], []))
+    scroll_pos, set_scroll_pos = solara.use_state(0)
+    file_change_counter, set_file_change_counter = solara.use_state(0)
+    del file_change_counter
+    selected_private, set_selected_private = use_reactive_or_value(
+        selected,
+        on_value=on_select if selection_mode == "single" else lambda x: None,
+        value_name="selected",
+        on_value_name=on_select_name,
+        use_internal_value=selection_mode != "single",
+    )
+
+    if selection_mode == "multiple":
+        selected_multiple_internal, set_selected_multiple_internal = solara.use_state(cast(List[T], []))
+        if selected_multiple is None:
+            selected_multiple_private = selected_multiple_internal
+
+            def set_selected_multiple_private(values: List[T]):
+                values = list(values)
+                _validate_selection_list(values, validate_multiple)
+                set_selected_multiple_internal(values)
+                if on_select_multiple:
+                    on_select_multiple(values)
+
+        else:
+            selected_multiple_reactive = solara.use_reactive(selected_multiple, on_select_multiple)
+            selected_multiple_private = selected_multiple_reactive.value
+
+            def set_selected_multiple_private(values: List[T]):
+                values = list(values)
+                _validate_selection_list(values, validate_multiple)
+                selected_multiple_reactive.set(values)
+
+        _validate_selection_list(selected_multiple_private, validate_multiple)
+    else:
+        selected_multiple_private = cast(List[T], [])
+
+        def set_selected_multiple_private(values: List[T]):
+            pass
+
+    del selected, selected_multiple
+
+    def sync_location_from_selected():
+        if selection_mode == "single" and selected_private is not None:
+            current_parent = source.parent(current_location.value)
+            if current_parent is not None and selected_private == current_parent:
+                return
+            new_location = source.sync_location_from_value(cast(T, selected_private))
+            if new_location is not None:
+                current_location.value = new_location
+
+    solara.use_effect(sync_location_from_selected, [selected_private])
+
+    def watch_location():
+        return source.watch(current_location.value, lambda: set_file_change_counter(lambda value: value + 1))
+
+    solara.use_effect(watch_location, [current_location.value, watch_key])
+
+    def change_location(new_location: T):
+        if source.can_read(new_location):
+            current_location.value = new_location
+            if on_location_change:
+                on_location_change(new_location)
+            set_warning(None)
+            return True
+        else:
+            set_warning(f"[no read access to {source.location_name(new_location)}]")
+            return False
+
+    def clear_multiple_selection():
+        if selected_multiple_private:
+            set_selected_multiple_private([])
+
+    def toggle_value(value: T):
+        values = list(selected_multiple_private)
+        if value in values:
+            values = [existing for existing in values if existing != value]
+        else:
+            values.append(value)
+        set_selected_multiple_private(values)
+
+    entries = source.list(current_location.value)
+    entry_by_name = {entry.name: entry for entry in entries}
+    parent = source.parent(current_location.value)
+
+    def on_item(item, double_click):
+        if item is None:
+            if selection_mode == "multiple":
+                clear_multiple_selection()
+                return
+            if selection_mode == "single" and on_select:
+                on_select(None)
+            return
+        if item["name"] == "..":
+            if parent is None:
+                return
+            if selection_mode == "multiple":
+                if double_click and change_location(parent):
+                    if scroll_pos_stack:
+                        last_pos = scroll_pos_stack[-1]
+                        set_scroll_pos_stack(scroll_pos_stack[:-1])
+                        set_scroll_pos(last_pos)
+                    clear_multiple_selection()
+                    set_double_clicked(None)
+                return
+            action_change_location = (selection_mode == "single" and double_click) or (selection_mode == "open" and not double_click)
+            if action_change_location and change_location(parent):
+                if scroll_pos_stack:
+                    last_pos = scroll_pos_stack[-1]
+                    set_scroll_pos_stack(scroll_pos_stack[:-1])
+                    set_scroll_pos(last_pos)
+                set_selected_private(None)
+                set_double_clicked(None)
+                if selection_mode == "single" and on_select:
+                    on_select(None)
+            if selection_mode == "single" and not double_click:
+                if on_select:
+                    on_select(parent)
+            return
+
+        entry = entry_by_name[item["name"]]
+        if selection_mode == "multiple":
+            if double_click:
+                if entry.is_file:
+                    if on_open:
+                        on_open(entry.value)
+                else:
+                    if change_location(entry.value):
+                        set_scroll_pos_stack(scroll_pos_stack + [scroll_pos])
+                        set_scroll_pos(0)
+                clear_multiple_selection()
+                set_double_clicked(None)
+            else:
+                toggle_value(entry.value)
+            return
+        if (selection_mode == "single" and double_click) or (selection_mode == "open" and not double_click):
+            if entry.is_file:
+                if on_open:
+                    on_open(entry.value)
+            else:
+                if change_location(entry.value):
+                    set_scroll_pos_stack(scroll_pos_stack + [scroll_pos])
+                    set_scroll_pos(0)
+                set_selected_private(None)
+            set_double_clicked(None)
+            if selection_mode == "single" and on_select:
+                on_select(None)
+        elif selection_mode == "single" and not double_click:
+            if on_select:
+                on_select(entry.value)
+        else:  # open mode double click is ignored
+            raise RuntimeError("Combination should not happen")  # pragma: no cover
+
+    def on_click(item):
+        if selection_mode == "single":
+            set_selected_private(item["name"] if item else None)
+        elif selection_mode == "open":
+            set_selected_private(item["name"] if item and item["is_file"] else None)
+        on_item(item, False)
+
+    def on_clicked_change(item):
+        if item is None:
+            on_click(None)
+
+    def on_double_click(item):
+        if item is not None:
+            set_double_clicked({"name": item["name"], "is_file": item["is_file"]})
+        if selection_mode in {"single", "multiple"}:
+            on_item(item, True)
+
+    files = ([{"name": "..", "is_file": False, "size": None}] if parent is not None else []) + [
+        {"name": entry.name, "is_file": entry.is_file, "size": entry.size} for entry in entries
+    ]
+    clicked = None
+    if selected_private is not None:
+        name = selected_private if isinstance(selected_private, str) else source.value_name(cast(T, selected_private))
+        clicked = {"name": name, "is_file": not isinstance(selected_private, str), "size": None}
+    selected_names = []
+    if selection_mode == "multiple":
+        selected_names = [source.value_name(value) for value in selected_multiple_private if source.is_visible(current_location.value, value)]
+
+    with Div(class_="solara-file-browser") as main:
+        Div(children=[source.location_name(current_location.value)])
+        file_list_kwargs: Dict[str, Any] = dict(
+            files=files,
+            clicked=None if selection_mode == "multiple" else clicked,
+            on_clicked=on_clicked_change,
+            on_click_event=on_click,
+            double_clicked=double_clicked,
+            on_double_click_event=on_double_click,
+            scroll_pos=scroll_pos,
+            on_scroll_pos=set_scroll_pos,
+        )
+        if selection_mode == "multiple":
+            file_list_kwargs.update(selected_names=selected_names, use_selected_names=True)
+        FileListWidget.element(**file_list_kwargs).key("FileList")
+        if warning:
+            Div(style_="font-weight: bold; color: red", children=[warning])
+
+    return main
+
+
+def _validate_path_list(paths: List[Path], name: str = "selected") -> None:
+    for path in paths:
+        if not isinstance(path, Path):
+            raise TypeError(f"{name} must contain pathlib.Path instances")
+
+
+class _LocalFileBrowserSource(_FileBrowserSource[Path]):
+    def __init__(self, filter: Callable[[Path], bool], directory_first: bool, watch: bool):
+        self.filter = filter
+        self.directory_first = directory_first
+        self.watch_enabled = watch
+
+    def list(self, location: Path) -> List[_FileBrowserEntry[Path]]:
+        return [
+            _FileBrowserEntry(
+                name=item["name"],
+                value=location / item["name"],
+                is_file=item["is_file"],
+                size=item["size"],
+            )
+            for item in list_dir(location, filter=self.filter, directory_first=self.directory_first)
+        ]
+
+    def parent(self, location: Path) -> Path:
+        if location.is_symlink():
+            return location.parent
+        elif any([d.is_symlink() for d in location.parents]):
+            return location.parent
+        else:
+            return location.resolve().parent
+
+    def can_read(self, location: Path) -> bool:
+        return os.access(location, os.R_OK)
+
+    def location_name(self, location: Path) -> str:
+        return str(location.resolve())
+
+    def value_name(self, value: Path) -> str:
+        return value.name
+
+    def is_visible(self, location: Path, value: Path) -> bool:
+        if not isinstance(value, Path):
+            return False
+        if value.parent == location:
+            return True
+        return value.is_absolute() and value.parent.resolve() == location.resolve()
+
+    def sync_location_from_value(self, value: Path) -> Optional[Path]:
+        if isinstance(value, Path) and value.is_absolute():
+            return value.parent.resolve()
+        return None
+
+    def watch(self, location: Path, refresh: Callable[[], None]) -> Optional[Callable[[], None]]:
+        if not self.watch_enabled:
+            return None
+        if not watchfiles:
+            logger.warning("watchfiles not installed, cannot watch directory")
+            return None
+
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            logger.warning("No running event loop, cannot watch directory for changes")
+            return None
+
+        async def watch_task():
+            try:
+                async for _ in watchfiles.awatch(location):
+                    logger.debug("Directory %s changed, refreshing file list", location)
+                    refresh()
+            except RuntimeError:
+                pass  # swallow the RuntimeError: Already borrowed errors from watchfiles
+            except Exception:
+                logger.exception("Error watching directory")
+
+        future = asyncio.create_task(watch_task())
+
+        def cancel():
+            future.cancel()
+
+        return cancel
+
+
+def _FileBrowserLocal(
+    directory: Union[None, str, Path, solara.Reactive[Path]] = None,
+    selected: Union[None, Path, solara.Reactive[Optional[Path]]] = None,
+    selected_paths: Union[None, List[Path], solara.Reactive[List[Path]]] = None,
+    on_directory_change: Optional[Callable[[Path], None]] = None,
+    on_path_select: Optional[Callable[[Optional[Path]], None]] = None,
+    on_paths_select: Optional[Callable[[List[Path]], None]] = None,
+    on_file_open: Optional[Callable[[Path], None]] = None,
+    filter: Callable[[Path], bool] = lambda x: True,
+    directory_first: bool = False,
+    on_file_name: Optional[Callable[[str], None]] = None,
+    start_directory=None,
+    can_select=False,
+    watch: bool = False,
+    multiple: bool = False,
+    allow_directory_string: bool = True,
+):
+    """Local filesystem implementation shared by FileBrowser variants."""
+    if start_directory is not None:
+        directory = start_directory  # pragma: no cover
+    if directory is None:
+        directory = Path(os.getcwd())  # pragma: no cover
+    if isinstance(directory, str):
+        if not allow_directory_string:
+            raise TypeError("directory must be a pathlib.Path or solara.Reactive[Path]")
+        directory = Path(directory)
+    if not allow_directory_string and isinstance(directory, solara.Reactive) and isinstance(directory.value, str):
+        raise TypeError("directory must be a pathlib.Path or solara.Reactive[Path]")
+
+    if multiple:
+        if isinstance(selected_paths, solara.Reactive):
+            _validate_path_list(selected_paths.value)
+        elif selected_paths is not None:
+            _validate_path_list(selected_paths)
+
+    source = _LocalFileBrowserSource(filter=filter, directory_first=directory_first, watch=watch)
+    selection_mode = "multiple" if multiple else "single" if can_select else "open"
+
+    def on_open(path: Path):
+        if on_file_open:
+            on_file_open(path)
+        if on_file_name is not None:
+            on_file_name(str(path))
+
+    return _FileBrowserBase(
+        source,
+        directory,
+        selected,
+        selected_multiple=selected_paths,
+        on_location_change=on_directory_change,
+        on_select=on_path_select,
+        on_select_multiple=on_paths_select,
+        on_open=on_open,
+        selection_mode=selection_mode,
+        validate_multiple=_validate_path_list,
+        watch_key=watch,
+        on_select_name="on_path_select",
+    )
 
 
 @solara.component
@@ -119,168 +533,62 @@ def FileBrowser(
      * `watch`: If `True`, watch the current directory for file changes and automatically refresh the file list.
         Requires the `watchfiles` package to be installed.
     """
-    if start_directory is not None:
-        directory = start_directory  # pragma: no cover
-    if directory is None:
-        directory = os.getcwd()  # pragma: no cover
-    if isinstance(directory, str):
-        directory = Path(directory)
-    # directory = directory.resolve()
-    current_dir = solara.use_reactive(directory)
-    double_clicked, set_double_clicked = solara.use_state(None)
-    warning, set_warning = solara.use_state(cast(Optional[str], None))
-    scroll_pos_stack, set_scroll_pos_stack = solara.use_state(cast(List[int], []))
-    scroll_pos, set_scroll_pos = solara.use_state(0)
-    # Counter to trigger re-render when files change
-    file_change_counter, set_file_change_counter = solara.use_state(0)
-    selected_private, set_selected_private = use_reactive_or_value(
-        selected,
-        on_value=on_path_select if can_select else lambda x: None,
-        value_name="selected",
-        on_value_name="on_path_select",
-        use_internal_value=not can_select,
+    return _FileBrowserLocal(
+        directory=directory,
+        selected=selected,
+        on_directory_change=on_directory_change,
+        on_path_select=on_path_select,
+        on_file_open=on_file_open,
+        filter=filter,
+        directory_first=directory_first,
+        on_file_name=on_file_name,
+        start_directory=start_directory,
+        can_select=can_select,
+        watch=watch,
     )
-    # remove so we don't accidentally use it
-    del selected
 
-    def sync_directory_from_selected():
-        if selected_private is not None:
-            # if we select a file, we need to make sure the directory is correct
-            # NOTE: although we expect a Path, abuse might make it a string
-            if isinstance(selected_private, Path):
-                # Only sync directory from selected if the path is absolute.
-                # Relative paths would resolve against the process CWD, not the
-                # current directory shown in the FileBrowser, leading to incorrect paths.
-                if selected_private.is_absolute():
-                    # Note that we do not call .resolve() before using .parent, otherwise /some/path/.. will
-                    # set the current directory to /, moving up two levels.
-                    current_dir.value = selected_private.parent.resolve()
 
-    solara.use_effect(sync_directory_from_selected, [selected_private])
+@solara.component
+def FileBrowserMultiple(
+    directory: Union[None, Path, solara.Reactive[Path]] = None,
+    selected: Union[None, List[Path], solara.Reactive[List[Path]]] = None,
+    on_paths_select: Optional[Callable[[List[Path]], None]] = None,
+    on_directory_change: Optional[Callable[[Path], None]] = None,
+    on_file_open: Optional[Callable[[Path], None]] = None,
+    filter: Callable[[Path], bool] = lambda x: True,
+    directory_first: bool = False,
+    watch: bool = False,
+):
+    """File/directory browser that supports selecting multiple local paths.
 
-    def watch_directory():
-        if not watch:
-            return
-        if not watchfiles:
-            logger.warning("watchfiles not installed, cannot watch directory")
-            return
+    Selection values are always `pathlib.Path` instances. Unlike `FileBrowser`,
+    this component does not accept string directories.
 
-        # Check if there's a running event loop before creating the coroutine
-        try:
-            asyncio.get_running_loop()
-        except RuntimeError:
-            # No running event loop (e.g., in unit tests or non-server environments)
-            logger.warning("No running event loop, cannot watch directory for changes")
-            return
+    Single-clicking a file or directory toggles it in the selected path list.
+    Double-clicking a file opens it, and double-clicking a directory navigates
+    into it. Opening or navigating clears the current selection.
 
-        dir_to_watch = current_dir.value
+    ## Arguments
 
-        async def watch_task():
-            try:
-                async for _ in watchfiles.awatch(dir_to_watch):
-                    logger.debug("Directory %s changed, refreshing file list", dir_to_watch)
-                    set_file_change_counter(lambda x: x + 1)
-            except RuntimeError:
-                pass  # swallow the RuntimeError: Already borrowed errors from watchfiles
-            except Exception:
-                logger.exception("Error watching directory")
-
-        future = asyncio.create_task(watch_task())
-        return future.cancel
-
-    solara.use_effect(watch_directory, [watch, current_dir.value])
-
-    def change_dir(new_dir: Path):
-        if os.access(new_dir, os.R_OK):
-            current_dir.value = new_dir
-            if on_directory_change:
-                on_directory_change(new_dir)
-            set_warning(None)
-            return True
-        else:
-            set_warning(f"[no read access to {new_dir}]")
-
-    def on_item(item, double_click):
-        if item is None:
-            if can_select and on_path_select:
-                on_path_select(None)
-            return
-        if item["name"] == "..":
-            if current_dir.value.is_symlink():
-                new_dir = current_dir.value.parent
-            elif any([d.is_symlink() for d in current_dir.value.parents]):
-                new_dir = current_dir.value.parent
-            else:
-                new_dir = current_dir.value.resolve().parent
-            action_change_directory = (can_select and double_click) or (not can_select and not double_click)
-            if action_change_directory and change_dir(new_dir):
-                if scroll_pos_stack:
-                    last_pos = scroll_pos_stack[-1]
-                    set_scroll_pos_stack(scroll_pos_stack[:-1])
-                    set_scroll_pos(last_pos)
-                set_selected_private(None)
-                set_double_clicked(None)
-                if on_path_select and can_select:
-                    on_path_select(None)
-            if can_select and not double_click:
-                if on_path_select:
-                    on_path_select(new_dir)
-            return
-
-        path = current_dir.value / item["name"]
-        is_file = item["is_file"]
-        if (can_select and double_click) or (not can_select and not double_click):
-            if is_file:
-                if on_file_open:
-                    on_file_open(path)
-                if on_file_name is not None:
-                    on_file_name(str(path))
-            else:
-                if change_dir(path):
-                    set_scroll_pos_stack(scroll_pos_stack + [scroll_pos])
-                    set_scroll_pos(0)
-                set_selected_private(None)
-            set_double_clicked(None)
-            if on_path_select and can_select:
-                on_path_select(None)
-        elif can_select and not double_click:
-            if on_path_select:
-                on_path_select(path)
-        else:  # not can_select and double_click is ignored
-            raise RuntimeError("Combination should not happen")  # pragma: no cover
-
-    def on_click(item):
-        set_selected_private(item["name"] if item else None)
-        on_item(item, False)
-
-    def on_double_click(item):
-        set_double_clicked(item)
-        if can_select:
-            on_item(item, True)
-        # otherwise we can ignore it, single click will handle it
-
-    files = [{"name": "..", "is_file": False}] + list_dir(current_dir.value, filter=filter, directory_first=directory_first)
-    clicked = (
-        {
-            "name": selected_private.name if isinstance(selected_private, Path) else selected_private,
-            "is_file": isinstance(selected_private, Path),
-            "size": None,
-        }
-        if selected_private is not None
-        else None
+     * `directory`: The directory to start in. If `None`, the current working directory is used.
+     * `selected`: The selected files or directories. If `None`, no path is selected.
+     * `on_paths_select`: Callback called with the selected path list.
+     * `on_directory_change`: Called when double-clicking a directory.
+     * `on_file_open`: Called when double-clicking a file.
+     * `filter`: A function that takes a `Path` and returns `True` if the file/directory should be shown.
+     * `directory_first`: If `True` directories are shown before files. Default: `False`.
+     * `watch`: If `True`, watch the current directory for file changes and automatically refresh the file list.
+        Requires the `watchfiles` package to be installed.
+    """
+    return _FileBrowserLocal(
+        directory=directory,
+        selected_paths=selected,
+        on_paths_select=on_paths_select,
+        on_directory_change=on_directory_change,
+        on_file_open=on_file_open,
+        filter=filter,
+        directory_first=directory_first,
+        watch=watch,
+        multiple=True,
+        allow_directory_string=False,
     )
-    with Div(class_="solara-file-browser") as main:
-        Div(children=[str(current_dir.value.resolve())])
-        FileListWidget.element(
-            files=files,
-            clicked=clicked,
-            on_clicked=on_click,
-            double_clicked=double_clicked,
-            on_double_clicked=on_double_click,
-            scroll_pos=scroll_pos,
-            on_scroll_pos=set_scroll_pos,
-        ).key("FileList")
-        if warning:
-            Div(style_="font-weight: bold; color: red", children=[warning])
-
-    return main

--- a/solara/components/file_list_widget.vue
+++ b/solara/components/file_list_widget.vue
@@ -8,9 +8,10 @@
       <v-list-item
           v-for="{name, is_file, size} in files"
           :key="name + '|' + is_file"
-          @click.stop="clicked = { name, is_file }"
-          @dblclick="double_clicked = { name, is_file }"
-          :class="(clicked && clicked.name == name) ? 'solara-file-list-selected': ''"
+          @click.stop="emitClick(name, is_file)"
+          @dblclick="emitDoubleClick(name, is_file)"
+          :ripple="!use_selected_names || !isSelected(name)"
+          :class="isSelected(name) ? 'solara-file-list-selected': ''"
       >
         <v-list-item-icon>
           <v-icon>{{ name === '..' ? 'mdi-keyboard-backspace' : is_file ? 'mdi-file-document' : 'mdi-folder' }}</v-icon>
@@ -28,6 +29,42 @@
 
 <script>
 module.exports = {
+  data() {
+    return {
+      click_id: 0,
+      // Keep multiple-selection highlighting local until Python confirms it;
+      // otherwise toggling an already selected row visibly waits for the trait round trip.
+      // When a row is already selected, disable Vuetify ripple because it animates
+      // over the selected background and looks like selection jitter during deselect.
+      optimistic_selected_names: this.selected_names || [],
+    }
+  },
+  methods: {
+    emitClick(name, is_file) {
+      this.click_id += 1
+      if (this.use_selected_names && name !== '..') {
+        const selected = this.optimistic_selected_names || []
+        if (selected.indexOf(name) === -1) {
+          this.optimistic_selected_names = selected.concat([name])
+        } else {
+          this.optimistic_selected_names = selected.filter(item => item !== name)
+        }
+      }
+      this.clicked = { name, is_file }
+      this.click_event = { name, is_file, click_id: this.click_id }
+    },
+    emitDoubleClick(name, is_file) {
+      this.click_id += 1
+      this.double_clicked = { name, is_file }
+      this.double_click_event = { name, is_file, click_id: this.click_id }
+    },
+    isSelected(name) {
+      if (this.use_selected_names) {
+        return (this.optimistic_selected_names || []).indexOf(name) !== -1
+      }
+      return this.clicked && this.clicked.name === name
+    }
+  },
   mounted() {
     const element = this.$refs.scrollpane.$el
     element.scrollTop = this.scroll_pos
@@ -38,6 +75,9 @@ module.exports = {
     element.addEventListener('scroll', this._scrollListener)
   },
   watch: {
+    selected_names(v) {
+      this.optimistic_selected_names = v || []
+    },
     scroll_pos(v) {
       this.$nextTick(() => this.$refs.scrollpane.$el.scrollTop = v);
     }

--- a/solara/website/pages/documentation/components/input/file_browser.py
+++ b/solara/website/pages/documentation/components/input/file_browser.py
@@ -1,38 +1,54 @@
-"""# FileBrowser"""
+"""
+# FileBrowser components
 
+FileBrowser components browse files and directories on the server side.
+
+   * `FileBrowser` opens files and can optionally select one path.
+   * `FileBrowserMultiple` selects multiple paths.
+
+Both components use `pathlib.Path` values for selection callbacks.
+`FileBrowser` keeps string directory support for backwards compatibility.
+`FileBrowserMultiple` only accepts `Path` directory and selection values.
+"""
+
+import tempfile
 from pathlib import Path
-from typing import Optional, cast
-import random
+from typing import List, cast
+
 import solara
 from solara.website.utils import apidoc
 
-opened = solara.reactive(cast(Optional[Path], None))
-selected = solara.reactive(cast(Optional[Path], None))
-directory = solara.reactive(Path("~").expanduser())
-can_select = solara.reactive(False)
+selected_multiple = solara.reactive(cast(List[Path], []))
+
+
+def create_demo_directory():
+    directory = Path(tempfile.gettempdir()) / "solara-file-browser-multiple-demo"
+    (directory / "reports").mkdir(parents=True, exist_ok=True)
+    (directory / "notebooks").mkdir(parents=True, exist_ok=True)
+    (directory / "notes.txt").write_text("notes\n")
+    (directory / "report.csv").write_text("name,value\nA,1\n")
+    (directory / "notebooks" / "example.ipynb").write_text("{}\n")
+    return directory
 
 
 @solara.component
 def Page():
-    def reset_path():
-        opened.value = None
-        selected.value = None
+    directory = solara.use_memo(create_demo_directory, [])
+    solara.Markdown(
+        """
+        `FileBrowserMultiple` selects multiple paths. The selected values are
+        `pathlib.Path` objects.
+        """
+    )
+    solara.Markdown("## FileBrowserMultiple")
+    solara.FileBrowserMultiple(directory, selected=selected_multiple)
 
-    def select_random_file():
-        files = list(directory.value.glob("*"))
-        if files:
-            selected.value = random.choice(files)
-
-    # reset path and file when can_select changes
-    solara.use_memo(reset_path, [can_select.value])
-    solara.Checkbox(label="Enable select", value=can_select)
-    solara.FileBrowser(directory, selected=selected, on_file_open=opened.set, can_select=can_select.value)
-    solara.Info(f"You are in directory: {directory}")
-    solara.Info(f"You selected path: {selected}")
-    solara.Info(f"You opened file: {opened}")
-
-    if can_select.value:
-        solara.Button(label="Select random file", on_click=select_random_file)
+    selected_paths = selected_multiple.value
+    selected_text = "\n".join(f"- `{path.relative_to(directory)}`" for path in selected_paths) or "- none"
+    with solara.Div(style_="min-height: 96px"):
+        solara.Markdown(f"Selected paths:\n\n{selected_text}")
 
 
 __doc__ += apidoc(solara.FileBrowser.f)  # type: ignore
+__doc__ += "# FileBrowserMultiple"
+__doc__ += apidoc(solara.FileBrowserMultiple.f)  # type: ignore

--- a/tests/integration/api_test.py
+++ b/tests/integration/api_test.py
@@ -29,7 +29,7 @@ def test_api_file_browser(page_session: playwright.sync_api.Page, solara_server,
     with solara_app("solara.website.pages"):
         page_session.goto(solara_server.base_url + "/documentation/components/")
         page_session.locator(".v-card >> text=File Browser").first.click()
-        page_session.locator("text=You are in directory").wait_for()
+        page_session.locator("text=Selected paths:").wait_for()
 
 
 def test_api_matplotlib(page_session: playwright.sync_api.Page, solara_server, solara_app):

--- a/tests/unit/file_browser_test.py
+++ b/tests/unit/file_browser_test.py
@@ -2,7 +2,7 @@ import asyncio
 import platform
 import unittest.mock
 from pathlib import Path
-from typing import Optional, cast
+from typing import List, Optional, cast
 
 import pytest
 
@@ -113,6 +113,16 @@ def test_file_browser_callback_can_select():
     # go up again
     list.test_click("..", double_click=True)
     assert "conftest.py" not in list
+
+
+def test_file_list_widget_test_click_payload_shape():
+    file_list = solara.components.file_browser.FileListWidget(files=[{"name": "file.txt", "is_file": True}])
+
+    file_list.test_click("file.txt")
+    assert set(file_list.clicked) == {"name", "is_file"}
+
+    file_list.test_click("file.txt", double_click=True)
+    assert set(file_list.double_clicked) == {"name", "is_file"}
 
 
 def test_file_browser_scroll_pos():
@@ -255,6 +265,7 @@ def test_file_browser_programmatic_select():
     selected.value = HERE.parent / "file_browser_test.py"
     assert list.clicked is not None
     assert list.clicked["name"] == "file_browser_test.py"
+    assert list.clicked["is_file"] is True
     list.test_click("..", double_click=True)
     assert list.files != files
     assert selected.value is None
@@ -274,6 +285,7 @@ def test_file_browser_programmatic_select():
     selected.value = HERE.parent / "file_browser_test.py"
     assert list.clicked is not None
     assert list.clicked["name"] == "file_browser_test.py"
+    assert list.clicked["is_file"] is True
     list.test_click("..", double_click=True)
     assert list.files != files
     assert selected.value is None
@@ -284,12 +296,224 @@ def test_file_browser_programmatic_select():
         return solara.FileBrowser(current_dir, selected=selected.value, on_path_select=selected.set, can_select=True)
 
     div, rc = solara.render_fixed(Test3(), handle_error=False)
+    list = div.children[1]
     assert current_dir.value == HERE.parent
     list.test_click("..", double_click=False)
     assert current_dir.value == HERE.parent
     # this will trigger the sync_directory_from_selected
     selected.value = current_dir.value / ".." / "unit" / ".."
     assert current_dir.value == HERE.parent
+    rc.close()
+
+
+def test_file_browser_selected_value_without_callback_warning():
+    selected = HERE.parent / "file_browser_test.py"
+
+    with unittest.mock.patch.object(solara.components.file_browser.logger, "warning") as mock_warning:
+        div, rc = solara.render_fixed(solara.FileBrowser(HERE.parent, selected=selected, can_select=True), handle_error=False)
+
+    mock_warning.assert_called_with(
+        "You should provide an %s callback if you are not using a reactive value, otherwise %s input will not update",
+        "on_path_select",
+        "selected",
+    )
+    rc.close()
+
+
+def test_file_browser_multiple_callback_select(tmp_path: Path):
+    (tmp_path / "a.txt").write_text("a")
+    (tmp_path / "b.txt").write_text("b")
+
+    selected = solara.reactive(cast(List[Path], []))
+    on_paths_select = unittest.mock.MagicMock()
+
+    @solara.component
+    def Test():
+        return solara.FileBrowserMultiple(tmp_path, selected=selected, on_paths_select=on_paths_select)
+
+    div, rc = solara.render_fixed(Test(), handle_error=False)
+    file_list: solara.components.file_browser.FileListWidget = div.children[1]
+
+    file_list.test_click("a.txt")
+    assert selected.value == [tmp_path / "a.txt"]
+    on_paths_select.assert_called_with([tmp_path / "a.txt"])
+
+    file_list.test_click("b.txt")
+    assert selected.value == [tmp_path / "a.txt", tmp_path / "b.txt"]
+    on_paths_select.assert_called_with([tmp_path / "a.txt", tmp_path / "b.txt"])
+
+    file_list.test_click("a.txt")
+    assert selected.value == [tmp_path / "b.txt"]
+    on_paths_select.assert_called_with([tmp_path / "b.txt"])
+
+    rc.close()
+
+
+def test_file_browser_multiple_programmatic_select(tmp_path: Path):
+    (tmp_path / "a.txt").write_text("a")
+    (tmp_path / "b.txt").write_text("b")
+    (tmp_path / "c.txt").write_text("c")
+
+    selected = solara.reactive(cast(List[Path], []))
+
+    @solara.component
+    def Test():
+        return solara.FileBrowserMultiple(tmp_path, selected=selected)
+
+    div, rc = solara.render_fixed(Test(), handle_error=False)
+    file_list: solara.components.file_browser.FileListWidget = div.children[1]
+
+    assert file_list.selected_names == []
+    selected.value = [tmp_path / "a.txt", tmp_path / "b.txt"]
+    assert sorted(file_list.selected_names) == ["a.txt", "b.txt"]
+
+    selected.value = [tmp_path / "nested" / "outside.txt", tmp_path / "c.txt"]
+    assert file_list.selected_names == ["c.txt"]
+
+    rc.close()
+
+
+def test_file_browser_multiple_open_and_navigate_clear_selection(tmp_path: Path):
+    (tmp_path / "a.txt").write_text("a")
+    subdir = tmp_path / "subdir"
+    subdir.mkdir()
+    (subdir / "b.txt").write_text("b")
+
+    selected = solara.reactive(cast(List[Path], []))
+    on_file_open = unittest.mock.MagicMock()
+    on_directory_change = unittest.mock.MagicMock()
+    on_paths_select = unittest.mock.MagicMock()
+
+    @solara.component
+    def Test():
+        return solara.FileBrowserMultiple(
+            tmp_path,
+            selected=selected,
+            on_paths_select=on_paths_select,
+            on_file_open=on_file_open,
+            on_directory_change=on_directory_change,
+        )
+
+    div, rc = solara.render_fixed(Test(), handle_error=False)
+    file_list: solara.components.file_browser.FileListWidget = div.children[1]
+
+    file_list.test_click("a.txt")
+    assert selected.value == [tmp_path / "a.txt"]
+
+    file_list.test_click("a.txt", double_click=True)
+    on_file_open.assert_called_with(tmp_path / "a.txt")
+    assert selected.value == []
+    on_paths_select.assert_called_with([])
+
+    file_list.test_click("subdir")
+    assert selected.value == [subdir]
+
+    file_list.test_click("subdir", double_click=True)
+    on_directory_change.assert_called_with(subdir)
+    assert selected.value == []
+    on_paths_select.assert_called_with([])
+    assert "b.txt" in file_list
+
+    rc.close()
+
+
+def test_file_browser_multiple_does_not_select_parent(tmp_path: Path):
+    selected = solara.reactive(cast(List[Path], []))
+    on_paths_select = unittest.mock.MagicMock()
+
+    @solara.component
+    def Test():
+        return solara.FileBrowserMultiple(tmp_path, selected=selected, on_paths_select=on_paths_select)
+
+    div, rc = solara.render_fixed(Test(), handle_error=False)
+    file_list: solara.components.file_browser.FileListWidget = div.children[1]
+
+    file_list.test_click("..")
+    assert selected.value == []
+    on_paths_select.assert_not_called()
+
+    rc.close()
+
+
+def test_file_browser_multiple_requires_path_directory(tmp_path: Path):
+    with pytest.raises(TypeError, match="directory"):
+        solara.render_fixed(solara.FileBrowserMultiple(str(tmp_path)), handle_error=False)
+
+
+def test_file_browser_base_supports_generic_source():
+    file_browser = solara.components.file_browser
+
+    class FakeSource(file_browser._FileBrowserSource[str]):
+        def __init__(self):
+            self.entries = {
+                "fake:/": [
+                    file_browser._FileBrowserEntry(name="docs", value="fake:/docs/", is_file=False),
+                    file_browser._FileBrowserEntry(name="readme.md", value="fake:/readme.md", is_file=True, size="9 B"),
+                ],
+                "fake:/docs/": [
+                    file_browser._FileBrowserEntry(name="guide.md", value="fake:/docs/guide.md", is_file=True, size="12 B"),
+                ],
+            }
+
+        def list(self, location):
+            return self.entries[location]
+
+        def parent(self, location):
+            if location == "fake:/docs/":
+                return "fake:/"
+            return "fake:/"
+
+        def can_read(self, location):
+            return True
+
+        def location_name(self, location):
+            return location
+
+        def value_name(self, value):
+            return value.rstrip("/").split("/")[-1]
+
+        def is_visible(self, location, value):
+            return any(entry.value == value for entry in self.list(location))
+
+    selected = solara.reactive(cast(List[str], []))
+    location = solara.reactive("fake:/")
+    on_select = unittest.mock.MagicMock()
+    on_location_change = unittest.mock.MagicMock()
+    on_open = unittest.mock.MagicMock()
+
+    @solara.component
+    def Test():
+        return file_browser._FileBrowserBase(
+            FakeSource(),
+            location,
+            selected_multiple=selected,
+            on_select_multiple=on_select,
+            on_location_change=on_location_change,
+            on_open=on_open,
+            selection_mode="multiple",
+        )
+
+    div, rc = solara.render_fixed(Test(), handle_error=False)
+    file_list: solara.components.file_browser.FileListWidget = div.children[1]
+
+    assert div.children[0].children[0] == "fake:/"
+    assert "docs" in file_list
+    assert "readme.md" in file_list
+
+    file_list.test_click("readme.md")
+    assert selected.value == ["fake:/readme.md"]
+    on_select.assert_called_with(["fake:/readme.md"])
+    assert file_list.selected_names == ["readme.md"]
+
+    file_list.test_click("docs", double_click=True)
+    on_location_change.assert_called_with("fake:/docs/")
+    assert location.value == "fake:/docs/"
+    assert selected.value == []
+    assert "guide.md" in file_list
+
+    file_list.test_click("guide.md", double_click=True)
+    on_open.assert_called_with("fake:/docs/guide.md")
+
     rc.close()
 
 
@@ -329,6 +553,29 @@ def test_file_browser_watch_disabled_by_default():
     file_list: solara.components.file_browser.FileListWidget = div.children[1]
     assert "file_browser_test.py" in file_list
     rc.close()
+
+
+def test_file_browser_watch_can_be_enabled_after_render(tmpdir: Path):
+    """Test that toggling watch from False to True starts the watch effect."""
+    tmpdir = Path(tmpdir)
+    (tmpdir / "test.txt").write_text("test")
+    watch = solara.reactive(False)
+
+    with unittest.mock.patch.object(solara.components.file_browser.logger, "warning") as mock_warning:
+
+        @solara.component
+        def Test():
+            return solara.FileBrowser(tmpdir, watch=watch.value)
+
+        div, rc = solara.render_fixed(Test(), handle_error=False)
+        file_list: solara.components.file_browser.FileListWidget = div.children[1]
+        assert "test.txt" in file_list
+        mock_warning.assert_not_called()
+
+        watch.value = True
+
+        mock_warning.assert_called_with("No running event loop, cannot watch directory for changes")
+        rc.close()
 
 
 def test_file_browser_watch_no_watchfiles(tmpdir: Path):
@@ -482,8 +729,11 @@ def test_file_browser_selected_relative_path_after_full_path(tmpdir: Path):
     relative_path = Path("subdir") / "file.txt"
     selected.value = relative_path
 
-    # This should not raise FileNotFoundError
-    # The current_dir should resolve relative to cwd, not to the previous current_dir
+    # This should not raise FileNotFoundError, and should not append the relative
+    # path's parent to the directory shown by the FileBrowser.
+    current_dir_text = div.children[0].children[0]
+    assert str(subdir) in current_dir_text
+    assert str(subdir / "subdir") not in current_dir_text
     rc.close()
 
 


### PR DESCRIPTION
## Summary
- Refactor `FileBrowser` around a reusable internal base while preserving single-selection behavior and string-directory compatibility.
- Add `FileBrowserMultiple` for `Path`-only multiple selection with optimistic row highlighting and selected-row ripple handling.
- Update the website docs demo/API docs and add focused tests, including a generic fake filesystem source.

## Usage snippets

Single file selection keeps the existing `FileBrowser` API:

```python
from pathlib import Path
from typing import Optional, cast

import solara

selected_file = solara.reactive(cast(Optional[Path], None))
solara.FileBrowser(Path.cwd(), selected=selected_file)
```

Multiple file selection uses `FileBrowserMultiple` and `Path` values:

```python
from pathlib import Path
from typing import List, cast

import solara

selected_files = solara.reactive(cast(List[Path], []))
solara.FileBrowserMultiple(Path.cwd(), selected=selected_files)
```

Callback style also receives `Path` values:

```python
from pathlib import Path
from typing import List

import solara


def on_select(paths: List[Path]):
    print(paths)


solara.FileBrowserMultiple(Path.cwd(), on_paths_select=on_select)
```

## Demo
- Video demo: selecting `report.csv` and `notes.txt`, toggling `report.csv`, and clearing the remaining selection.

https://github.com/user-attachments/assets/c14d45e5-62b3-442c-af59-00f1286fb3a8

## Tests
- `uv run pytest tests/unit/file_browser_test.py::test_file_browser_callback_can_select tests/unit/file_browser_test.py::test_file_browser_relative_path tests/unit/file_browser_test.py::test_file_browser_programmatic_select tests/unit/file_browser_test.py::test_file_browser_multiple_callback_select tests/unit/file_browser_test.py::test_file_browser_multiple_programmatic_select tests/unit/file_browser_test.py::test_file_browser_multiple_open_and_navigate_clear_selection tests/unit/file_browser_test.py::test_file_browser_multiple_does_not_select_parent tests/unit/file_browser_test.py::test_file_browser_multiple_requires_path_directory tests/unit/file_browser_test.py::test_file_browser_base_supports_generic_source -q`
- Commit hooks: passed on the squashed commit