### PR TITLE
fix: make ES module (define_module) hot reload survive in-place app reload

### DIFF
--- a/solara/server/app.py
+++ b/solara/server/app.py
@@ -338,7 +338,10 @@ class AppScript:
             # ask all contexts/users to reload
             for context in context_values:
                 with context:
-                    context.reload()
+                    try:
+                        context.reload()
+                    except Exception:
+                        logger.exception("Could not reload context %s", context.id)
 
 
 def _run_app(
@@ -589,8 +592,11 @@ def solara_comm_target(comm, msg_first):
 
     def reload():
         comm = comm_ref()
-        assert comm is not None
         context = kernel_context.get_current_context()
+        if comm is None:
+            # client is gone (page closed/navigated); nothing to reload
+            logger.debug(f"No control comm for context {context.id}, skipping reload")
+            return
         # we don't reload the app ourself, we send a message to the client
         # this ensures that we don't run code of any client that for some reason is connected
         # but not working anymore. And it indirectly passes a message from the current thread

--- a/solara/server/esm.py
+++ b/solara/server/esm.py
@@ -23,11 +23,18 @@ _import_map_per_kernel: Dict[str, ipyreact.importmap.ImportMap] = {}
 # in solara server, we'll monkey patch ipyreact.module with this
 def define_module(name, module: Union[str, Path]):
     # collect the dependencies at this moment
-    dependencies = list(_modules.keys())
-    logger.info("define module %s %s (dependencies=%r)", name, module, dependencies)
-    if name in _modules:
-        old_module, dependencies = _modules[name]
-    _modules[name] = (module, dependencies)
+    with lock:
+        dependencies = list(_modules.keys())
+        logger.info("define module %s %s (dependencies=%r)", name, module, dependencies)
+        if name in _modules:
+            old_module, dependencies = _modules[name]
+        _modules[name] = (module, dependencies)
+    if isinstance(module, Path):
+        # rebuilding the bundle (e.g. vite/esbuild --watch) triggers a normal
+        # solara reload, which re-reads the file in create_modules
+        from solara.server import reload
+
+        reload.reloader.watcher.add_file(str(module))
     if kernel_context.has_current_context():
         create_modules()
     return None
@@ -38,13 +45,26 @@ def get_module_names():
 
 
 def create_modules():
-    kernel_id = kernel_context.get_current_context().id
+    context = kernel_context.get_current_context()
+    kernel_id = context.id
+    if kernel_id not in _modules_added_per_kernel:
+        # widgets close with the kernel; drop our per-kernel bookkeeping too
+        def cleanup(kernel_id=kernel_id):
+            _modules_added_per_kernel.pop(kernel_id, None)
+            _import_map_per_kernel.pop(kernel_id, None)
+
+        context.on_close(cleanup)
     _modules_added = _modules_added_per_kernel[kernel_id]
     logger.info("create modules %s", _modules)
     widgets = {}
     with lock:
         for name, (module, dependencies) in _modules.items():
-            if name not in _modules_added:
+            widget = _modules_added.get(name)
+            if widget is not None and widget.comm is None:
+                # closed by context.restart (hot reload) - a trait update
+                # would go nowhere, recreate instead
+                widget = None
+            if widget is None:
                 _modules_added[name] = create_module(name, module, dependencies=dependencies)
                 logger.info("create module %s %s %s", name, module, dependencies)
             else:
@@ -62,7 +82,11 @@ def create_module(name, module: Union[str, Path], dependencies: List[str]):
 def create_import_map():
     kernel_id = kernel_context.get_current_context().id
     with lock:
-        if kernel_id not in _import_map_per_kernel:
+        widget = _import_map_per_kernel.get(kernel_id)
+        if widget is not None and widget.comm is None:
+            # closed by context.restart (hot reload), recreate instead
+            widget = None
+        if widget is None:
             _import_map_per_kernel[kernel_id] = ipyreact.importmap.ImportMap(import_map=ipyreact.importmap._effective_import_map)
             logger.info("create import map %s", ipyreact.importmap._effective_import_map)
         else:

--- a/tests/integration/esm_test.py
+++ b/tests/integration/esm_test.py
@@ -1,8 +1,11 @@
 from pathlib import Path
 
+import uuid
+
 import ipyreact
 import playwright
 import pytest
+from packaging.version import Version
 
 import solara
 import solara.server.patch
@@ -48,3 +51,51 @@ def test_ipyreact(browser: playwright.sync_api.Browser, page_session: playwright
         page_session.goto(solara_server.base_url)
         page_session.locator("text=clicked 0").first.click()
         page_session.locator("text=clicked 1").first.click()
+
+
+hot_module_code = """
+import * as React from "react";
+
+export function Label() {
+    return React.createElement("div", {className: "hot-widget"}, "version %d");
+};
+"""
+
+hot_app_code = """
+from pathlib import Path
+
+import ipyreact
+import solara
+
+HERE = Path(__file__).parent
+
+ipyreact.define_module("hot-reload-module", HERE / "hot_module.js")
+
+
+@solara.component
+def Page():
+    ipyreact.Widget.element(_module="hot-reload-module", _type="Label")
+"""
+
+
+@pytest.mark.skipif(
+    Version(ipyreact.__version__) <= Version("0.5.0"),
+    reason="needs the module hot reload frontend fixes (widgetti/ipyreact#79)",
+)
+def test_ipyreact_module_hot_reload(
+    tmp_path, browser: playwright.sync_api.Browser, page_session: playwright.sync_api.Page, solara_server, solara_app, extra_include_path
+):
+    # define_module(Path) registers the bundle with the reloader: rewriting
+    # the file must trigger an in-place reload, recreate the (closed) Module
+    # widget and render the new code - no page refresh, no app file change.
+    # unique module name: the app is imported once per parametrized instance
+    # from a different tmp_path, but python caches by module name
+    app_name = f"esm_hot_app_{uuid.uuid4().hex[:8]}"
+    module_file = tmp_path / "hot_module.js"
+    module_file.write_text(hot_module_code % 1)
+    (tmp_path / f"{app_name}.py").write_text(hot_app_code)
+    with extra_include_path(str(tmp_path)), solara_app(f"{app_name}:Page"):
+        page_session.goto(solara_server.base_url)
+        page_session.locator(".hot-widget >> text=version 1").wait_for()
+        module_file.write_text(hot_module_code % 2)
+        page_session.locator(".hot-widget >> text=version 2").wait_for()

--- a/tests/unit/esm_test.py
+++ b/tests/unit/esm_test.py
@@ -1,0 +1,90 @@
+from pathlib import Path
+
+import pytest
+
+ipyreact = pytest.importorskip("ipyreact")
+
+from solara.server import esm, kernel_context  # noqa: E402
+from solara.server.kernel import Kernel  # noqa: E402
+
+
+@pytest.fixture()
+def clean_esm_state():
+    modules = esm._modules.copy()
+    esm._modules.clear()
+    added = dict(esm._modules_added_per_kernel)
+    esm._modules_added_per_kernel.clear()
+    import_maps = dict(esm._import_map_per_kernel)
+    esm._import_map_per_kernel.clear()
+    try:
+        yield
+    finally:
+        esm._modules.clear()
+        esm._modules.update(modules)
+        esm._modules_added_per_kernel.clear()
+        esm._modules_added_per_kernel.update(added)
+        esm._import_map_per_kernel.clear()
+        esm._import_map_per_kernel.update(import_maps)
+
+
+@pytest.fixture()
+def virtual_context(clean_esm_state):
+    context = kernel_context.VirtualKernelContext(id="esm-test-1", kernel=Kernel(), session_id="session-esm-1")
+    try:
+        with context:
+            yield context
+    finally:
+        context.close()
+
+
+def test_create_modules_per_kernel_reuse(virtual_context):
+    esm.define_module("esm-test-module", "export default 1")
+    widgets = esm.create_modules()
+    widget = widgets["esm-test-module"]
+    # a second call must reuse the same (live) widget for this kernel
+    assert esm.create_modules()["esm-test-module"] is widget
+
+
+def test_create_modules_recreates_closed_widget(virtual_context):
+    esm.define_module("esm-test-module", "export default 1")
+    widget = esm.create_modules()["esm-test-module"]
+    # context.restart() closes the kernel's widgets on (hot) reload; updating
+    # a trait on a closed widget never reaches the browser, so create_modules
+    # must hand out a fresh widget instead
+    widget.close()
+    assert widget.comm is None
+    widget2 = esm.create_modules()["esm-test-module"]
+    assert widget2 is not widget
+    assert widget2.comm is not None
+
+
+def test_redefine_module_updates_live_widget(virtual_context):
+    esm.define_module("esm-test-module", "export default 1")
+    widget = esm.create_modules()["esm-test-module"]
+    esm.define_module("esm-test-module", "export default 2")
+    assert esm.create_modules()["esm-test-module"] is widget
+    assert widget.code == "export default 2"
+
+
+def test_define_module_path_is_watched(clean_esm_state, tmp_path: Path, monkeypatch):
+    from solara.server import reload
+
+    watched = []
+    monkeypatch.setattr(reload.reloader.watcher, "add_file", lambda file: watched.append(str(file)))
+    module = tmp_path / "bundle.mjs"
+    module.write_text("export default 1")
+    esm.define_module("esm-test-path-module", module)
+    assert watched == [str(module)]
+
+
+def test_kernel_bookkeeping_dropped_on_close(clean_esm_state):
+    context = kernel_context.VirtualKernelContext(id="esm-test-2", kernel=Kernel(), session_id="session-esm-2")
+    with context:
+        esm.define_module("esm-test-module", "export default 1")
+        esm.create_modules()
+        esm.create_import_map()
+        assert "esm-test-2" in esm._modules_added_per_kernel
+        assert "esm-test-2" in esm._import_map_per_kernel
+    context.close()
+    assert "esm-test-2" not in esm._modules_added_per_kernel
+    assert "esm-test-2" not in esm._import_map_per_kernel


### PR DESCRIPTION
## Summary

Companion to widgetti/ipyreact#79. The named-module path (`ipyreact.define_module`, patched kernel-aware in `solara/server/esm.py`) could not hot-reload module code without a manual page refresh — note this is distinct from the per-widget `_esm` path, which hot-reloads fine and is unchanged.

Kernel-side causes fixed here:

- **`context.restart()` (in-place reload) closes the per-kernel `Module`/`ImportMap` widgets**, so the redefine path updated traits on dead widgets — the new code never reached the browser. `create_modules`/`create_import_map` now recreate widgets whose comm is gone.
- **`define_module(Path)` now registers the file with the reloader**: a `vite`/`esbuild --watch` rebuild of a bundle triggers a normal in-place reload — edit → build → see, no app-file touching.
- Per-kernel bookkeeping is dropped on kernel close (was leaking per kernel id); `_modules` mutation is locked against concurrent `create_modules` from other kernels.
- Robust reload: one dead control comm (a closed/navigated page) no longer aborts reload for **every** other context (`assert comm is not None` → skip, plus a per-context exception guard in the watcher loop).

## Tests

- `tests/unit/esm_test.py`: widget reuse per kernel, recreation after close, live-trait update, Path-watch registration, bookkeeping cleanup on kernel close. 3 of 5 fail on the previous `esm.py` (the new behaviors), 2 guard existing behavior.
- `tests/integration/esm_test.py::test_ipyreact_module_hot_reload`: browser test of the full loop — render module v1, rewrite the watched `.js` file, assert v2 renders in place. Passes locally against ipyreact with the #79 frontend fixes (both server flavors); version-gated (`ipyreact > 0.5.0`) so it skips in CI until those are released.

Found while building the analogous ES-module mechanism for ipyvue's vue3 branch, where the full loop (vite-built bundle of real .vue templates → edit → rebuild → in-place reload) is verified end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)