### PR TITLE
fix: stop the busy indicator animating while hidden

### DIFF
--- a/solara/server/templates/solara.html.j2
+++ b/solara/server/templates/solara.html.j2
@@ -58,7 +58,8 @@
 {% raw -%}
 <script type="x-template" id="vue-app-template" style="display: none">
     <v-app :key="forceUpdateTrigger" :class="loadingPage ? 'solara-page-loading' : ''">
-        <v-progress-linear :style="{visibility: (kernelBusyLong && isMounted) ? 'visible' : 'hidden'}" indeterminate
+        <v-progress-linear :style="{visibility: (kernelBusyLong && isMounted) ? 'visible' : 'hidden'}"
+            :indeterminate="kernelBusyLong && isMounted"
             absolute></v-progress-linear>
         <v-alert v-if="needsRefresh || cancelAutoRefresh" type="warning" border="left"
             style="position: absolute; right: 0px; z-index: 100; left: 0px;">


### PR DESCRIPTION
## What

The kernel-busy progress bar (`v-progress-linear` in the app template) is shown/hidden with `visibility`, but `indeterminate` was hardcoded `true`. An indeterminate Vuetify progress bar runs CSS keyframe animations continuously, and `visibility: hidden` does **not** stop them — so every Solara page runs a full style/layout/layerize/paint pass at 60fps for as long as the tab is open, even when completely idle.

This binds `:indeterminate` to the same condition as visibility, so the animating elements are removed from the render tree when the kernel is not busy.

## Why

Found while profiling an app with Chrome DevTools: a 25-second trace of an **idle** page showed ~1600 rendering-pipeline events (60/s), ~55ms/s of main-thread time plus continuous GPU compositing. It affects every Solara page, on every client, indefinitely — a needless drain on battery/CPU for idle tabs.

## Verification

After the change, on an idle page:
- `document.getAnimations()` → `0` (was 2: `indeterminate` + `indeterminate-short`)
- a 25s performance trace shows **zero** `Layout`/`Paint`/`Layerize` events

Behaviour when the kernel *is* busy is unchanged: the bar still shows and animates (`kernelBusyLong && isMounted`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)