### PR TITLE
fix: restructure client reconnect into a supersedable state machine (spurious reloads + empty-mount wedge)

### DIFF
--- a/docs/design-redis-state-persistence.md
+++ b/docs/design-redis-state-persistence.md
@@ -728,19 +728,28 @@ separate triggers:
   genuinely correct** (the browser needs new assets; a soft-remount on stale JS is
   wrong).
 
-`app-status` reply (`app.py:481-489`) gains two fields:
+`app-status` reply (`app.py:481-489`) gains these fields:
 
 ```python
 {"method": "app-status", "started": bool,
+ "containerId": <root container model id when started, else None>,
  "canRecover": <persistence enabled or auto_remount forced, and not recovery-failed>,
  "clientVersion": <opaque asset hash>}
 ```
 
-Client decision on reconnect:
+Client decision on reconnect — one *reconnect cycle* per `connected` event, owned by a
+monotonic generation; a cycle superseded by a newer one (or whose socket dropped again)
+aborts silently, and the probe retries before a failure counts as a verdict (the full
+state machine — PROBE / RESUME / REPAIR / REMOUNT / GIVE UP, with its invariants — is
+documented in the block comment above `connectionStatusChanged` in `main-vuetify.js`):
 
-- `started: true` → today's `fetchAll()` (same-instance hot reconnect — unchanged).
+- `started: true` and the client still has its mounted view → `fetchAll()`
+  (same-instance hot reconnect — unchanged; **RESUME**).
+- `started: true` but the client's view is gone (a previous soft-remount was interrupted
+  mid-way by another socket drop) → **re-attach** to the running app: `fetchAll()` +
+  mount the reply's `containerId` — the popout attach path (**REPAIR**).
 - `started: false && canRecover && clientVersion == own` → **soft-remount** (including
-  after a schema-tag reset — the client can't tell and doesn't need to).
+  after a schema-tag reset — the client can't tell and doesn't need to; **REMOUNT**).
 - otherwise → today's `needsRefresh` dialog: recovery disabled, the client bundle
   changed, or **restore bailed out** (§4.3, `canRecover: false` on a recovery-failed
   context — "we lost", visibly; subject to the bail-out storm valve).
@@ -761,8 +770,12 @@ release; the version-pinned `@widgetti/solara-vuetify-app` bundles are untouched
 
 ### 6.2 Remount sequence (replaces `main-vuetify.js:185-187`)
 
