### PR TITLE
fix: purge stale comms on soft-remount + claim backend key on takeover miss (zombie-kernel fencing)

### DIFF
--- a/solara/server/static/main-vuetify.js
+++ b/solara/server/static/main-vuetify.js
@@ -136,6 +136,35 @@ async function solaraInit(mountId, appName) {
     // re-entrancy + flapping guard for the soft-remount (§6.2)
     let remountInProgress = false;
 
+    // Purge orphaned comm registrations left on the kernel CONNECTION after a widget manager is
+    // torn down. jupyter-widgets' WidgetModel.close(true) (used by clearStateLocal for a silent
+    // local teardown) deletes the model's reference to its comm but does NOT unregister the
+    // CommHandler from the connection's private _comms map (close(true) skips comm.close()). Those
+    // orphans are inert on the same node, but on a reconnect that lands on a DIFFERENT node still
+    // serving one of those ids, the resync (_loadFromKernel -> createComm(id)) throws
+    // "Comm is already created" mid-map, leaving half the widget tree detached (inputs never sync
+    // to python again). Disposing the CommHandler runs its unregister callback WITHOUT sending a
+    // comm_close over the wire (matching clearStateLocal's silent intent). commIdsBefore is
+    // snapshotted before the new manager registers its fresh comms, so we never purge live ones.
+    function purgeStaleComms(commIdsBefore) {
+        const comms = kernel && kernel._comms;
+        if (!comms || typeof comms.get !== 'function') {
+            // bundle change (private field renamed): skip rather than throw - the collision is
+            // rare (needs a cross-node reconnect) and must not break the common reconnect path.
+            return;
+        }
+        for (const id of commIdsBefore) {
+            const comm = comms.get(id);
+            if (comm && typeof comm.dispose === 'function') {
+                try {
+                    comm.dispose();
+                } catch (e) {
+                    console.warn('solara remount: stale comm dispose failed', e);
+                }
+            }
+        }
+    }
+
     // debug/test hooks on the solara JS global (§6.4): always-on, unstable-by-contract. Getters
     // return the CURRENT closure values because the socket is replaced on every reconnect and the
     // widget manager on every soft-remount, so captured references go stale by design.
@@ -246,6 +275,12 @@ async function solaraInit(mountId, appName) {
         }
         remountInProgress = true;
         app.$data.remounting = true;
+        // snapshot the comm ids registered on the connection BEFORE teardown, so we can purge the
+        // ones orphaned by the silent teardown below (see purgeStaleComms). Taken before the new
+        // manager runs, so it can only ever name comms from the generation we are tearing down.
+        const commIdsBefore = (kernel && kernel._comms && typeof kernel._comms.keys === 'function')
+            ? [...kernel._comms.keys()]
+            : [];
         try {
             // tear down the dead widget manager (disposes models). On a fresh kernel the old comms
             // are already gone server-side, so prefer the silent local teardown (bundle >= 0.5.0)
@@ -273,6 +308,10 @@ async function solaraInit(mountId, appName) {
                     console.warn('solara remount: dispose failed', e);
                 }
             }
+            // the silent teardown above (clearStateLocal / close(true)) leaves the disposed
+            // widgets' CommHandlers registered on the connection; purge them now, before the new
+            // manager registers its own, so a later cross-node reconnect resync cannot collide.
+            purgeStaleComms(commIdsBefore);
             // settled promises would otherwise make the re-mount a no-op (§6.2)
             delete widgetPromises[mountId];
             delete widgetResolveFns[mountId];

--- a/solara/state/memory.py
+++ b/solara/state/memory.py
@@ -46,6 +46,27 @@ class MemoryStateBackend(StateBackend):
             return None
         return entry
 
+    def _claim(self, kernel_id: str, session_hmacs: Sequence[bytes], schema_tag: str) -> None:
+        """Write the fresh-start entry (generation 1, no fields) for claim-on-miss.
+
+        Caller holds ``self._lock``. Stores the FIRST candidate hmac as the identity (there is no
+        stored identity to verify against on a miss; the first candidate is the current signing
+        key by the sign-first rotation convention). No candidates -> no claim (fail open to the
+        pre-claim behavior rather than storing an unverifiable empty identity).
+        """
+        first = bytes(session_hmacs[0]) if session_hmacs else b""
+        if not first:
+            return
+        from .persist import _default_ttl
+
+        self._store[kernel_id] = _Entry(
+            generation=1,
+            session_hmac=first,
+            schema_tag=schema_tag,
+            fields={},
+            deadline=self._clock() + _default_ttl(),
+        )
+
     def takeover(self, kernel_id: str, session_hmacs: "Union[bytes, Sequence[bytes]]", schema_tag: str) -> TakeoverResult:
         # bytes IS a Sequence[int]: a bare-bytes arg would iterate to ints and silently never match.
         if isinstance(session_hmacs, (bytes, bytearray)):
@@ -53,6 +74,15 @@ class MemoryStateBackend(StateBackend):
         with self._lock:
             entry = self._get_live(kernel_id)
             if entry is None:
+                # claim-on-miss (fencing for never-flushed kernels): write the fresh-start
+                # generation NOW instead of waiting for the first flush. Without the claim,
+                # peek_generation() stays None until something is flushed, so a kernel that never
+                # persists a value (e.g. a login form pre-login) is an UNFENCEABLE zombie: after a
+                # cross-node takeover, _reuse_context_is_stale can never supersede the old context
+                # and it keeps re-serving stale widgets. The claim stores the claimer's identity
+                # (first candidate = the current signing key, sign-first convention) and the same
+                # TTL as a takeover refresh, so an abandoned claim simply expires.
+                self._claim(kernel_id, session_hmacs, schema_tag)
                 return TakeoverResult(reason="miss", generation=1, fields={})
             # verify-ANY (key rotation): the stored identity may have been written under a now-old
             # key; constant-time compare against every candidate.
@@ -60,6 +90,9 @@ class MemoryStateBackend(StateBackend):
                 return TakeoverResult(reason="identity-mismatch", generation=0, fields={})
             if entry.schema_tag != schema_tag:
                 del self._store[kernel_id]
+                # same unfenceable-zombie hole as the miss branch: the caller proceeds at
+                # generation 1 with fresh state, so claim the key for it under the new schema tag.
+                self._claim(kernel_id, session_hmacs, schema_tag)
                 return TakeoverResult(reason="schema-reset", generation=1, fields={})
             entry.generation += 1
             # refresh the deadline on connect, matching the redis Lua's EXPIRE on takeover

--- a/solara/state/redis.py
+++ b/solara/state/redis.py
@@ -34,8 +34,30 @@ logger = logging.getLogger("solara.state.redis")
 # Verify identity (verify-ANY across the candidate session HMACs, for key rotation) -> check schema
 # -> bump generation -> refresh TTL -> read reactive:* fields, as one atomic unit. Returns a flat
 # array: {reason, generation [, field, value]...}.
+#
+# On a MISS (and after a schema reset) the key is CLAIMED: the fresh-start generation (1), the
+# claimer's identity (ARGV[3] - the current signing key, sign-first rotation convention; on a miss
+# there is no stored hmac to verify against) and the schema tag are written with the takeover TTL.
+# Without the claim, peek_generation() stays nil until the first flush, so a kernel that never
+# persists a value (e.g. a login form pre-login) is an UNFENCEABLE zombie: after a cross-node
+# takeover the old node's _reuse_context_is_stale can never supersede its live context, and it
+# keeps re-serving stale widgets whose inputs no longer sync. An abandoned claim simply
+# TTL-expires; the claimer's first flush (generation 1) becomes a plain fenced update.
 _LUA_TAKEOVER = """
+local function claim()
+    if not ARGV[3] then
+        return
+    end
+    redis.call('HSET', KEYS[1], '__generation__', 1)
+    redis.call('HSET', KEYS[1], '__session_id__', ARGV[3])
+    redis.call('HSET', KEYS[1], '__version__', ARGV[1])
+    local ttl = tonumber(ARGV[2])
+    if ttl and ttl >= 1 then
+        redis.call('EXPIRE', KEYS[1], ttl)
+    end
+end
 if redis.call('EXISTS', KEYS[1]) == 0 then
+    claim()
     return {'miss', 1}
 end
 local stored_session = redis.call('HGET', KEYS[1], '__session_id__')
@@ -54,6 +76,7 @@ end
 local stored_version = redis.call('HGET', KEYS[1], '__version__')
 if (not stored_version) or (stored_version ~= ARGV[1]) then
     redis.call('DEL', KEYS[1])
+    claim()
     return {'schema-reset', 1}
 end
 local generation = redis.call('HINCRBY', KEYS[1], '__generation__', 1)

--- a/tests/integration/reconnect_state_test.py
+++ b/tests/integration/reconnect_state_test.py
@@ -163,6 +163,67 @@ def test_state_persistence_soft_remount(
         page_session.goto("about:blank")
 
 
+# --- stale-comm purge on soft-remount (regression for the cross-node comm collision) -------
+
+
+def test_soft_remount_purges_stale_comms(
+    browser: playwright.sync_api.Browser,
+    page_session: playwright.sync_api.Page,
+    solara_server,
+    solara_app,
+    extra_include_path,
+    request,
+    state_settings,
+):
+    """A soft-remount must not leak the disposed generation's comms on the kernel connection.
+
+    Mechanism (confirmed against @jupyter-widgets/base): the silent local teardown closes each
+    widget model with ``close(true)`` ("comm already closed remotely"), which deletes the model's
+    reference to its comm but does NOT unregister the CommHandler from the connection's ``_comms``
+    map. Those orphans are inert on the same node, but when a later reconnect lands on a DIFFERENT
+    node that still serves one of those ids, the resync (``_loadFromKernel`` -> ``createComm(id)``)
+    throws "Comm is already created" mid-map and leaves half the widget tree detached (its inputs
+    never sync to python again - e.g. a login button that can never enable). Observed on a
+    round-robin staging deploy.
+
+    We can't stand up two nodes in-process, but we can pin the fix's precondition deterministically:
+    after a real single-process soft-remount, NONE of the comm ids that were registered before the
+    remount may still be registered on the connection. Without the purge they linger (RED); with it
+    they are disposed (GREEN). We also assert the collision error never surfaces and the app stays
+    interactive.
+    """
+    page_errors: list = []
+    page_session.on("pageerror", lambda exc: page_errors.append(str(exc)))
+    try:
+        with extra_include_path(HERE), solara_app("reconnect_state_test:Page"):
+            page_session.goto(solara_server.base_url)
+            page_session.locator("text=Value 0").wait_for()
+
+            # comm ids registered on the connection for THIS (pre-remount) generation
+            comm_ids_before = set(page_session.evaluate("Array.from(solara.debug.kernel()._comms.keys())"))
+            assert comm_ids_before, "expected the kernel connection to have registered comms before failover"
+
+            # real single-process failover -> soft-remount (same path as the marquee test)
+            page_session.evaluate("solara.debug.simulateFailover()")
+            page_session.wait_for_function("() => window.solara && solara.debug && solara.debug.remountCount === 1", timeout=30000)
+            page_session.locator("text=Value 0").wait_for()
+
+            # the disposed generation's comms must be gone from the connection registry
+            comm_ids_after = set(page_session.evaluate("Array.from(solara.debug.kernel()._comms.keys())"))
+            leaked = comm_ids_before & comm_ids_after
+            assert not leaked, f"stale comms from before the remount still registered on the kernel connection: {leaked}"
+
+            # the collision itself must never have surfaced
+            assert not any("Comm is already created" in e for e in page_errors), page_errors
+
+            # app still interactive after the remount: the button syncs to python
+            page_session.locator("text=IncrementCount").click()
+            page_session.locator("text=Value 1").wait_for()
+            assert not any("Comm is already created" in e for e in page_errors), page_errors
+    finally:
+        page_session.goto("about:blank")
+
+
 # --- fail-closed gate (cheap negative, no browser) ----------------------------------------
 
 

--- a/tests/unit/state_backend_test.py
+++ b/tests/unit/state_backend_test.py
@@ -52,14 +52,65 @@ def backend(request):
         client.flushdb()
 
 
-def test_miss_writes_nothing(backend):
+def test_miss_claims_the_key(backend):
     result = backend.takeover("k", SESSION_A, "v1")
     assert result.reason == "miss"
     assert result.generation == 1
     assert result.fields == {}
-    # a miss must not have created anything: a second takeover is still a miss
-    assert backend.peek_generation("k") is None
-    assert backend.takeover("k", SESSION_A, "v1").reason == "miss"
+    # claim-on-miss: the fresh-start generation is immediately visible to peek_generation, so a
+    # kernel that never flushes anything (e.g. a login form pre-login) is still FENCEABLE - its
+    # node can detect a later takeover elsewhere and supersede the zombie context. (Before the
+    # claim, peek stayed None until the first flush and such kernels were unfenceable.)
+    assert backend.peek_generation("k") == 1
+    # a repeat takeover by the same session is now a restore of the claimed (empty) key
+    again = backend.takeover("k", SESSION_A, "v1")
+    assert again.reason == "restored"
+    assert again.generation == 2
+    assert again.fields == {}
+
+
+def test_claimed_key_supersedes_never_flushed_owner(backend):
+    # node A claims on miss and never flushes (nothing persisted yet)
+    a = backend.takeover("k", SESSION_A, "v1")
+    assert (a.reason, a.generation) == ("miss", 1)
+    # node B (same browser session) takes over the same kernel id
+    b = backend.takeover("k", SESSION_A, "v1")
+    assert b.generation == 2
+    # A can now SEE it is behind - exactly the _reuse_context_is_stale comparison
+    stored = backend.peek_generation("k")
+    assert stored == 2
+    assert stored != a.generation
+    # and A's late first-flush is fenced out
+    assert backend.flush("k", a.generation, {"reactive:x": b"stale"}, TTL, SESSION_A, "v1") is False
+
+
+def test_claimed_key_refuses_foreign_session(backend):
+    # the claimed-but-never-flushed key follows the same identity rule as a flushed one
+    backend.takeover("k", SESSION_A, "v1")
+    result = backend.takeover("k", SESSION_B, "v1")
+    assert result.reason == "identity-mismatch"
+    assert result.generation == 0
+    assert result.fields == {}
+    # the foreign session gained no write rights
+    assert backend.flush("k", 2, {"reactive:x": b"evil"}, TTL, SESSION_B, "v1") is False
+
+
+def test_claim_expires_with_ttl(backend):
+    if isinstance(backend, MemoryStateBackend):
+        now = [0.0]
+        backend._clock = lambda: now[0]
+        backend.takeover("k", SESSION_A, "v1")
+        assert backend.peek_generation("k") == 1
+        # the claim carries the default ttl (hours in practice); jump far past any sane value
+        now[0] = 10 * 24 * 3600.0
+        assert backend.peek_generation("k") is None
+        # an expired claim behaves as absent: the next takeover is a fresh miss+claim
+        assert backend.takeover("k", SESSION_A, "v1").reason == "miss"
+    else:
+        # redis: the claim must have set an EXPIRE (abandoned claims may not live forever)
+        backend.takeover("k", SESSION_A, "v1")
+        ttl = backend.client.ttl(backend._key("k"))
+        assert ttl > 0
 
 
 def test_flush_creates_with_identity_on_absent_key(backend):
@@ -123,9 +174,13 @@ def test_schema_reset_deletes(backend):
     assert result.reason == "schema-reset"
     assert result.generation == 1
     assert result.fields == {}
-    # the hash was deleted, so it is gone entirely
-    assert backend.peek_generation("k") is None
-    assert backend.takeover("k", SESSION_A, "v1").reason == "miss"
+    # the old-tag data was deleted, and (same unfenceable-zombie hole as a miss) the key was
+    # re-CLAIMED for the caller under the new tag: generation 1, no data fields
+    assert backend.peek_generation("k") == 1
+    assert backend.takeover("k", SESSION_A, "v2").fields == {}
+    # a takeover with the old tag hits the claimed key and resets again (schema flapping is
+    # always a reset, never a silent restore across tags)
+    assert backend.takeover("k", SESSION_A, "v1").reason == "schema-reset"
 
 
 def test_fenced_flush_rejects_stale_generation(backend):

--- a/tests/unit/state_redis_test.py
+++ b/tests/unit/state_redis_test.py
@@ -218,12 +218,26 @@ def test_e2e_double_reconnect_two_backends_one_server(monkeypatch):
     session_id, kernel_id = "sess-r-abab", "kern-r-abab"
     shmac = session_hmac(session_id)
 
-    # instance A flushes "from-A" at generation 1
+    # instance A flushes "from-A" at generation 1. Flush synchronously: since takeover claims
+    # the key on a miss, peek==1 no longer means "A's flush landed" — a debounced flush still
+    # in flight here would race B's takeover below and get fenced, flipping this into the
+    # (designed, §5.5) reclaim-once fight instead of the zombie scenario this test pins.
     context_a = kc.initialize_virtual_kernel(session_id, kernel_id, Mock())
     context_a.page_connect("pageA")
     with context_a:
         r.value = "from-A"
-    assert wait_until(lambda: backend_a.peek_generation(kernel_id) == 1)
+    manager_a = context_a.state_persistence
+    assert manager_a is not None
+    assert manager_a.flush_now() == FlushOutcome.OK
+    assert backend_a.peek_generation(kernel_id) == 1
+    # the page's websocket drops BEFORE the reconnect lands on B (what a real failover does).
+    # Also required for determinism in-process: toestand scopes listeners by kernel *id* (see
+    # watch()'s docstring), so B's r.value below re-marks A dirty; A's debounced flush then gets
+    # fenced, and a fenced kernel WITH a connected page would take the (designed, §5.5)
+    # reclaim-once path — gen 3, defeating the zombie scenario this test pins. Disconnected,
+    # a fenced A is an orphan: it concedes and closes as superseded — the same outcome the
+    # reconnect's staleness check produces, whichever fires first.
+    context_a.page_disconnect("pageA")
 
     # instance B (the second backend on the same server) takes over -> gen 2, then flushes "from-B"
     result_b = backend_b.takeover(kernel_id, shmac, SCHEMA_TAG)

--- a/tests/unit/state_server_test.py
+++ b/tests/unit/state_server_test.py
@@ -119,12 +119,21 @@ def test_double_reconnect_supersedes_stale_context(backend):
     session_id, kernel_id = "sess-abab", "kern-abab"
     shmac = session_hmac(session_id)
 
-    # instance A lives in contexts and flushes "from-A" at generation 1
+    # instance A lives in contexts and flushes "from-A" at generation 1. Flush synchronously
+    # (claim-on-miss makes peek==1 true before the debounced flush lands) and drop A's page —
+    # what a real failover does — so A's cross-marked debounced flush (toestand scopes listeners
+    # by kernel id, so B's write below re-marks A dirty) fences as an ORPHAN that concedes,
+    # instead of taking the connected-page reclaim-once path (§5.5) that would bump past B on
+    # slow runners and fence B's flush.
     context_a = kc.initialize_virtual_kernel(session_id, kernel_id, Mock())
     context_a.page_connect("pageA")
     with context_a:
         r.value = "from-A"
-    assert wait_until(lambda: backend.peek_generation(kernel_id) == 1)
+    manager_a = context_a.state_persistence
+    assert manager_a is not None
+    assert manager_a.flush_now() == FlushOutcome.OK
+    assert backend.peek_generation(kernel_id) == 1
+    context_a.page_disconnect("pageA")
 
     # simulate instance B taking over on another instance: takeover bumps to 2, then flush "from-B"
     result_b = backend.takeover(kernel_id, shmac, SCHEMA_TAG)

--- a/tests/unit/state_server_test.py
+++ b/tests/unit/state_server_test.py
@@ -147,6 +147,44 @@ def test_double_reconnect_supersedes_stale_context(backend):
         assert r.value == "from-B"
 
 
+def test_double_reconnect_supersedes_never_flushed_context(backend):
+    """The A->B->A bounce for a kernel that NEVER flushed (e.g. a login form pre-login).
+
+    Regression for the unfenceable-zombie hole: without claim-on-miss in ``takeover()``, a
+    never-flushed kernel has no backend row, ``peek_generation()`` returns None forever, and
+    ``_reuse_context_is_stale`` can never supersede the old context after a cross-node takeover -
+    it keeps re-serving stale widgets whose inputs no longer sync (observed on a round-robin
+    staging deploy as a login button that could never enable). With the claim, the miss itself
+    establishes generation 1, so the takeover on node B is visible to node A's reuse check.
+    """
+    r = solara.reactive("v0", persist=True, key="test.server.neverflushed")
+    session_id, kernel_id = "sess-neverflushed", "kern-neverflushed"
+    shmac = session_hmac(session_id)
+
+    # instance A connects; nothing is ever flushed (the user typed into non-persisted inputs only)
+    context_a = kc.initialize_virtual_kernel(session_id, kernel_id, Mock())
+    context_a.page_connect("pageA")
+    assert context_a.state_persistence is not None
+    assert context_a.state_persistence.generation == 1
+    # the claim made the never-flushed kernel visible (this is the fix's crux: None before)
+    assert backend.peek_generation(kernel_id) == 1
+
+    # instance B takes over the same kernel id (same browser session); still no flush anywhere
+    result_b = backend.takeover(kernel_id, shmac, SCHEMA_TAG)
+    assert result_b.generation == 2
+
+    # reconnect lands back on A's reuse branch: the never-flushed zombie must be superseded
+    context_new = kc.initialize_virtual_kernel(session_id, kernel_id, Mock())
+    assert context_new is not context_a
+    assert context_a.closed_event.is_set()
+    assert context_a.close_reason == "superseded"
+    assert context_new.state_persistence is not None
+    # the fresh context took over at a higher generation and starts from defaults (nothing stored)
+    assert context_new.state_persistence.generation == 3
+    with context_new:
+        assert r.value == "v0"
+
+
 # --- session mismatch on takeover ---------------------------------------------------------
 
 

--- a/tests/unit/state_worker_test.py
+++ b/tests/unit/state_worker_test.py
@@ -251,15 +251,18 @@ def test_breaker_open_leaves_keys_dirty_then_drains(worker_factory):
     worker.start()
     with context:
         r.value = 5
-    # first attempt hits an open breaker: skip, keys stay dirty, nothing written
+    # first attempt hits an open breaker: skip, keys stay dirty, no DATA written (the attach-time
+    # takeover claim-on-miss already wrote the generation-1 meta row, so peek is 1 by design;
+    # "nothing flushed" is now observable as the claimed row having no data fields)
     assert worker.wait_for_flushes(1)
     assert manager.dirty_keys == {key}
-    assert backend.peek_generation(context.id) is None
+    assert backend.peek_generation(context.id) == 1
+    assert backend._store[context.id].fields == {}
     # let the window elapse; the re-armed timer retries and, with the breaker now closing on a
     # successful probe, drains the dirty keys (no permanent stranding)
     clock.advance(30.0)
     # wait on the backend observable: flush_now drains dirty BEFORE the write lands
-    assert wait_until(lambda: backend.peek_generation(context.id) == 1)
+    assert wait_until(lambda: backend._store[context.id].fields != {})
     assert manager.dirty_keys == set()
     assert breaker.state == "closed"
 


### PR DESCRIPTION
## The bug (staging, round-robin LB, opt-in state persistence)

After a soft-remount, reconnects that landed back on the original node produced `Uncaught (in promise) Error: Comm is already created` mid-resync — and, worse, a **wedge**: the page kept talking to the old node's stale kernel, typing no longer synced to Python (a login button that could never enable), and `remountCount` stuck at 1 forever.

An independent two-node verification rig (2 solara instances behind Caddy `round_robin`, shared real redis, instrumented `createComm`) split this into **two independent defects**, each with its own fix and commit:

## 1. Client: stale comm registrations survive the soft-remount (`main-vuetify.js`)

`clearStateLocal()` → `WidgetModel.close(true)` skips `comm.close()` (by design — silent teardown), but that leaves every disposed model's `CommHandler` registered in the kernel connection's `_comms` map. A reconnect landing on a node still serving those ids collides in `_loadFromKernel` → `createComm(id)` and detaches the rest of the widget tree.

**Fix**: snapshot the registered comm ids before teardown and `comm.dispose()` them after — the unregister callback fires with **no wire message**, matching the silent-teardown intent; live comms can never be purged (snapshot precedes the new manager); private-field guard degrades to no-op on bundle change.

**Rig numbers (calm scenario: 6 reconnects spaced 5 s):** master **72 collisions + 3 page errors** per run → with the purge **0/0**. Ablation confirmed the purge alone accounts for the entire reduction (a single-flight reconnect guard tried earlier contributed nothing and is not part of this PR). 100% of colliding ids were pre-remount boot-generation ids re-served by the original kernel surviving as a zombie.

## 2. Server: never-flushed kernels were unfenceable zombies (`memory.py`, `redis.py`)

`takeover()` on a MISS wrote nothing, so `peek_generation()` stayed `None` until the first flush — and `_reuse_context_is_stale()` could **never** supersede a kernel that hadn't persisted anything yet (login form pre-login). After a cross-node takeover, the old context survived as a live zombie: answered `app-status started=true`, re-served stale widgets, typing didn't sync. Control experiment: after one flush of any persisted value, supersede fires on every hop and there are zero issues even on unfixed master — the missing claim is the discriminator.

**Fix — claim-on-miss** (and after schema reset, same hole): takeover writes generation 1 + the claimer's identity + schema tag, with the takeover TTL.
- **Identity**: no stored hmac exists on a miss, so the FIRST candidate (current signing key, sign-first rotation convention) is stored; same-session takeovers verify via verify-any; foreign sessions refused exactly as for flushed keys.
- **TTL**: abandoned claims expire; no new litter class.
- **Flush coherence**: the claimer's first flush (gen 1) becomes a plain fenced update; refuse-create-on-missing at gen ≠ 1 untouched.
- **Client semantics**: claimed-then-retaken returns `restored` with 0 fields; `lastRestore` still reports `miss` (status derives from `n_restored`).

**Rig numbers:** master calm: node pinned to the zombie (`8801,8801,8801…`), `remount=1` across 8 reconnects, **typing dead on 3/6 steps**. Fixed branch: nodes alternate every hop (`8801,8802,8801…`), **`remount=7` of 8 reconnects** (supersede on every real hop), **0 typing failures, 0 collisions, 0 page errors**. Rapid scenario: master 168 collisions/7 page errors → **0/0**.

## Tests
- `test_soft_remount_purges_stale_comms` (integration, flask+starlette): RED without the purge (25 leaked ids), GREEN with it.
- `test_miss_claims_the_key`, `test_claimed_key_supersedes_never_flushed_owner`, `test_claimed_key_refuses_foreign_session`, `test_claim_expires_with_ttl` (backend contract, memory + fakeredis-Lua + opt-in real redis).
- `test_double_reconnect_supersedes_never_flushed_context` (server): the A→B→A bounce with NO flush anywhere — the exact staging wedge; fails without claim-on-miss.
- Updated: `test_schema_reset_deletes` (reset now re-claims), breaker-open test ("nothing flushed" now asserted on data fields, since the claim legitimately writes the meta row).

Full `tests/unit/state_*` + lifecycle: **174 passed**. `tests/integration/reconnect_state_test.py`: **5 passed, 1 skipped**. Pre-commit (ruff/mypy) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
