### PR TITLE
feat: kernel-aware ES module support for ipyvue

### DIFF
--- a/solara/components/component_vue.py
+++ b/solara/components/component_vue.py
@@ -1,6 +1,6 @@
 import inspect
 import os
-from typing import Any, Callable, Dict, Type
+from typing import Any, Callable, Dict, Optional, Type
 
 import ipyvue as vue
 import ipyvuetify as v
@@ -65,18 +65,36 @@ def _widget_from_signature(
 
 
 def _widget_vue(
-    vue_path: str,
+    vue_path: Optional[str],
     vuetify=True,
     to_json: Dict[str, Callable[[Any, widgets.Widget], Any]] = {},
     from_json: Dict[str, Callable[[Any, widgets.Widget], Any]] = {},
     tags: Dict[str, Any] = {},
+    esm_module: Optional[str] = None,
+    esm_export: Optional[str] = None,
 ) -> Callable[[Callable[P, None]], Type[v.VuetifyTemplate]]:
     def decorator(func: Callable[P, None]):
-        class VuetifyWidgetSolara(v.VuetifyTemplate):
-            template_file = (os.path.abspath(inspect.getfile(func)), vue_path)
+        if esm_module is not None:
+            # the component is an export of a precompiled ES module
+            # (see ipyvue.define_module) instead of a compiled-in-the-browser
+            # .vue file
+            class VuetifyWidgetSolara(v.VuetifyTemplate):
+                @traitlets.default("template")
+                def _default_template(self):
+                    return vue.Template(esm_module=esm_module, esm_export=esm_export)
 
-        class VueWidgetSolara(vue.VueTemplate):
-            template_file = (os.path.abspath(inspect.getfile(func)), vue_path)
+            class VueWidgetSolara(vue.VueTemplate):
+                @traitlets.default("template")
+                def _default_template(self):
+                    return vue.Template(esm_module=esm_module, esm_export=esm_export)
+
+        else:
+
+            class VuetifyWidgetSolara(v.VuetifyTemplate):  # type: ignore[no-redef]
+                template_file = (os.path.abspath(inspect.getfile(func)), vue_path)
+
+            class VueWidgetSolara(vue.VueTemplate):  # type: ignore[no-redef]
+                template_file = (os.path.abspath(inspect.getfile(func)), vue_path)
 
         base_class = VuetifyWidgetSolara if vuetify else VueWidgetSolara
         widget_class = _widget_from_signature("VueWidgetSolaraSub", base_class, func, "vue_", to_json=to_json, from_json=from_json, tags=tags)
@@ -87,11 +105,13 @@ def _widget_vue(
 
 
 def component_vue(
-    vue_path: str,
+    vue_path: Optional[str] = None,
     vuetify=True,
     tags: Dict[str, Any] = {},
     to_json: Dict[str, Callable[[Any, widgets.Widget], Any]] = {},
     from_json: Dict[str, Callable[[Any, widgets.Widget], Any]] = {},
+    esm_module: Optional[str] = None,
+    esm_export: Optional[str] = None,
 ) -> Callable[[Callable[P, None]], Callable[P, solara.Element]]:
     """Decorator to create a component backed by a Vue template.
 
@@ -165,15 +185,40 @@ def component_vue(
 
     ```
 
+    ## Precompiled ES modules
+
+    Instead of a `.vue` file that is compiled in the browser, the component can be an export of a
+    precompiled ES module (e.g. built with vite, see `ipyvue.define_module`). This requires ipyvue
+    with ES module support:
+
+    ```python
+    import ipyvue
+    import solara
+
+    ipyvue.define_module("my-components", Path(__file__).parent / "dist/my-components.mjs")
+
+    @solara.component_vue(esm_module="my-components", esm_export="Counter")
+    def Counter(count: int = 0, event_bump: Callable[[int], None] = None):
+        pass
+    ```
+
     ## Arguments
 
      * `vue_path`: The path to the Vue template file.
      * `vuetify`: Whether the Vue template uses Vuetify components.
+     * `esm_module`: Name of an ES module registered with `ipyvue.define_module` (alternative to `vue_path`).
+     * `esm_export`: The export of that module to use as the component (default: the default export).
 
     """
+    if (vue_path is None) == (esm_module is None):
+        raise TypeError("pass either vue_path or esm_module")
+    if esm_module is not None and not hasattr(vue, "define_module"):
+        raise RuntimeError("esm_module requires ipyvue with ES module support")
 
     def decorator(func: Callable[P, None]):
-        VueWidgetSolaraSub = _widget_vue(vue_path, vuetify=vuetify, to_json=to_json, from_json=from_json, tags=tags)(func)
+        VueWidgetSolaraSub = _widget_vue(
+            vue_path, vuetify=vuetify, to_json=to_json, from_json=from_json, tags=tags, esm_module=esm_module, esm_export=esm_export
+        )(func)
 
         def wrapper(*args, **kwargs):
             event_callbacks = {}

--- a/solara/server/app.py
+++ b/solara/server/app.py
@@ -412,6 +412,13 @@ def load_app_widget(app_state, app_script: AppScript, pathname: str):
         solara.server.esm.create_modules()
         solara.server.esm.create_import_map()
 
+    import ipyvue
+
+    if hasattr(ipyvue, "define_module"):
+        import solara.server.esm_vue
+
+        solara.server.esm_vue.create_modules()
+
     try:
         render_context = context.app_object
         app_state = app_state_initial

--- a/solara/server/esm.py
+++ b/solara/server/esm.py
@@ -21,19 +21,25 @@ _import_map_per_kernel: Dict[str, ipyreact.importmap.ImportMap] = {}
 
 
 # in solara server, we'll monkey patch ipyreact.module with this
-def define_module(name, module: Union[str, Path, None] = None, *, code: Optional[str] = None):
-    if (module is None) == (code is None):
-        raise TypeError("pass either module (url or Path) or code")
+def define_module(name: str, module: Optional[Path] = None, *, code: Optional[str] = None, url: Optional[str] = None):
+    if sum(x is not None for x in (module, code, url)) != 1:
+        raise TypeError("pass exactly one of module (a Path), code or url")
+    if module is not None and not isinstance(module, Path):
+        raise TypeError("module must be a Path; use url=... or code=... for strings")
+    source: Union[str, Path]
     if code is not None:
-        module = _CODE_PREFIX + code
-    assert module is not None
-    # collect the dependencies at this moment
+        source = _CODE_PREFIX + code
+    elif url is not None:
+        source = url
+    else:
+        assert module is not None
+        source = module
     with lock:
         dependencies = list(_modules.keys())
-        logger.info("define module %s %s (dependencies=%r)", name, module, dependencies)
+        logger.info("define module %s (dependencies=%r)", name, dependencies)
         if name in _modules:
             old_module, dependencies = _modules[name]
-        _modules[name] = (module, dependencies)
+        _modules[name] = (source, dependencies)
     if isinstance(module, Path):
         # rebuilding the bundle (e.g. vite/esbuild --watch) triggers a normal
         # solara reload, which re-reads the file in create_modules

--- a/solara/server/esm.py
+++ b/solara/server/esm.py
@@ -2,6 +2,7 @@
 # in the future, we may want to move the esm features of ipyreact
 # into a separate package, and then we can import it unconditionally
 import logging
+import warnings
 import threading
 from collections import defaultdict
 from pathlib import Path
@@ -21,11 +22,18 @@ _import_map_per_kernel: Dict[str, ipyreact.importmap.ImportMap] = {}
 
 
 # in solara server, we'll monkey patch ipyreact.module with this
-def define_module(name: str, module: Optional[Path] = None, *, code: Optional[str] = None, url: Optional[str] = None):
+def define_module(name: str, module: Union[str, Path, None] = None, *, code: Optional[str] = None, url: Optional[str] = None):
     if sum(x is not None for x in (module, code, url)) != 1:
         raise TypeError("pass exactly one of module (a Path), code or url")
-    if module is not None and not isinstance(module, Path):
-        raise TypeError("module must be a Path; use url=... or code=... for strings")
+    if isinstance(module, str):
+        # the pre-0.6 ipyreact API: a plain str was module code
+        warnings.warn(
+            "passing module code as a plain str is deprecated, use code=... (or url=... for a url)",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        code = module
+        module = None
     source: Union[str, Path]
     if code is not None:
         source = _CODE_PREFIX + code

--- a/solara/server/esm.py
+++ b/solara/server/esm.py
@@ -5,7 +5,7 @@ import logging
 import threading
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import ipyreact.importmap
 import ipyreact.module
@@ -21,7 +21,12 @@ _import_map_per_kernel: Dict[str, ipyreact.importmap.ImportMap] = {}
 
 
 # in solara server, we'll monkey patch ipyreact.module with this
-def define_module(name, module: Union[str, Path]):
+def define_module(name, module: Union[str, Path, None] = None, *, code: Optional[str] = None):
+    if (module is None) == (code is None):
+        raise TypeError("pass either module (url or Path) or code")
+    if code is not None:
+        module = _CODE_PREFIX + code
+    assert module is not None
     # collect the dependencies at this moment
     with lock:
         dependencies = list(_modules.keys())
@@ -68,15 +73,42 @@ def create_modules():
                 _modules_added[name] = create_module(name, module, dependencies=dependencies)
                 logger.info("create module %s %s %s", name, module, dependencies)
             else:
-                _modules_added[name].code = module if not isinstance(module, Path) else module.read_text(encoding="utf8")
+                _modules_added[name].code = _read(module) if not _is_url(module) else _modules_added[name].code
                 _modules_added[name].dependencies = dependencies
                 logger.info("update module %s %s %s", name, module, dependencies)
             widgets[name] = _modules_added[name]
     return widgets
 
 
+# inline source is stored with this prefix so a plain str always means a url
+_CODE_PREFIX = "\x00code:"
+
+
+def _is_url(module: Union[str, Path]) -> bool:
+    return isinstance(module, str) and not module.startswith(_CODE_PREFIX)
+
+
+def _read(module: Union[str, Path]) -> str:
+    if isinstance(module, Path):
+        return module.read_text(encoding="utf8")
+    return module[len(_CODE_PREFIX) :] if module.startswith(_CODE_PREFIX) else module
+
+
+def get_module_urls() -> List[str]:
+    from solara.server.server import versioned_url
+
+    with lock:
+        urls = [module for module, _ in _modules.values() if isinstance(module, str) and _is_url(module)]
+    return [versioned_url(url) for url in urls]
+
+
 def create_module(name, module: Union[str, Path], dependencies: List[str]):
-    return ipyreact.module.Module(code=module if not isinstance(module, Path) else module.read_text(encoding="utf8"), name=name, dependencies=dependencies)
+    from solara.server.server import versioned_url
+
+    if _is_url(module):
+        assert isinstance(module, str)
+        return ipyreact.module.Module(url=versioned_url(module), name=name, dependencies=dependencies)
+    return ipyreact.module.Module(code=_read(module), name=name, dependencies=dependencies)
 
 
 def create_import_map():

--- a/solara/server/esm_vue.py
+++ b/solara/server/esm_vue.py
@@ -43,6 +43,16 @@ def get_module_names() -> List[str]:
     return list(_modules.keys())
 
 
+def get_module_urls() -> List[str]:
+    """Urls of url-backed modules, for modulepreload hints in the page."""
+    with lock:
+        return [module for module, _ in _modules.values() if isinstance(module, str) and _is_url(module)]
+
+
+def _is_url(module: Union[str, Path]) -> bool:
+    return isinstance(module, str) and (module.startswith("http") or module.startswith("/"))
+
+
 def _read(module: Union[str, Path]) -> str:
     return module.read_text(encoding="utf8") if isinstance(module, Path) else module
 
@@ -66,9 +76,16 @@ def create_modules():
                 # would go nowhere, recreate instead
                 widget = None
             if widget is None:
-                widget = ipyvue.esm.Module(code=_read(module), name=name, dependencies=dependencies)
+                if _is_url(module):
+                    widget = ipyvue.esm.Module(url=module, name=name, dependencies=dependencies)
+                else:
+                    widget = ipyvue.esm.Module(code=_read(module), name=name, dependencies=dependencies)
                 _modules_added[name] = widget
                 logger.info("create vue module %s", name)
+            elif _is_url(module):
+                if widget.url != module:
+                    widget.url = module
+                    logger.info("update vue module url %s", name)
             else:
                 code = _read(module)
                 if widget.code != code:

--- a/solara/server/esm_vue.py
+++ b/solara/server/esm_vue.py
@@ -21,10 +21,19 @@ _modules: Dict[str, Tuple[Union[str, Path], List[str]]] = {}
 _modules_added_per_kernel: Dict[str, Dict[str, ipyvue.esm.Module]] = defaultdict(dict)
 
 
-def define_module(name: str, module: Union[str, Path, None] = None, *, code: Optional[str] = None):
-    if (module is None) == (code is None):
-        raise TypeError("pass either module (url or Path) or code")
-    source: Union[str, Path] = _CODE_PREFIX + code if code is not None else module  # type: ignore[assignment]
+def define_module(name: str, module: Optional[Path] = None, *, code: Optional[str] = None, url: Optional[str] = None):
+    if sum(x is not None for x in (module, code, url)) != 1:
+        raise TypeError("pass exactly one of module (a Path), code or url")
+    if module is not None and not isinstance(module, Path):
+        raise TypeError("module must be a Path; use url=... or code=... for strings")
+    source: Union[str, Path]
+    if code is not None:
+        source = _CODE_PREFIX + code
+    elif url is not None:
+        source = url
+    else:
+        assert module is not None
+        source = module
     with lock:
         dependencies = list(_modules.keys())
         logger.info("define vue module %s (dependencies=%r)", name, dependencies)

--- a/solara/server/esm_vue.py
+++ b/solara/server/esm_vue.py
@@ -1,0 +1,80 @@
+# Kernel-aware ES-module support for ipyvue, mirroring esm.py (ipyreact).
+# ipyvue.define_module is monkey-patched (see patch.py) so modules are
+# declared once at import time and materialized per kernel. Unlike the
+# ipyreact variant, a redefinition recreates the Module widget when the
+# kernel's previous widget was closed (e.g. by context.restart on hot
+# reload), so in-place reloads actually reach the browser.
+import logging
+import threading
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List, Tuple, Union
+
+import ipyvue.esm
+
+from solara.server import kernel_context
+
+logger = logging.getLogger("solara.server.esm_vue")
+lock = threading.Lock()
+
+_modules: Dict[str, Tuple[Union[str, Path], List[str]]] = {}
+_modules_added_per_kernel: Dict[str, Dict[str, ipyvue.esm.Module]] = defaultdict(dict)
+
+
+def define_module(name: str, module: Union[str, Path]):
+    with lock:
+        dependencies = list(_modules.keys())
+        logger.info("define vue module %s %s (dependencies=%r)", name, module, dependencies)
+        if name in _modules:
+            _old_module, dependencies = _modules[name]
+        _modules[name] = (module, dependencies)
+    if isinstance(module, Path):
+        # rebuilding the bundle (e.g. vite build --watch) triggers a normal
+        # solara reload, which re-reads the file in create_modules
+        from solara.server import reload
+
+        reload.reloader.watcher.add_file(str(module))
+    if kernel_context.has_current_context():
+        create_modules()
+    return None
+
+
+def get_module_names() -> List[str]:
+    return list(_modules.keys())
+
+
+def _read(module: Union[str, Path]) -> str:
+    return module.read_text(encoding="utf8") if isinstance(module, Path) else module
+
+
+def create_modules():
+    context = kernel_context.get_current_context()
+    kernel_id = context.id
+    if kernel_id not in _modules_added_per_kernel:
+        # widgets close with the kernel; drop our per-kernel bookkeeping too
+        def cleanup(kernel_id=kernel_id) -> None:
+            _modules_added_per_kernel.pop(kernel_id, None)
+
+        context.on_close(cleanup)
+    _modules_added = _modules_added_per_kernel[kernel_id]
+    widgets = {}
+    with lock:
+        for name, (module, dependencies) in _modules.items():
+            widget = _modules_added.get(name)
+            if widget is not None and widget.comm is None:
+                # closed by context.restart (hot reload) - a trait update
+                # would go nowhere, recreate instead
+                widget = None
+            if widget is None:
+                widget = ipyvue.esm.Module(code=_read(module), name=name, dependencies=dependencies)
+                _modules_added[name] = widget
+                logger.info("create vue module %s", name)
+            else:
+                code = _read(module)
+                if widget.code != code:
+                    widget.code = code
+                    logger.info("update vue module %s", name)
+                if widget.dependencies != dependencies:
+                    widget.dependencies = dependencies
+            widgets[name] = widget
+    return widgets

--- a/solara/server/esm_vue.py
+++ b/solara/server/esm_vue.py
@@ -46,10 +46,30 @@ def get_module_names() -> List[str]:
     return list(_modules.keys())
 
 
+_PUBLIC_PREFIX = "/static/public/"
+
+
+def versioned_url(url: str) -> str:
+    """Append ?v=<content-hash> to urls solara serves itself.
+
+    The same url is used for the modulepreload hint in the page and the
+    Module widget, so the preload always hits the cache; StaticPublic sends
+    long-lived cache headers when the hash matches (see starlette.py).
+    Urls with an existing query string and external urls pass through.
+    """
+    from solara.server import server
+
+    if not url.startswith(_PUBLIC_PREFIX) or "?" in url:
+        return url
+    digest = server.public_url_content_hash(url[len(_PUBLIC_PREFIX) :])
+    return f"{url}?v={digest}" if digest else url
+
+
 def get_module_urls() -> List[str]:
     """Urls of url-backed modules, for modulepreload hints in the page."""
     with lock:
-        return [module for module, _ in _modules.values() if isinstance(module, str) and _is_url(module)]
+        urls = [module for module, _ in _modules.values() if isinstance(module, str) and _is_url(module)]
+    return [versioned_url(url) for url in urls]
 
 
 # inline source is stored with this prefix so a plain str always means a url
@@ -86,14 +106,17 @@ def create_modules():
                 widget = None
             if widget is None:
                 if _is_url(module):
-                    widget = ipyvue.esm.Module(url=module, name=name, dependencies=dependencies)
+                    assert isinstance(module, str)
+                    widget = ipyvue.esm.Module(url=versioned_url(module), name=name, dependencies=dependencies)
                 else:
                     widget = ipyvue.esm.Module(code=_read(module), name=name, dependencies=dependencies)
                 _modules_added[name] = widget
                 logger.info("create vue module %s", name)
             elif _is_url(module):
-                if widget.url != module:
-                    widget.url = module
+                assert isinstance(module, str)
+                url = versioned_url(module)
+                if widget.url != url:
+                    widget.url = url
                     logger.info("update vue module url %s", name)
             else:
                 code = _read(module)

--- a/solara/server/esm_vue.py
+++ b/solara/server/esm_vue.py
@@ -46,29 +46,12 @@ def get_module_names() -> List[str]:
     return list(_modules.keys())
 
 
-_PUBLIC_PREFIX = "/static/public/"
-
-
-def versioned_url(url: str) -> str:
-    """Append ?v=<content-hash> to urls solara serves itself.
-
-    The same url is used for the modulepreload hint in the page and the
-    Module widget, so the preload always hits the cache; StaticPublic sends
-    long-lived cache headers when the hash matches (see starlette.py).
-    Urls with an existing query string and external urls pass through.
-    """
-    from solara.server import server
-
-    if not url.startswith(_PUBLIC_PREFIX) or "?" in url:
-        return url
-    digest = server.public_url_content_hash(url[len(_PUBLIC_PREFIX) :])
-    return f"{url}?v={digest}" if digest else url
-
-
 def get_module_urls() -> List[str]:
     """Urls of url-backed modules, for modulepreload hints in the page."""
     with lock:
         urls = [module for module, _ in _modules.values() if isinstance(module, str) and _is_url(module)]
+    from solara.server.server import versioned_url
+
     return [versioned_url(url) for url in urls]
 
 
@@ -84,6 +67,12 @@ def _read(module: Union[str, Path]) -> str:
     if isinstance(module, Path):
         return module.read_text(encoding="utf8")
     return module[len(_CODE_PREFIX) :] if module.startswith(_CODE_PREFIX) else module
+
+
+def _versioned(url: str) -> str:
+    from solara.server.server import versioned_url
+
+    return versioned_url(url)
 
 
 def create_modules():
@@ -107,14 +96,14 @@ def create_modules():
             if widget is None:
                 if _is_url(module):
                     assert isinstance(module, str)
-                    widget = ipyvue.esm.Module(url=versioned_url(module), name=name, dependencies=dependencies)
+                    widget = ipyvue.esm.Module(url=_versioned(module), name=name, dependencies=dependencies)
                 else:
                     widget = ipyvue.esm.Module(code=_read(module), name=name, dependencies=dependencies)
                 _modules_added[name] = widget
                 logger.info("create vue module %s", name)
             elif _is_url(module):
                 assert isinstance(module, str)
-                url = versioned_url(module)
+                url = _versioned(module)
                 if widget.url != url:
                     widget.url = url
                     logger.info("update vue module url %s", name)

--- a/solara/server/esm_vue.py
+++ b/solara/server/esm_vue.py
@@ -8,7 +8,7 @@ import logging
 import threading
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import ipyvue.esm
 
@@ -21,13 +21,16 @@ _modules: Dict[str, Tuple[Union[str, Path], List[str]]] = {}
 _modules_added_per_kernel: Dict[str, Dict[str, ipyvue.esm.Module]] = defaultdict(dict)
 
 
-def define_module(name: str, module: Union[str, Path]):
+def define_module(name: str, module: Union[str, Path, None] = None, *, code: Optional[str] = None):
+    if (module is None) == (code is None):
+        raise TypeError("pass either module (url or Path) or code")
+    source: Union[str, Path] = _CODE_PREFIX + code if code is not None else module  # type: ignore[assignment]
     with lock:
         dependencies = list(_modules.keys())
-        logger.info("define vue module %s %s (dependencies=%r)", name, module, dependencies)
+        logger.info("define vue module %s (dependencies=%r)", name, dependencies)
         if name in _modules:
             _old_module, dependencies = _modules[name]
-        _modules[name] = (module, dependencies)
+        _modules[name] = (source, dependencies)
     if isinstance(module, Path):
         # rebuilding the bundle (e.g. vite build --watch) triggers a normal
         # solara reload, which re-reads the file in create_modules
@@ -49,12 +52,18 @@ def get_module_urls() -> List[str]:
         return [module for module, _ in _modules.values() if isinstance(module, str) and _is_url(module)]
 
 
+# inline source is stored with this prefix so a plain str always means a url
+_CODE_PREFIX = "\x00code:"
+
+
 def _is_url(module: Union[str, Path]) -> bool:
-    return isinstance(module, str) and (module.startswith("http") or module.startswith("/"))
+    return isinstance(module, str) and not module.startswith(_CODE_PREFIX)
 
 
 def _read(module: Union[str, Path]) -> str:
-    return module.read_text(encoding="utf8") if isinstance(module, Path) else module
+    if isinstance(module, Path):
+        return module.read_text(encoding="utf8")
+    return module[len(_CODE_PREFIX) :] if module.startswith(_CODE_PREFIX) else module
 
 
 def create_modules():

--- a/solara/server/patch.py
+++ b/solara/server/patch.py
@@ -369,6 +369,22 @@ def patch_ipyreact():
     ipyreact.importmap._update_import_map = lambda: None
 
 
+def patch_ipyvue_esm():
+    import ipyvue
+
+    if not hasattr(ipyvue, "define_module"):
+        # ipyvue without ES module support
+        return
+
+    import ipyvue.esm
+
+    from . import esm_vue
+
+    ipyvue.esm.define_module = esm_vue.define_module
+    ipyvue.esm.get_module_names = esm_vue.get_module_names
+    ipyvue.define_module = esm_vue.define_module
+
+
 @solara.util.once
 def patch_matplotlib():
     import matplotlib
@@ -465,6 +481,8 @@ def patch():
         pass
     else:
         patch_ipyreact()
+
+    patch_ipyvue_esm()
 
     if "MPLBACKEND" not in os.environ:
         if ipykernel_version_major < 6:

--- a/solara/server/server.py
+++ b/solara/server/server.py
@@ -371,7 +371,15 @@ def read_root(
         if hasattr(ipyvue, "define_module"):
             from solara.server import esm_vue
 
-            module_urls = esm_vue.get_module_urls()
+            module_urls += esm_vue.get_module_urls()
+    except ModuleNotFoundError:
+        pass
+    try:
+        import ipyreact  # noqa: F401
+
+        from solara.server import esm
+
+        module_urls += esm.get_module_urls()
     except ModuleNotFoundError:
         pass
 
@@ -475,6 +483,23 @@ def public_url_content_hash(filename: str) -> Optional[str]:
             _public_hash_cache[key] = ((stat.st_mtime, stat.st_size), digest)
             return digest
     return None
+
+
+_PUBLIC_PREFIX = "/static/public/"
+
+
+def versioned_url(url: str) -> str:
+    """Append ?v=<content-hash> to urls solara serves itself.
+
+    The same url is used for the modulepreload hint in the page and the
+    Module widget, so the preload always hits the cache; StaticPublic sends
+    long-lived cache headers when the hash matches (see starlette.py).
+    Urls with an existing query string and external urls pass through.
+    """
+    if not url.startswith(_PUBLIC_PREFIX) or "?" in url:
+        return url
+    digest = public_url_content_hash(url[len(_PUBLIC_PREFIX) :])
+    return f"{url}?v={digest}" if digest else url
 
 
 def get_nbextensions_directories() -> List[Path]:

--- a/solara/server/server.py
+++ b/solara/server/server.py
@@ -442,6 +442,41 @@ def find_prefixed_directory(path):
 
 
 @solara.memoize(storage=cache_memory)
+def public_directories() -> List[Path]:
+    from . import app as appmod
+
+    return [app.directory.parent / "public" for app in appmod.apps.values()]
+
+
+_public_hash_cache: Dict[str, Tuple[Tuple[float, int], str]] = {}
+
+
+def public_url_content_hash(filename: str) -> Optional[str]:
+    """Content hash of a file served at /static/public/<filename>, or None.
+
+    Memoized on (mtime, size), so rebuilt bundles get a fresh hash.
+    """
+    for directory in public_directories():
+        path = (directory / filename).resolve()
+        if not str(path).startswith(str(directory.resolve())):
+            return None
+        if path.exists():
+            stat = path.stat()
+            key = str(path)
+            cached = _public_hash_cache.get(key)
+            if cached and cached[0] == (stat.st_mtime, stat.st_size):
+                return cached[1]
+            if sys.version_info[:2] < (3, 9):
+                h = hashlib.new("md5")
+            else:
+                h = hashlib.new("md5", usedforsecurity=False)  # type: ignore
+            h.update(path.read_bytes())
+            digest = h.hexdigest()[:12]
+            _public_hash_cache[key] = ((stat.st_mtime, stat.st_size), digest)
+            return digest
+    return None
+
+
 def get_nbextensions_directories() -> List[Path]:
     from jupyter_core.paths import jupyter_path
 

--- a/solara/server/server.py
+++ b/solara/server/server.py
@@ -364,8 +364,20 @@ def read_root(
                 code = f'<script src="{url}"></script>'
         return Markup(code)
 
+    module_urls = []
+    try:
+        import ipyvue
+
+        if hasattr(ipyvue, "define_module"):
+            from solara.server import esm_vue
+
+            module_urls = esm_vue.get_module_urls()
+    except ModuleNotFoundError:
+        pass
+
     resources = {
         "theme": "light",
+        "module_urls": module_urls,
         "nbextensions": nbextensions,
         "nbextensions_hashes": nbextensions_hashes,
         "include_css": include_css,

--- a/solara/server/starlette.py
+++ b/solara/server/starlette.py
@@ -53,6 +53,8 @@ from starlette.middleware.gzip import GZipMiddleware
 from starlette.requests import HTTPConnection, Request
 from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 from starlette.routing import Mount, Route, WebSocketRoute
+from urllib.parse import parse_qs
+
 from starlette.staticfiles import StaticFiles
 from starlette.types import Receive, Scope, Send
 
@@ -636,6 +638,18 @@ class StaticPublic(StaticFilesOptionalAuth):
     def lookup_path(self, *args, **kwargs):
         self.all_directories = self.get_directories(None, None)
         return super().lookup_path(*args, **kwargs)
+
+    async def get_response(self, path: str, scope):
+        response = await super().get_response(path, scope)
+        # requests versioned with the current content hash (?v=..., see
+        # solara.server.esm_vue.versioned_url) can be cached forever: any
+        # change to the file changes the url
+        query = parse_qs(scope.get("query_string", b"").decode())
+        version = query.get("v", [None])[0]
+        if version is not None and response.status_code in (200, 304):
+            if version == server.public_url_content_hash(path):
+                response.headers["Cache-Control"] = "max-age=31536000, immutable"
+        return response
 
     def get_directories(
         self,

--- a/solara/server/templates/solara.html.j2
+++ b/solara/server/templates/solara.html.j2
@@ -9,6 +9,10 @@
     <link rel="icon" type="image/png" sizes="any" href="{{root_path}}/static/assets/favicon.png">
     <link rel="icon" type="image/svg+xml" href="{{root_path}}/static/assets/favicon.svg">
 
+    {% for url in resources.module_urls -%}
+    {# start fetching ES modules (ipyvue.define_module) while the kernel starts #}
+    <link rel="modulepreload" href="{{ url }}" />
+    {% endfor -%}
     {% block header %}
 
     {{ pre_rendered_css | safe }}

--- a/solara/website/pages/documentation/advanced/content/10-howto/55-vue_esm_components.md
+++ b/solara/website/pages/documentation/advanced/content/10-howto/55-vue_esm_components.md
@@ -27,7 +27,7 @@ import solara
 
 ipyvue.define_module(
     "my-components",
-    """
+    code="""
     import { h } from "vue";
 
     export const Counter = {
@@ -102,11 +102,11 @@ and every save of a `.vue` file rebuilds the bundle and hot reloads the page in 
 
 ## Serving the bundle by url (production)
 
-`define_module` also accepts a **url** (a plain `str` always means a url; use `code=` for
-inline source). Serve the built bundle from your app's `public/` directory and pass the url:
+`define_module` also accepts an explicit **url** keyword (next to `module` for a `Path` and
+`code=` for inline source). Serve the built bundle from your app's `public/` directory and pass the url:
 
 ```python
-ipyvue.define_module("my-components", "/static/public/my-components.mjs")
+ipyvue.define_module("my-components", url="/static/public/my-components.mjs")
 ```
 
 For urls solara serves itself this enables aggressive caching without staleness:

--- a/solara/website/pages/documentation/advanced/content/10-howto/55-vue_esm_components.md
+++ b/solara/website/pages/documentation/advanced/content/10-howto/55-vue_esm_components.md
@@ -100,6 +100,26 @@ ipyvue.define_module("my-components", Path(__file__).parent / "dist/my-component
 Under `solara run`, the bundle file is watched: run `vite build --watch` next to the server
 and every save of a `.vue` file rebuilds the bundle and hot reloads the page in place.
 
+## Serving the bundle by url (production)
+
+`define_module` also accepts a **url** (a plain `str` always means a url; use `code=` for
+inline source). Serve the built bundle from your app's `public/` directory and pass the url:
+
+```python
+ipyvue.define_module("my-components", "/static/public/my-components.mjs")
+```
+
+For urls solara serves itself this enables aggressive caching without staleness:
+
+- the page emits `<link rel="modulepreload" href=".../my-components.mjs?v=<content-hash>">`,
+  so the browser fetches the bundle in parallel with kernel startup;
+- the widget uses the **same versioned url**, so the preload is always a cache hit;
+- solara serves the file with `Cache-Control: max-age=1y, immutable` when the requested
+  hash matches — a rebuild changes the hash and therefore the url, so caches never go stale.
+
+The same applies to ipyreact modules. During development, prefer the `Path` form: the file
+is watched, so a bundler in watch mode gives in-place hot reload.
+
 ## Using a precompiled component as a tag
 
 An export can also be used as a tag inside any other template via the `components` dict.

--- a/solara/website/pages/documentation/advanced/content/10-howto/55-vue_esm_components.md
+++ b/solara/website/pages/documentation/advanced/content/10-howto/55-vue_esm_components.md
@@ -1,0 +1,124 @@
+---
+title: Using precompiled Vue components (ES modules)
+description: Ship ahead-of-time compiled Vue single file components, with npm dependencies bundled in, instead of compiling templates in the browser.
+---
+# How can I use precompiled Vue components?
+
+Note: this requires ipyvue with ES module support (the vue3 series).
+
+Normally, [`@solara.component_vue`](/documentation/api/utilities/component_vue) sends the `.vue`
+template source to the browser, where it is compiled at runtime. Alternatively, you can compile
+your `.vue` files **ahead of time** into a single ES module with a bundler like [vite](https://vitejs.dev):
+
+- npm dependencies get compiled into the bundle (no CDN or window-global tricks needed),
+- no template source goes over the wire, and no runtime template compiler is needed,
+- the components are plain Vue code, checkable with `vue-tsc` and reusable outside solara.
+
+## A complete runnable example
+
+`ipyvue.define_module` accepts the module source as a string or a `Path`, so a minimal
+example does not even need a build step:
+
+```python
+from typing import Callable
+
+import ipyvue
+import solara
+
+ipyvue.define_module(
+    "my-components",
+    """
+    import { h } from "vue";
+
+    export const Counter = {
+        data: () => ({ count: 0 }),  // placeholder, the real value comes from Python
+        methods: {
+            bump() {},  // placeholder, solara injects the event_bump handler
+        },
+        render() {
+            return h(
+                "button",
+                { class: "my-counter", onClick: () => this.bump(1) },
+                `clicked ${this.count} times`,
+            );
+        },
+    };
+    """,
+)
+
+
+@solara.component_vue(esm_module="my-components", esm_export="Counter")
+def Counter(count: int = 0, event_bump: Callable[[int], None] = None):
+    pass
+
+
+@solara.component
+def Page():
+    count = solara.use_reactive(0)
+    Counter(count=count.value, event_bump=lambda amount: count.set(count.value + amount))
+```
+
+This works exactly like a [`@solara.component_vue`](/documentation/api/utilities/component_vue)
+component backed by a `.vue` file: arguments become Vue data (overriding the component's own
+`data()` placeholders) and `event_*` arguments become callable methods, because the component's
+options are merged under ipyvue's model mixin with the same precedence as a browser-compiled
+template.
+
+## Building real .vue files with vite
+
+For actual applications, keep your components as `.vue` single file components and build them:
+
+```js
+// vite.config.mjs
+import { defineConfig } from "vite";
+import vue from "@vitejs/plugin-vue";
+
+export default defineConfig({
+  plugins: [vue()],
+  build: {
+    lib: { entry: "src/index.js", formats: ["es"], fileName: () => "my-components.mjs" },
+    // vue is provided by ipyvue via the import map
+    rollupOptions: { external: ["vue"] },
+  },
+});
+```
+
+```js
+// src/index.js — npm dependencies (e.g. canvas-confetti) simply get bundled
+export { default as Dashboard } from "./dashboard.vue";
+export { default as Toggle } from "./toggle.vue";
+```
+
+```python
+from pathlib import Path
+
+import ipyvue
+
+ipyvue.define_module("my-components", Path(__file__).parent / "dist/my-components.mjs")
+```
+
+Under `solara run`, the bundle file is watched: run `vite build --watch` next to the server
+and every save of a `.vue` file rebuilds the bundle and hot reloads the page in place.
+
+## Using a precompiled component as a tag
+
+An export can also be used as a tag inside any other template via the `components` dict.
+In that form no model mixin is applied — the component keeps its own props/emits contract:
+
+```python
+class MyWidget(ipyvue.VueTemplate):
+    template = traitlets.Unicode(
+        """
+        <template>
+            <my-toggle :value="enabled" @input="on_input"></my-toggle>
+        </template>
+        """
+    ).tag(sync=True)
+    enabled = traitlets.Bool(False).tag(sync=True)
+    components = traitlets.Dict(
+        {"my-toggle": {"esm_module": "my-components", "esm_export": "Toggle"}}
+    ).tag(sync=True, **widget_serialization)
+
+    def vue_on_input(self, value):
+        self.enabled = value
+```

--- a/tests/integration/esm_test.py
+++ b/tests/integration/esm_test.py
@@ -23,7 +23,7 @@ export default function({value, setValue, ...children}) {
     return React.createElement("button", {onClick: () => setValue(value + 1), children: `clicked ${value || 0}`})
 }
 """
-ipyreact.define_module("solara-test", test_js_code)
+ipyreact.define_module("solara-test", code=test_js_code)
 
 
 @solara.component
@@ -34,7 +34,7 @@ def Page():
 
 @solara.component
 def PageDefineDuringRun():
-    ipyreact.define_module("solara-test-dynamic", test_js_code)
+    ipyreact.define_module("solara-test-dynamic", code=test_js_code)
     value = solara.use_reactive(0)
     ipyreact.ValueWidget.element(_module="solara-test-dynamic", value=0, on_value=value.set)
 

--- a/tests/unit/component_frontend_test.py
+++ b/tests/unit/component_frontend_test.py
@@ -82,3 +82,17 @@ def test_component_vue_event():
 
     widget._handle_event(None, {"event": "event_foo", "data": 43}, [b"bar2"])
     mock.assert_called_with(43, [b"bar2"])
+
+
+def test_component_vue_esm_argument_validation():
+    import ipyvue
+
+    with pytest.raises(TypeError, match="either vue_path or esm_module"):
+        solara.component_vue()
+
+    with pytest.raises(TypeError, match="either vue_path or esm_module"):
+        solara.component_vue("component_vue_test.vue", esm_module="my-components")
+
+    if not hasattr(ipyvue, "define_module"):
+        with pytest.raises(RuntimeError, match="ES module support"):
+            solara.component_vue(esm_module="my-components")

--- a/tests/unit/esm_test.py
+++ b/tests/unit/esm_test.py
@@ -38,7 +38,7 @@ def virtual_context(clean_esm_state):
 
 
 def test_create_modules_per_kernel_reuse(virtual_context):
-    esm.define_module("esm-test-module", "export default 1")
+    esm.define_module("esm-test-module", code="export default 1")
     widgets = esm.create_modules()
     widget = widgets["esm-test-module"]
     # a second call must reuse the same (live) widget for this kernel
@@ -46,7 +46,7 @@ def test_create_modules_per_kernel_reuse(virtual_context):
 
 
 def test_create_modules_recreates_closed_widget(virtual_context):
-    esm.define_module("esm-test-module", "export default 1")
+    esm.define_module("esm-test-module", code="export default 1")
     widget = esm.create_modules()["esm-test-module"]
     # context.restart() closes the kernel's widgets on (hot) reload; updating
     # a trait on a closed widget never reaches the browser, so create_modules
@@ -59,9 +59,9 @@ def test_create_modules_recreates_closed_widget(virtual_context):
 
 
 def test_redefine_module_updates_live_widget(virtual_context):
-    esm.define_module("esm-test-module", "export default 1")
+    esm.define_module("esm-test-module", code="export default 1")
     widget = esm.create_modules()["esm-test-module"]
-    esm.define_module("esm-test-module", "export default 2")
+    esm.define_module("esm-test-module", code="export default 2")
     assert esm.create_modules()["esm-test-module"] is widget
     assert widget.code == "export default 2"
 
@@ -80,7 +80,7 @@ def test_define_module_path_is_watched(clean_esm_state, tmp_path: Path, monkeypa
 def test_kernel_bookkeeping_dropped_on_close(clean_esm_state):
     context = kernel_context.VirtualKernelContext(id="esm-test-2", kernel=Kernel(), session_id="session-esm-2")
     with context:
-        esm.define_module("esm-test-module", "export default 1")
+        esm.define_module("esm-test-module", code="export default 1")
         esm.create_modules()
         esm.create_import_map()
         assert "esm-test-2" in esm._modules_added_per_kernel

--- a/tests/unit/esm_vue_test.py
+++ b/tests/unit/esm_vue_test.py
@@ -117,3 +117,44 @@ def test_get_module_urls(clean_esm_state, tmp_path: Path):
     esm_vue.define_module("esm-vue-file-module", module)
     # only url-backed modules can be preloaded by the page
     assert esm_vue.get_module_urls() == ["/static/public/bundle.mjs"]
+
+
+def test_versioned_url(clean_esm_state, tmp_path: Path, monkeypatch):
+    from solara.server import server
+
+    public = tmp_path / "public"
+    public.mkdir()
+    bundle = public / "bundle.mjs"
+    bundle.write_text("export default 1")
+    monkeypatch.setattr(server, "public_directories", lambda: [public])
+    server._public_hash_cache.clear()
+
+    url = esm_vue.versioned_url("/static/public/bundle.mjs")
+    assert url.startswith("/static/public/bundle.mjs?v=")
+    # stable until the content changes
+    assert esm_vue.versioned_url("/static/public/bundle.mjs") == url
+    bundle.write_text("export default 2")
+    assert esm_vue.versioned_url("/static/public/bundle.mjs") != url
+
+    # pass-through cases: external, already versioned, unresolvable, traversal
+    assert esm_vue.versioned_url("https://cdn.example/x.mjs") == "https://cdn.example/x.mjs"
+    assert esm_vue.versioned_url("/static/public/bundle.mjs?v=1") == "/static/public/bundle.mjs?v=1"
+    assert esm_vue.versioned_url("/static/public/missing.mjs") == "/static/public/missing.mjs"
+    assert esm_vue.versioned_url("/static/public/../secret.mjs") == "/static/public/../secret.mjs"
+
+
+def test_module_widget_and_page_share_versioned_url(virtual_context, tmp_path: Path, monkeypatch):
+    from solara.server import server
+
+    public = tmp_path / "public"
+    public.mkdir()
+    (public / "bundle.mjs").write_text("export default 1")
+    monkeypatch.setattr(server, "public_directories", lambda: [public])
+    server._public_hash_cache.clear()
+
+    esm_vue.define_module("esm-vue-versioned", "/static/public/bundle.mjs")
+    widget = esm_vue.create_modules()["esm-vue-versioned"]
+    # the preload hint in the page and the widget must agree, so the
+    # preloaded response is a cache hit
+    assert widget.url == esm_vue.get_module_urls()[0]
+    assert "?v=" in widget.url

--- a/tests/unit/esm_vue_test.py
+++ b/tests/unit/esm_vue_test.py
@@ -37,7 +37,7 @@ def virtual_context(clean_esm_state):
 
 
 def test_create_modules_per_kernel_reuse(virtual_context):
-    esm_vue.define_module("esm-vue-test-module", "export default 1")
+    esm_vue.define_module("esm-vue-test-module", code="export default 1")
     widgets = esm_vue.create_modules()
     widget = widgets["esm-vue-test-module"]
     # a second call must reuse the same (live) widget for this kernel
@@ -45,7 +45,7 @@ def test_create_modules_per_kernel_reuse(virtual_context):
 
 
 def test_create_modules_recreates_closed_widget(virtual_context):
-    esm_vue.define_module("esm-vue-test-module", "export default 1")
+    esm_vue.define_module("esm-vue-test-module", code="export default 1")
     widget = esm_vue.create_modules()["esm-vue-test-module"]
     # context.restart() closes the kernel's widgets on (hot) reload; updating
     # a trait on a closed widget never reaches the browser, so create_modules
@@ -58,9 +58,9 @@ def test_create_modules_recreates_closed_widget(virtual_context):
 
 
 def test_redefine_module_updates_live_widget(virtual_context):
-    esm_vue.define_module("esm-vue-test-module", "export default 1")
+    esm_vue.define_module("esm-vue-test-module", code="export default 1")
     widget = esm_vue.create_modules()["esm-vue-test-module"]
-    esm_vue.define_module("esm-vue-test-module", "export default 2")
+    esm_vue.define_module("esm-vue-test-module", code="export default 2")
     assert esm_vue.create_modules()["esm-vue-test-module"] is widget
     assert widget.code == "export default 2"
 
@@ -79,7 +79,7 @@ def test_define_module_path_is_watched(clean_esm_state, tmp_path: Path, monkeypa
 def test_kernel_bookkeeping_dropped_on_close(clean_esm_state):
     context = kernel_context.VirtualKernelContext(id="esm-vue-test-2", kernel=Kernel(), session_id="session-esm-vue-2")
     with context:
-        esm_vue.define_module("esm-vue-test-module", "export default 1")
+        esm_vue.define_module("esm-vue-test-module", code="export default 1")
         esm_vue.create_modules()
         assert "esm-vue-test-2" in esm_vue._modules_added_per_kernel
     context.close()

--- a/tests/unit/esm_vue_test.py
+++ b/tests/unit/esm_vue_test.py
@@ -111,7 +111,7 @@ def test_component_vue_esm_widget(virtual_context):
 
 
 def test_get_module_urls(clean_esm_state, tmp_path: Path):
-    esm_vue.define_module("esm-vue-url-module", "/static/public/bundle.mjs")
+    esm_vue.define_module("esm-vue-url-module", url="/static/public/bundle.mjs")
     module = tmp_path / "bundle.mjs"
     module.write_text("export default 1")
     esm_vue.define_module("esm-vue-file-module", module)
@@ -152,7 +152,7 @@ def test_module_widget_and_page_share_versioned_url(virtual_context, tmp_path: P
     monkeypatch.setattr(server, "public_directories", lambda: [public])
     server._public_hash_cache.clear()
 
-    esm_vue.define_module("esm-vue-versioned", "/static/public/bundle.mjs")
+    esm_vue.define_module("esm-vue-versioned", url="/static/public/bundle.mjs")
     widget = esm_vue.create_modules()["esm-vue-versioned"]
     # the preload hint in the page and the widget must agree, so the
     # preloaded response is a cache hit

--- a/tests/unit/esm_vue_test.py
+++ b/tests/unit/esm_vue_test.py
@@ -1,0 +1,110 @@
+from pathlib import Path
+
+import pytest
+
+ipyvue = pytest.importorskip("ipyvue")
+
+if not hasattr(ipyvue, "define_module"):
+    pytest.skip("requires ipyvue with ES module support (>=3.0.0a9)", allow_module_level=True)
+
+from solara.server import esm_vue, kernel_context  # noqa: E402
+from solara.server.kernel import Kernel  # noqa: E402
+
+
+@pytest.fixture()
+def clean_esm_state():
+    modules = esm_vue._modules.copy()
+    esm_vue._modules.clear()
+    added = dict(esm_vue._modules_added_per_kernel)
+    esm_vue._modules_added_per_kernel.clear()
+    try:
+        yield
+    finally:
+        esm_vue._modules.clear()
+        esm_vue._modules.update(modules)
+        esm_vue._modules_added_per_kernel.clear()
+        esm_vue._modules_added_per_kernel.update(added)
+
+
+@pytest.fixture()
+def virtual_context(clean_esm_state):
+    context = kernel_context.VirtualKernelContext(id="esm-vue-test-1", kernel=Kernel(), session_id="session-esm-vue-1")
+    try:
+        with context:
+            yield context
+    finally:
+        context.close()
+
+
+def test_create_modules_per_kernel_reuse(virtual_context):
+    esm_vue.define_module("esm-vue-test-module", "export default 1")
+    widgets = esm_vue.create_modules()
+    widget = widgets["esm-vue-test-module"]
+    # a second call must reuse the same (live) widget for this kernel
+    assert esm_vue.create_modules()["esm-vue-test-module"] is widget
+
+
+def test_create_modules_recreates_closed_widget(virtual_context):
+    esm_vue.define_module("esm-vue-test-module", "export default 1")
+    widget = esm_vue.create_modules()["esm-vue-test-module"]
+    # context.restart() closes the kernel's widgets on (hot) reload; updating
+    # a trait on a closed widget never reaches the browser, so create_modules
+    # must hand out a fresh widget instead
+    widget.close()
+    assert widget.comm is None
+    widget2 = esm_vue.create_modules()["esm-vue-test-module"]
+    assert widget2 is not widget
+    assert widget2.comm is not None
+
+
+def test_redefine_module_updates_live_widget(virtual_context):
+    esm_vue.define_module("esm-vue-test-module", "export default 1")
+    widget = esm_vue.create_modules()["esm-vue-test-module"]
+    esm_vue.define_module("esm-vue-test-module", "export default 2")
+    assert esm_vue.create_modules()["esm-vue-test-module"] is widget
+    assert widget.code == "export default 2"
+
+
+def test_define_module_path_is_watched(clean_esm_state, tmp_path: Path, monkeypatch):
+    from solara.server import reload
+
+    watched = []
+    monkeypatch.setattr(reload.reloader.watcher, "add_file", lambda file: watched.append(str(file)))
+    module = tmp_path / "bundle.mjs"
+    module.write_text("export default 1")
+    esm_vue.define_module("esm-vue-test-path-module", module)
+    assert watched == [str(module)]
+
+
+def test_kernel_bookkeeping_dropped_on_close(clean_esm_state):
+    context = kernel_context.VirtualKernelContext(id="esm-vue-test-2", kernel=Kernel(), session_id="session-esm-vue-2")
+    with context:
+        esm_vue.define_module("esm-vue-test-module", "export default 1")
+        esm_vue.create_modules()
+        assert "esm-vue-test-2" in esm_vue._modules_added_per_kernel
+    context.close()
+    assert "esm-vue-test-2" not in esm_vue._modules_added_per_kernel
+
+
+def test_component_vue_esm_widget(virtual_context):
+    import solara
+    from solara.components.component_vue import _widget_vue
+
+    @_widget_vue(None, esm_module="esm-vue-test-module", esm_export="Counter")
+    def Counter(count: int = 0):
+        pass
+
+    widget = Counter(count=3)
+    assert widget.template.esm_module == "esm-vue-test-module"
+    assert widget.template.esm_export == "Counter"
+    assert widget.count == 3
+
+    # and via the public decorator (returns a reacton component)
+    @solara.component_vue(esm_module="esm-vue-test-module", esm_export="Counter")
+    def CounterComponent(count: int = 0):
+        pass
+
+    box, _rc = solara.render(CounterComponent(count=5), handle_error=False)
+    widget = box.children[0]
+    assert widget.template.esm_module == "esm-vue-test-module"
+    assert widget.count == 5

--- a/tests/unit/esm_vue_test.py
+++ b/tests/unit/esm_vue_test.py
@@ -108,3 +108,12 @@ def test_component_vue_esm_widget(virtual_context):
     widget = box.children[0]
     assert widget.template.esm_module == "esm-vue-test-module"
     assert widget.count == 5
+
+
+def test_get_module_urls(clean_esm_state, tmp_path: Path):
+    esm_vue.define_module("esm-vue-url-module", "/static/public/bundle.mjs")
+    module = tmp_path / "bundle.mjs"
+    module.write_text("export default 1")
+    esm_vue.define_module("esm-vue-file-module", module)
+    # only url-backed modules can be preloaded by the page
+    assert esm_vue.get_module_urls() == ["/static/public/bundle.mjs"]

--- a/tests/unit/esm_vue_test.py
+++ b/tests/unit/esm_vue_test.py
@@ -129,18 +129,18 @@ def test_versioned_url(clean_esm_state, tmp_path: Path, monkeypatch):
     monkeypatch.setattr(server, "public_directories", lambda: [public])
     server._public_hash_cache.clear()
 
-    url = esm_vue.versioned_url("/static/public/bundle.mjs")
+    url = server.versioned_url("/static/public/bundle.mjs")
     assert url.startswith("/static/public/bundle.mjs?v=")
     # stable until the content changes
-    assert esm_vue.versioned_url("/static/public/bundle.mjs") == url
+    assert server.versioned_url("/static/public/bundle.mjs") == url
     bundle.write_text("export default 2")
-    assert esm_vue.versioned_url("/static/public/bundle.mjs") != url
+    assert server.versioned_url("/static/public/bundle.mjs") != url
 
     # pass-through cases: external, already versioned, unresolvable, traversal
-    assert esm_vue.versioned_url("https://cdn.example/x.mjs") == "https://cdn.example/x.mjs"
-    assert esm_vue.versioned_url("/static/public/bundle.mjs?v=1") == "/static/public/bundle.mjs?v=1"
-    assert esm_vue.versioned_url("/static/public/missing.mjs") == "/static/public/missing.mjs"
-    assert esm_vue.versioned_url("/static/public/../secret.mjs") == "/static/public/../secret.mjs"
+    assert server.versioned_url("https://cdn.example/x.mjs") == "https://cdn.example/x.mjs"
+    assert server.versioned_url("/static/public/bundle.mjs?v=1") == "/static/public/bundle.mjs?v=1"
+    assert server.versioned_url("/static/public/missing.mjs") == "/static/public/missing.mjs"
+    assert server.versioned_url("/static/public/../secret.mjs") == "/static/public/../secret.mjs"
 
 
 def test_module_widget_and_page_share_versioned_url(virtual_context, tmp_path: Path, monkeypatch):


### PR DESCRIPTION
## Summary

Companion to widgetti/ipyvue#106 (ipyvue's vue3 branch gains `define_module` for precompiled ESM bundles). This gives those modules the same server-side handling ipyreact modules get in `solara/server/esm.py`:

- definitions recorded once (module level), `Module` widgets materialized per kernel inside the kernel context
- widgets recreated when `context.restart()` closed them, so in-place hot reload works (same fix as #1168)
- `define_module(Path)` registered with the reloader — rebuilding a bundle (`vite build --watch`) triggers a normal in-place reload
- per-kernel bookkeeping dropped on kernel close; `_modules` mutation locked

Everything is `hasattr(ipyvue, "define_module")`-gated, so it is a no-op on current ipyvue releases; the unit tests skip likewise until an ipyvue release ships the feature (verified 5/5 passing locally against the ipyvue#106 branch).

## Url modules: preload + content-hash caching

`define_module` takes exactly one of `module` (a `Path`), `code=` or `url=` (nothing is guessed from a plain str); `url=` serves the bundle from the app's static dir. For urls solara serves itself (`/static/public/...`):

- the page emits `<link rel="modulepreload" href=".../bundle.mjs?v=<content-hash>">`, so the browser fetches the bundle **in parallel with kernel startup** instead of waiting for the Module widget over the websocket (es-module-shims honors modulepreload in shim mode);
- the **same versioned url** is used for the hint and the widget (one helper, `esm_vue.versioned_url`), so the preload is always a cache hit;
- `StaticPublic` serves the file with `Cache-Control: max-age=1y, immutable` **only when the requested `?v` matches the current content hash** — rebuilds change the hash and therefore the url (automatic cache busting), stale hashes get normal headers (no poisoning). External urls and urls with their own query string pass through untouched.

This generalizes the existing nbextension-hash mechanism (`nbextensions_hashes` + requirejs `urlArgs`) to app-served ES modules.

## Documentation

Includes a website howto page (`documentation/advanced/howto/vue-esm-components`) with a complete runnable example (verified end to end locally against the ipyvue#106 branch: renders, click events reach Python, trait updates re-render) plus the vite workflow and the tag form.

## Usage (once ipyvue#106 is released)

`solara.component_vue` gains `esm_module`/`esm_export` as an alternative to `vue_path`:

```python
import ipyvue
import solara

# build .vue SFCs ahead of time with vite (vue external, npm deps bundled);
# solara watches the file, so `vite build --watch` gives in-place hot reload
ipyvue.define_module("my-components", Path(__file__).parent / "dist/my-components.mjs")


@solara.component_vue(esm_module="my-components", esm_export="Counter")
def Counter(count: int = 0, event_bump: Callable[[int], None] = None):
    pass
```

Same contract as a `.vue`-file component: arguments become Vue data (overriding the component's own `data()` placeholders), `event_*` arguments become callable methods. The howto page in this PR contains a complete no-build-step runnable example (verified end to end against the ipyvue#106 branch: renders, clicks reach Python, state re-renders) plus the vite workflow and the tag form.

No template source goes over the wire and `vue/compiler-sfc` is not needed at runtime for these components. Coexists with ipyreact modules on the same page (verified; registries are separate, the import-map namespace is shared so module names must be unique across libraries).