-1. Guard `remountInProgress`; popouts (`?modelid`) keep current behavior (they attach to
-   a specific model that no longer exists; dialog or auto-close).
+1. Ownership by reconnect generation (no in-flight boolean: a boolean guard wedges
+   forever when a rebuild hangs on a reply lost to a socket drop). A rebuild flips
+   `viewMounted` to false first and back to true only after a completed mount, so an
+   interrupted rebuild is *detected and repaired by the next cycle* (REPAIR, §6.1)
+   instead of blocking it. Popouts (`?modelid`) keep current behavior (they attach to a
+   specific model that no longer exists; dialog or auto-close).
 2. Show a light "Restoring session…" indicator (reuse the top progress bar / small
    overlay — not the full loader; keep the stale DOM visible until swap).
 3. Tear down: `widgetManager.clear_state()`/`dispose()` (closes dead comms, disposes
@@ -775,10 +788,11 @@ release; the version-pinned `@widgetti/solara-vuetify-app` bundles are untouched
    `window.location` (pushState routing means the boot-time `path` variable is stale);
    `run(appName, {path, dark, themes})`.
 6. Server restores state before/at first render (Pillars A+B), replies new root
-   `widget_id`; `solaraMount()` swaps it in. Clear the guard and indicator.
+   `widget_id`; `solaraMount()` swaps it in. Set `viewMounted`, clear the indicator.
 
-Edge cases handled: flapping reconnects (guard + re-check connection before final swap;
-last completed attempt wins), fast double reconnect landing back on the original
+Edge cases handled: flapping reconnects (generation ownership: superseded cycles abort
+silently at their next await boundary; the latest cycle repairs whatever an interrupted
+one left behind), fast double reconnect landing back on the original
 instance (server discards its stale context on generation mismatch, §5.1 — the client
 just sees another `started: false` + `canRecover` and soft-remounts; no client-side
 special case needed), multiple tabs sharing one kernel id (each re-runs `run`; restore

--- a/solara/server/app.py
+++ b/solara/server/app.py
@@ -544,6 +544,11 @@ def solara_comm_target(comm, msg_first):
             reply = {
                 "method": "app-status",
                 "started": started,
+                # the root container's model id. A client whose rebuild was interrupted (socket
+                # drop between run() and the mount) has no view left but finds started=true here
+                # on its next reconnect; this id lets it RE-ATTACH to the running app (fetchAll +
+                # mount, the popout path) instead of resyncing state into a viewless page.
+                "containerId": context.container._model_id if context.container is not None else None,
                 # whether the client may soft-remount instead of showing the refresh dialog (§6.1)
                 "canRecover": _can_recover(context),
                 # opaque asset hash; a mismatch with the client's baked-in solara.clientVersion

--- a/solara/server/static/main-vuetify.js
+++ b/solara/server/static/main-vuetify.js
@@ -113,6 +113,7 @@ function generateUuid() {
 
 async function solaraInit(mountId, appName) {
     console.log('solara init', mountId, appName);
+    mountId = mountId || 'content';
     define("vue", [], () => Vue);
     define("vuetify", [], () => Vuetify);
     cookies = getCookiesMap(document.cookie);
@@ -133,8 +134,15 @@ async function solaraInit(mountId, appName) {
     }
     const close_url = `${solara.rootPath}/_solara/api/close/${kernelId}?session_id=${kernel.clientId}`;
     let skipReconnectedCheck = true;
-    // re-entrancy + flapping guard for the soft-remount (§6.2)
-    let remountInProgress = false;
+    // reconnect state machine state (see the block comment above connectionStatusChanged):
+    // every 'connected' event starts a reconnect CYCLE owning this generation; a cycle that is
+    // no longer the latest (or whose socket dropped again) aborts silently. A monotonic counter
+    // cannot deadlock the way an in-flight boolean could (there is nothing to clear).
+    let reconnectGeneration = 0;
+    // true iff a root view was mounted and not torn down since. Every rebuild sets it false
+    // FIRST and true only after a completed mount, so an interrupted rebuild (socket drop
+    // mid-way) leaves viewMounted == false for the next cycle to detect and REPAIR.
+    let viewMounted = false;
 
     // Purge orphaned comm registrations left on the kernel CONNECTION after a widget manager is
     // torn down. jupyter-widgets' WidgetModel.close(true) (used by clearStateLocal for a silent
@@ -175,6 +183,7 @@ async function solaraInit(mountId, appName) {
         connectionStatus: kernel.connectionStatus,
         reconnectCount: 0,
         remountCount: 0,
+        viewMounted: () => viewMounted,
         lastRestore: null,
         dropConnection() {
             // close the raw underlying socket WITHOUT kernel.dispose, so the jupyterlab-services
@@ -235,13 +244,15 @@ async function solaraInit(mountId, appName) {
     }
 
     async function fallbackToDialog() {
-        // the refresh-dialog path (recovery disabled, bundle changed, bailout, popout, or a failed
-        // remount). shutdownKernel lives ONLY here.
+        // the GIVE-UP verdict (recovery disabled, bundle changed, bailout, popout, consistent
+        // probe failure, or a failed rebuild). shutdownKernel lives ONLY here, and this is only
+        // ever called by the latest live cycle (see the state machine comment).
+        app.$data.remounting = false;
         app.$data.needsRefresh = true;
         await solara.shutdownKernel(kernel);
     }
 
-    async function solaraAppStatus(k) {
+    async function solaraAppStatus(k, timeoutMs) {
         // inline control-comm probe (mirrors solara-widget-manager appStatus) that returns the FULL
         // reply object - the bundled widgetManager.appStatus() drops canRecover/clientVersion/lastRestore.
         const controlComm = k.createComm('solara.control', generateUuid());
@@ -256,85 +267,155 @@ async function solaraInit(mountId, appName) {
                 }
             };
             controlComm.onClose = () => reject(new Error('solara.control comm closed'));
-            setTimeout(() => reject(new Error('app-status timeout')), 500);
+            setTimeout(() => reject(new Error('app-status timeout')), timeoutMs);
             controlComm.send({ method: 'app-status' });
         });
     }
 
-    async function solaraRemount() {
-        if (remountInProgress) {
-            // a reconnect arriving mid-remount is ignored; the in-progress attempt re-checks the
-            // connection before its final swap (last completed attempt wins, §6.2)
-            return;
+    async function probeAppStatus(superseded) {
+        // PROBE step of the reconnect cycle. Returns the reply object, a synthetic
+        // {started:false, canRecover:false} after CONSISTENT failure (that is a real verdict),
+        // or null when the cycle got superseded mid-probe (abort silently - a probe riding a
+        // dead transport, or raced by a newer cycle, proves nothing about the app's health).
+        // The give-up verdict tears a session down for good (dialog, and with forceRefresh a
+        // full page reload), so it must never follow a SINGLE late/lost reply: one blip (busy
+        // backend restoring another kernel, network jitter) would otherwise kill a perfectly
+        // recoverable session.
+        for (let attempt = 1; attempt <= 3; attempt++) {
+            try {
+                const reply = await solaraAppStatus(kernel, 2000);
+                return superseded() ? null : reply;
+            } catch (e) {
+                console.warn(`solara reconnect: app-status probe attempt ${attempt} failed`, e);
+                if (superseded()) {
+                    return null;
+                }
+                if (attempt < 3) {
+                    // brief backoff, then retry on a fresh comm
+                    await new Promise((resolve) => setTimeout(resolve, 250 * attempt));
+                    if (superseded()) {
+                        return null;
+                    }
+                }
+            }
         }
-        if (searchParams.has('modelid')) {
-            // popouts attach to a specific model id that no longer exists on a fresh instance -
-            // there is nothing to soft-remount, so fall back to the dialog (§6.2)
-            await fallbackToDialog();
-            return;
-        }
-        remountInProgress = true;
-        app.$data.remounting = true;
-        // snapshot the comm ids registered on the connection BEFORE teardown, so we can purge the
+        return { started: false, canRecover: false };
+    }
+
+    async function teardownClientWidgets(superseded) {
+        // shared teardown for REMOUNT/REPAIR: silently dispose the widget-manager generation
+        // that is current ON ENTRY (a live one, or the remnants of an interrupted rebuild),
+        // purge its comm registrations, and install a fresh manager + mount point. Returns the
+        // fresh manager, or null when the cycle got superseded mid-teardown: the shared mount
+        // state then already belongs to the newer cycle's own rebuild and must not be touched
+        // (a stale teardown finishing late would otherwise dispose the fresh manager the newer
+        // cycle just installed).
+        const manager = widgetManager;
+        // Snapshot the comm ids registered on the connection BEFORE teardown, so we can purge the
         // ones orphaned by the silent teardown below (see purgeStaleComms). Taken before the new
         // manager runs, so it can only ever name comms from the generation we are tearing down.
         const commIdsBefore = (kernel && kernel._comms && typeof kernel._comms.keys === 'function')
             ? [...kernel._comms.keys()]
             : [];
+        // tear down the dead widget manager (disposes models). On a fresh kernel the old comms
+        // are already gone server-side, so prefer the silent local teardown (bundle >= 0.5.0)
+        // which does NOT send a comm_close per widget over the reconnected socket. Fall back to
+        // clear_state() on older bundles (it sends comm_close - harmless, the server filters the
+        // resulting "No such comm" noise). Bundle and pip versions are decoupled in the wild, so
+        // the feature-detect is required.
+        if (typeof manager.clearStateLocal === 'function') {
+            try {
+                await manager.clearStateLocal();  // silent local teardown (bundle >= 0.5.0)
+            } catch (e) {
+                console.warn('solara remount: clearStateLocal failed', e);
+            }
+        } else {
+            try {
+                manager.clear_state();  // old bundles: sends comm_close (server filters the noise)
+            } catch (e) {
+                console.warn('solara remount: clear_state failed', e);
+            }
+        }
+        if (typeof manager.dispose === 'function') {
+            try {
+                manager.dispose();
+            } catch (e) {
+                console.warn('solara remount: dispose failed', e);
+            }
+        }
+        if (superseded()) {
+            return null;
+        }
+        // the silent teardown above (clearStateLocal / close(true)) leaves the disposed
+        // widgets' CommHandlers registered on the connection; purge them now, before the new
+        // manager registers its own, so a later cross-node reconnect resync cannot collide.
+        purgeStaleComms(commIdsBefore);
+        // settled promises would otherwise make the re-mount a no-op (§6.2)
+        delete widgetPromises[mountId];
+        delete widgetResolveFns[mountId];
+        // destroy + recreate the Vue mount-point (bound :key in the loader templates)
+        app.$data.remountKey += 1;
+        // fresh widget manager on the same reconnected kernel
+        widgetManager = makeWidgetManager();
+        return widgetManager;
+    }
+
+    async function rebuildView(superseded, containerId) {
+        // REMOUNT (containerId null): run() the app again - the server restores persisted state
+        // on its fresh kernel context (§6.2).
+        // REPAIR (containerId given): the app is already running server-side but OUR view is
+        // gone (a previous rebuild was interrupted mid-way): re-attach to the existing root
+        // container - fetchAll + mount, the same path a popout uses to attach - so no server
+        // state is lost.
+        if (searchParams.has('modelid')) {
+            // popouts attach to a specific model id that no longer exists on a fresh instance -
+            // there is nothing to rebuild, so fall back to the dialog (§6.2)
+            await fallbackToDialog();
+            return;
+        }
+        app.$data.remounting = true;
+        // the view is going away NOW: if this rebuild never completes (socket drop mid-way,
+        // lost run() reply), the next cycle sees viewMounted == false and REPAIRs (invariant 2)
+        viewMounted = false;
         try {
-            // tear down the dead widget manager (disposes models). On a fresh kernel the old comms
-            // are already gone server-side, so prefer the silent local teardown (bundle >= 0.5.0)
-            // which does NOT send a comm_close per widget over the reconnected socket. Fall back to
-            // clear_state() on older bundles (it sends comm_close - harmless, the server filters the
-            // resulting "No such comm" noise). Bundle and pip versions are decoupled in the wild, so
-            // the feature-detect is required.
-            if (typeof widgetManager.clearStateLocal === 'function') {
-                try {
-                    await widgetManager.clearStateLocal();  // silent local teardown (bundle >= 0.5.0)
-                } catch (e) {
-                    console.warn('solara remount: clearStateLocal failed', e);
-                }
-            } else {
-                try {
-                    widgetManager.clear_state();  // old bundles: sends comm_close (server filters the noise)
-                } catch (e) {
-                    console.warn('solara remount: clear_state failed', e);
-                }
-            }
-            if (typeof widgetManager.dispose === 'function') {
-                try {
-                    widgetManager.dispose();
-                } catch (e) {
-                    console.warn('solara remount: dispose failed', e);
-                }
-            }
-            // the silent teardown above (clearStateLocal / close(true)) leaves the disposed
-            // widgets' CommHandlers registered on the connection; purge them now, before the new
-            // manager registers its own, so a later cross-node reconnect resync cannot collide.
-            purgeStaleComms(commIdsBefore);
-            // settled promises would otherwise make the re-mount a no-op (§6.2)
-            delete widgetPromises[mountId];
-            delete widgetResolveFns[mountId];
-            // destroy + recreate the Vue mount-point (bound :key in the loader templates)
-            app.$data.remountKey += 1;
-            // fresh widget manager on the same reconnected kernel
-            widgetManager = makeWidgetManager();
-            // pushState routing makes the boot-time path stale - recompute from the live URL now
-            const path = window.location.pathname.slice(solara.rootPath.length) + window.location.search;
-            const widgetModelId = await widgetManager.run(appName, { path, dark: inDarkMode(), themes: vuetifyThemes });
-            if (kernel.connectionStatus !== 'connected') {
-                // the socket dropped again during the remount - abort quietly; the next 'connected'
-                // event restarts the flow
+            // work with OUR generation's manager from here on (never re-read the shared
+            // binding after an await: a newer cycle's rebuild may have replaced it)
+            const manager = await teardownClientWidgets(superseded);
+            if (manager === null || superseded()) {
                 return;
             }
-            await solaraMount(widgetManager, mountId, widgetModelId);
+            let modelId;
+            if (containerId) {
+                await manager.fetchAll();
+                modelId = containerId;
+            } else {
+                // pushState routing makes the boot-time path stale - recompute from the live URL now
+                const path = window.location.pathname.slice(solara.rootPath.length) + window.location.search;
+                modelId = await manager.run(appName, { path, dark: inDarkMode(), themes: vuetifyThemes });
+            }
+            if (superseded()) {
+                // the socket dropped again (or a newer cycle took over) during the rebuild -
+                // abort quietly; the next cycle detects viewMounted == false and repairs
+                return;
+            }
+            await solaraMount(manager, mountId, modelId);
+            viewMounted = true;
             solara.debug.remountCount++;
         } catch (e) {
+            if (superseded()) {
+                // a superseded rebuild's failure is not a verdict: its comms may simply have
+                // been torn down by the newer cycle's own rebuild
+                console.warn('solara rebuild aborted (superseded)', e);
+                return;
+            }
             console.error('solara remount failed', e);
             await fallbackToDialog();
         } finally {
-            app.$data.remounting = false;
-            remountInProgress = false;
+            if (!superseded()) {
+                // the latest cycle owns the "Restoring session..." indicator; a superseded
+                // rebuild must not clear what the newer cycle just set
+                app.$data.remounting = false;
+            }
         }
     }
 
@@ -366,6 +447,46 @@ async function solaraInit(mountId, appName) {
     });
 
 
+    // =====================================================================================
+    // Reconnect state machine (design §6.1/§6.2)
+    //
+    // State (all per page, in this closure):
+    //   reconnectGeneration   monotonic; every 'connected' event starts a new reconnect CYCLE
+    //                         that owns its generation. superseded() means "a newer cycle
+    //                         exists, or the socket dropped again"; a superseded cycle aborts
+    //                         SILENTLY at its next await boundary - its observations are stale
+    //                         and prove nothing about the app's health.
+    //   viewMounted           true iff a root view was mounted and not torn down since. Every
+    //                         rebuild flips it false first and true only after a completed
+    //                         mount, so an interrupted rebuild is visible to the next cycle.
+    //   app.$data.needsRefresh   terminal: the refresh dialog is up (or forceRefresh already
+    //                         reloaded the page); later cycles do nothing.
+    //
+    // One cycle = one PROBE, then exactly one verdict, taken only while still the latest live
+    // cycle:
+    //   PROBE     app-status on a fresh solara.control comm, up to 3 attempts of 2s with
+    //             backoff (probeAppStatus). Only CONSISTENT failure is a verdict; a single
+    //             late/lost reply is not.
+    //   RESUME    started && viewMounted -> fetchAll() (same-instance hot reconnect).
+    //   REPAIR    started && !viewMounted -> a previous rebuild tore the view down but never
+    //             completed (socket drop mid-rebuild): the app is running server-side, so
+    //             re-attach to its root container (rebuildView with reply.containerId).
+    //   REMOUNT   !started && canRecover && clientVersion matches -> rebuildView(run): the
+    //             server restores persisted state on its fresh kernel (§6.2).
+    //   GIVE UP   otherwise -> fallbackToDialog(): needsRefresh + shutdownKernel. The ONLY
+    //             place that shuts the kernel down or raises the dialog.
+    //
+    // Invariants:
+    //   1. at most one cycle - the latest - takes a verdict and touches the UI state
+    //      (remounting indicator, dialog); there is no in-flight boolean that can wedge -
+    //      ownership is the generation number, and superseded work simply returns.
+    //   2. a rebuild either completes to a mounted view (viewMounted = true) or leaves
+    //      viewMounted == false, which the NEXT cycle detects and repairs; a rebuild hung on a
+    //      lost reply can therefore never block recovery.
+    //   3. the server half (kernel_context.initialize_virtual_kernel) generation-checks a
+    //      reused context against the backend and supersedes it BEFORE wiring the websocket,
+    //      so the probe always observes the post-supersede context.
+    // =====================================================================================
     kernel.connectionStatusChanged.connect((s) => {
         if (unloading) {
             // we don't want to show ui changes when hitting refresh
@@ -378,28 +499,31 @@ async function solaraInit(mountId, appName) {
         }
         if (s.connectionStatus == 'connected' && !skipReconnectedCheck) {
             solara.debug.reconnectCount++;
+            const generation = ++reconnectGeneration;
+            const superseded = () => generation !== reconnectGeneration || kernel.connectionStatus !== 'connected';
             (async () => {
                 if (app.$data.needsRefresh) {
-                    // already gave up
+                    // terminal: we already gave up
                     return;
                 }
-                // On reconnect we expect the app to still be started. If it is not, we either landed
-                // on a different node/worker or the server restarted. Probe app-status and decide
-                // (§6.1): started -> hot reconnect (fetchAll); recoverable AND matching client bundle
-                // -> soft-remount (no dialog); otherwise -> refresh dialog.
-                let reply;
-                try {
-                    reply = await solaraAppStatus(kernel);
-                } catch (e) {
-                    // no reply within the timeout - treat as not started and not recoverable
-                    reply = { started: false, canRecover: false };
+                const reply = await probeAppStatus(superseded);
+                if (reply === null || superseded()) {
+                    return;
                 }
                 solara.debug.lastRestore = reply.lastRestore || null;
-                if (reply.started) {
+                if (reply.started && viewMounted) {
+                    // RESUME. Settle the indicator first: a previous rebuild may have completed
+                    // its mount just as its socket dropped, leaving the overlay up.
+                    app.$data.remounting = false;
                     await widgetManager.fetchAll();
+                } else if (reply.started) {
+                    // REPAIR (falls back to a plain REMOUNT when the server predates containerId)
+                    await rebuildView(superseded, reply.containerId || null);
                 } else if (reply.canRecover && reply.clientVersion === solara.clientVersion) {
-                    await solaraRemount();
+                    // REMOUNT
+                    await rebuildView(superseded, null);
                 } else {
+                    // GIVE UP
                     await fallbackToDialog();
                 }
             })();
@@ -458,7 +582,8 @@ async function solaraInit(mountId, appName) {
     } else {
         widgetModelId = await widgetManager.run(appName, {path, dark: inDarkMode(), themes: vuetifyThemes});
     }
-    await solaraMount(widgetManager, mountId || 'content', widgetModelId);
+    await solaraMount(widgetManager, mountId, widgetModelId);
+    viewMounted = true;
     skipReconnectedCheck = false;
     solara.renderKatex();
 }

--- a/tests/integration/reconnect_state_test.py
+++ b/tests/integration/reconnect_state_test.py
@@ -21,6 +21,7 @@ Eviction fails closed; the second test pins the fail-closed gate of the HTTP evi
 pinned in tests/unit/state_server_test.py).
 """
 
+import time
 import uuid
 from pathlib import Path
 
@@ -29,6 +30,7 @@ import pytest
 import requests
 
 import solara
+import solara.server.app
 import solara.server.settings
 import solara.state
 import solara.server.kernel_context
@@ -220,6 +222,184 @@ def test_soft_remount_purges_stale_comms(
             page_session.locator("text=IncrementCount").click()
             page_session.locator("text=Value 1").wait_for()
             assert not any("Comm is already created" in e for e in page_errors), page_errors
+    finally:
+        page_session.goto("about:blank")
+
+
+# --- slow app-status probe must not tear down a healthy session ----------------------------
+
+
+@pytest.fixture
+def slow_app_status(monkeypatch):
+    """Delay the server's app-status control-comm reply by ~1s.
+
+    ``_last_restore`` is called only while building the app-status reply, so this delays
+    exactly the reconnect probe - nothing else. 1s is over the old hard 500ms probe timeout
+    (which turned one late reply into the refresh dialog / a full reload) and well under the
+    current per-attempt timeout.
+    """
+    orig = solara.server.app._last_restore
+
+    def slow(manager):
+        time.sleep(1.0)
+        return orig(manager)
+
+    monkeypatch.setattr(solara.server.app, "_last_restore", slow)
+
+
+def test_slow_app_status_probe_does_not_reload(
+    browser: playwright.sync_api.Browser,
+    page_session: playwright.sync_api.Page,
+    solara_server,
+    solara_app,
+    extra_include_path,
+    request,
+    state_settings,
+    slow_app_status,
+):
+    """A single slow app-status probe on reconnect must NOT conclude "not recoverable".
+
+    Regression test for a spurious full-page reload seen behind a round-robin load balancer:
+    the reconnect handler probed app-status with a hard 500ms timeout and treated ONE timeout
+    as "not started, not recoverable" -> refresh dialog + shutdownKernel of a perfectly healthy
+    kernel (and with SOLARA_THEME_FORCE_REFRESH=True an immediate location.reload()). A busy or
+    cold backend (here: a 1s reply latency) or a second reconnect racing the probe was enough.
+    The probe now retries with a longer per-attempt timeout, and a superseded cycle never
+    concludes; the dialog requires consistent failure.
+    """
+    try:
+        with extra_include_path(HERE), solara_app("reconnect_state_test:Page"):
+            page_session.goto(solara_server.base_url)
+            page_session.locator("text=Value 0").wait_for()
+            # reload canary: survives everything except an actual page (re)load
+            page_session.evaluate("window.__reloadCanary = true")
+            page_session.locator("text=IncrementCount").click()
+            page_session.locator("text=Value 1").wait_for()
+
+            # a plain network blip: drop the raw socket, kernel and context stay alive
+            page_session.evaluate("solara.debug.dropConnection()")
+            page_session.wait_for_function("() => window.solara && solara.debug && solara.debug.reconnectCount >= 1", timeout=30000)
+
+            # deterministic sync point for the probe verdict: on success the handler stores the
+            # reply's lastRestore (the ~1s-late reply must WIN); on the old code the 500ms
+            # timeout flips needsRefresh instead and lastRestore stays null.
+            page_session.wait_for_function(
+                "() => (solara.debug.lastRestore !== null) || (window.app && app.$data.needsRefresh)",
+                timeout=30000,
+            )
+            assert not page_session.evaluate("window.app && app.$data.needsRefresh"), "one slow app-status probe tore the session down (refresh dialog)"
+            assert page_session.evaluate("window.__reloadCanary === true"), "the page reloaded"
+            assert page_session.locator("text=Please refresh the page").count() == 0
+
+            # and the session actually resynced: the button still reaches python
+            page_session.locator("text=IncrementCount").click()
+            page_session.locator("text=Value 2").wait_for(timeout=15000)
+    finally:
+        page_session.goto("about:blank")
+
+
+# --- interrupted rebuild must self-heal on the next reconnect (the empty-mount wedge) ------
+
+
+@pytest.fixture
+def lose_remount_run_reply(monkeypatch):
+    """Sabotage the SECOND app run (the soft-remount's) so its 'finished' reply is lost.
+
+    After ``load_app_widget`` completes (the app IS started server-side, container set), the
+    kernel's websockets are removed from the session and closed. Removing them FIRST makes the
+    loss deterministic on every server: starlette's ``close()`` is scheduled through a portal,
+    so a closed-but-still-draining socket could otherwise let the reply escape. The client's
+    ``widgetManager.run()`` promise then never settles - exactly what a socket drop between
+    run() and the mount produces in production. The client is left with started=true
+    server-side and NO view client-side: the empty-mount wedge.
+    """
+    import solara.server.app as server_app
+
+    orig = server_app.load_app_widget
+    calls = {"n": 0}
+
+    def sabotaged(state, app, path):
+        orig(state, app, path)
+        calls["n"] += 1
+        if calls["n"] == 2:
+            context = solara.server.kernel_context.get_current_context()
+            sockets = list(context.kernel.session.websockets)
+            context.kernel.session.websockets.clear()
+            for ws in sockets:
+                try:
+                    ws.close()
+                except Exception:  # noqa
+                    pass
+
+    monkeypatch.setattr(server_app, "load_app_widget", sabotaged)
+    return calls
+
+
+def test_interrupted_remount_repairs_on_next_reconnect(
+    browser: playwright.sync_api.Browser,
+    page_session: playwright.sync_api.Page,
+    solara_server,
+    solara_app,
+    extra_include_path,
+    request,
+    state_settings,
+    lose_remount_run_reply,
+):
+    """A rebuild interrupted mid-way (lost run reply + socket drop) must self-heal.
+
+    Regression test for the empty-mount wedge: a soft-remount whose ``run()`` reply is lost
+    hangs after it already tore the client view down. The old ``remountInProgress`` boolean
+    then swallowed every later remount, and the next probe (started=true, the run DID execute
+    server-side) resynced state into a viewless page: empty DOM, no errors, forever.
+
+    The state machine invariant under test: a rebuild either completes to a mounted view, or
+    leaves ``viewMounted == false``, which the NEXT reconnect cycle detects (started=true from
+    the probe) and REPAIRs by re-attaching to the running app via the reply's containerId.
+
+    NOTE the stale-DOM trap: after ``simulateFailover()`` the pre-failover DOM stays visible
+    until the rebuild's teardown, so DOM locators alone prove nothing here. The sync points
+    are the fixture's server-side call counter and the client's remountCount/viewMounted;
+    only the final click round-trip proves a live view.
+    """
+    calls = lose_remount_run_reply
+    try:
+        with extra_include_path(HERE), solara_app("reconnect_state_test:Page"):
+            page_session.goto(solara_server.base_url)
+            page_session.locator("text=Value 0").wait_for()
+            page_session.locator("text=IncrementCount").click()
+            page_session.locator("text=Value 1").wait_for()
+            # reload canary: survives everything except an actual page (re)load
+            page_session.evaluate("window.__reloadCanary = true")
+
+            # failover -> reconnect cycle 1 -> REMOUNT -> its run() executes server-side (the
+            # app restores "Value 1") but the reply is destroyed together with the socket by
+            # the fixture -> the rebuild hangs, view torn down, viewMounted stays false
+            page_session.evaluate("solara.debug.simulateFailover()")
+
+            # sync point 1: the remount's run reached the server and its reply was destroyed
+            # (the server runs threaded in-process, so we can poll the fixture's counter)
+            deadline = time.time() + 20
+            while calls["n"] < 2 and time.time() < deadline:
+                page_session.wait_for_timeout(100)
+            assert calls["n"] >= 2, "the soft-remount's run never reached the server"
+
+            # sync point 2: the wedge cannot resolve itself (the hung rebuild never counts) -
+            # a completed mount from here on MUST be the next cycle's REPAIR. On the old code
+            # remountCount stays 0 forever (the wedge), so this wait times out.
+            page_session.wait_for_function(
+                "() => window.solara && solara.debug && solara.debug.remountCount >= 1 && solara.debug.viewMounted()",
+                timeout=30000,
+            )
+
+            assert not page_session.evaluate("window.app && app.$data.needsRefresh"), "the wedge escalated to the refresh dialog"
+            assert page_session.evaluate("window.__reloadCanary === true"), "the page reloaded"
+            assert page_session.locator("text=Please refresh the page").count() == 0
+
+            # the REPAIR re-attached to the SAME app run (persisted value restored by run #2),
+            # and the view is live: the button round-trips to python
+            page_session.locator("text=Value 1").wait_for(timeout=15000)
+            page_session.locator("text=IncrementCount").click()
+            page_session.locator("text=Value 2").wait_for(timeout=15000)
     finally:
         page_session.goto("about:blank")
 

--- a/tests/unit/state_server_test.py
+++ b/tests/unit/state_server_test.py
@@ -510,6 +510,37 @@ def test_evict_comm_closes_context(backend, monkeypatch):
     assert kernel_id not in kc.contexts
 
 
+# --- app-status reply shape (the client reconnect state machine's PROBE input) -------------
+
+
+def test_app_status_reply_shape(backend):
+    """Pin the fields the client's reconnect state machine branches on (main-vuetify.js).
+
+    ``containerId`` in particular: it is what lets a client whose rebuild was interrupted
+    (started=true but no view mounted) RE-ATTACH to the running app instead of resyncing
+    state into a viewless page (the REPAIR verdict).
+    """
+    from solara.server.app import client_version, solara_comm_target
+
+    context = kc.initialize_virtual_kernel("sess-status", "kern-status", Mock())
+    fake = _FakeComm()
+    with context:
+        solara_comm_target(fake, None)
+        fake.dispatch({"method": "app-status"})
+        not_started = fake.sent[-1]
+        # a started context (the run handler sets context.container) reports its root container
+        context.container = Mock(_model_id="model-123")
+        fake.dispatch({"method": "app-status"})
+        started = fake.sent[-1]
+
+    assert not_started["started"] is False
+    assert not_started["containerId"] is None
+    assert not_started["clientVersion"] == client_version()
+    assert not_started["canRecover"] is True  # a backend is configured, no bail-out
+    assert started["started"] is True
+    assert started["containerId"] == "model-123"
+
+
 # --- bail-out storm valve (§4.3) ----------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

The client reconnect path grew several layered fixes this week (1.58.2 + #1167). Before adding another patch, this PR steps back and restructures the ~200 lines of reconnect handling in `main-vuetify.js` into one explicit, documented state machine, and fixes the two remaining production bug classes that the old shape made possible. The verified server-side work from #1167 (comm purge, claim-on-miss fencing) is untouched.

## The two bugs

1. **Spurious teardown of healthy sessions.** The reconnect handler probed `app-status` with a hard one-shot 500&nbsp;ms timeout and treated ANY probe failure as "not started, not recoverable" → `needsRefresh` **and `shutdownKernel` of a healthy kernel**. With `SOLARA_THEME_FORCE_REFRESH=True` (staging config) that is an immediate `location.reload()`; stock production shows the refresh dialog. One late reply (busy backend restoring another kernel, network jitter, or a second reconnect racing the first probe) was enough.
2. **The empty-mount wedge (pre-existing, newly fixed here).** A soft-remount interrupted between `run()` and the mount (socket drop; the `finished` reply is lost) hung forever while holding the `remountInProgress` boolean. Every later remount was silently swallowed, and the next reconnect (probe says `started: true` — the run DID execute server-side) resynced state into a viewless page: empty DOM, no errors, unrecoverable. Ironically, bug 1 sometimes "recovered" these wedges by killing the session.

Shared root cause: reconnect handling had no single owner. Every `connected` event started an independent async flow guarded by ad-hoc flags, and the flows raced each other.

## The state machine (now documented above `connectionStatusChanged` in `main-vuetify.js`)

**State:** `reconnectGeneration` (monotonic; each `connected` event starts a cycle owning its generation — `superseded()` = a newer cycle exists or the socket dropped again), `viewMounted` (true iff a root view is mounted and not torn down since), `needsRefresh` (terminal).

**One cycle = one PROBE, then exactly one verdict, taken only while still the latest live cycle:**

| verdict | condition | action |
|---|---|---|
| PROBE | — | `app-status` on a fresh `solara.control` comm, up to 3 attempts × 2 s with backoff. Only CONSISTENT failure is a verdict. |
| RESUME | `started && viewMounted` | `fetchAll()` (same-instance hot reconnect, unchanged) |
| REPAIR | `started && !viewMounted` | a previous rebuild was interrupted: **re-attach** to the running app — `fetchAll()` + mount the reply's new `containerId` field (the popout attach path). No server state lost. |
| REMOUNT | `!started && canRecover && clientVersion` match | rebuild via `run()` (server restores persisted state) |
| GIVE UP | otherwise | `fallbackToDialog()` — the ONLY place that sets `needsRefresh`/calls `shutdownKernel` |

**Invariants:**
1. At most one cycle — the latest — takes a verdict and touches UI state; there is **no in-flight boolean left that can wedge**. Ownership is the generation number; superseded work aborts silently at its next `await` boundary.
2. A rebuild either completes to a mounted view (`viewMounted = true`) or leaves `viewMounted == false`, which the NEXT cycle detects and REPAIRs. A rebuild hung on a lost reply can never block recovery again.
3. Server half (unchanged, `kernel_context.initialize_virtual_kernel`): a reused context is generation-checked against the backend and superseded BEFORE the websocket is wired, so the probe always observes the post-supersede context.

## Inherited vs redesigned

Inherited from the uncommitted `fix/reconnect-probe-reload` work (rig-verified): the probe retry (3 × 2 s + backoff), the generation counter idea, and the `slow_app_status` integration test. Redesigned on top: `remountInProgress` **removed** (it contradicted generation ownership and was the wedge), `viewMounted` + the REPAIR verdict added (fixes the wedge instead of documenting it), the probe/teardown/rebuild factored into named functions matching the machine's steps, all UI-state writes routed through verdict owners, and the `containerId` field added to the `app-status` reply (server, one line + mypy guard).

## Rig numbers (2 backends + caddy round_robin + redis, `SOLARA_STATE_BACKEND=redis`)

| experiment | master (1.58.2) | this PR |
|---|---|---|
| calm control (6 spaced closes) | 0/1 incidents | 0/1 incidents |
| slow probe (1.0 s app-status latency, one calm close) | **5/5 needsRefresh + kernel shutdown** (session dead) | **0/5**, typing round-trips after |
| forceRefresh parity (staging config, slow probe) | **3/3 full page reloads** | **0/3** |
| rapid bursts (0.2 s latency, 8 bursts of 2–3 drops) | **4/5 runs hit needsRefresh** (bursts 3,4,3,8) | **0/5**, typing OK after every burst |
| designed clientVersion-mismatch reload | 2/2 (works) | 2/2 (preserved) |
| empty-mount wedge (drop mid-remount, run reply lost) | **5/5 dead** (viewless page) | **0/5**, REPAIR re-attaches, typing OK |

## Tests

- NEW `test_interrupted_remount_repairs_on_next_reconnect` (integration, flask+starlette): deterministically loses the remount's `run` reply server-side, red on master (times out — remountCount stays 0 forever), green here; verified the test fails again if the REPAIR branch is neutered.
- NEW `test_app_status_reply_shape` (unit): pins the probe reply fields incl. `containerId`.
- Inherited `test_slow_app_status_probe_does_not_reload` (integration): red on master, green here.
- Gates: `tests/integration/reconnect_state_test.py` + `reconnect_test.py` (flask+starlette) 15 passed; full `tests/unit/` 404 passed; `node --check`; pre-commit (ruff/mypy/codespell) clean.
- `test_reconnect_fail` flake question: 22 runs on unmodified master (isolation + suite context) all green — pre-existing timing sensitivity (the 3 s non-production auto-refresh countdown racing the 5 s contexts-empty wait), most likely load-dependent; not chased here.

## Needs live-staging validation

- The REPAIR path behind the real round-robin LB with redis (rig-verified, but staging has real latency + `SOLARA_THEME_FORCE_REFRESH=True`).
- The probe-retry budget (worst case ~7 s before the dialog on a truly dead-but-socket-accepting server) — acceptable UX?
- Version-skew during a rolling deploy: `started:true` from an old server (no `containerId`) degrades REPAIR to a plain REMOUNT (`run()` — use_state resets, persisted state restored), never a viewless page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
