### PR TITLE
fix: cache-bust the nodeps nbextension bundles

### DIFF
--- a/solara/server/templates/solara.html.j2
+++ b/solara/server/templates/solara.html.j2
@@ -477,7 +477,9 @@
                 },
                 // Add cache busting to the urlArgs to ensure latest versions of nbextensions are loaded
                 urlArgs: function (id, url) {
-                    const extensionName = id.replace("/static/nbextensions/", "").replace(".js", "");
+                    // the nodeps bundles ship in the extension's directory, which is
+                    // what gets hashed, so version them with the extension's hash
+                    const extensionName = id.replace(/^\/?(static\/)?nbextensions\//, "").replace(".js", "").replace(/\/nodeps$/, "/extension");
                     if (nbextensionHashes[extensionName] !== undefined) {
                         // Check if the url already has a query string, if so, append the hash as an additional parameter
                         return (url.indexOf('?') === -1 ? '?' : '&') + nbextensionHashes[extensionName];


### PR DESCRIPTION
## Summary

The requirejs `urlArgs` cache-busting only matched `*/extension` module ids, so the **nodeps bundles** — which contain the actual widget frontends and are loaded via the requirejs `map` config (`jupyter-vue` → `nbextensions/jupyter-vue/nodeps`) — were requested without any version parameter. Browsers then keep serving a stale cached copy after the extension is updated, which breaks pages in ways that show **no console error** (e.g. a widget manager waiting forever on a model the old bundle doesn't have — the page just sits at "Loading app").

The extension-directory hash already covers the nodeps files (it hashes every file in the extension directories), so the fix is to normalize the module id: strip the `nbextensions/` prefix variants and map `<ext>/nodeps` to `<ext>/extension` before the hash lookup.

Verified locally: `nodeps.js` is now requested as `nodeps.js?<hash>` and stale-cache pages recover on a plain reload.

Found while working on ES module support for ipyvue (#1169), where every frontend rebuild was silently masked by this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)