### PR TITLE
fix: do not log an error when a task finishes after its call loop closed

### DIFF
--- a/solara/tasks.py
+++ b/solara/tasks.py
@@ -286,11 +286,17 @@ class TaskAsyncio(Task[P, R]):
                     try:
                         call_event_loop.call_soon_threadsafe(future.set_exception, e)
                     except Exception as e2:
-                        if not self._is_context_closed():
+                        if not self._is_future_orphaned(call_event_loop):
                             logger.exception(
                                 "error setting exception from for task %s. Original exception: %s\nReason for failing to set exception: %s",
                                 self.function.__name__,
                                 e,
+                                e2,
+                            )
+                        else:
+                            logger.debug(
+                                "ignoring error setting exception for task %s, nobody can await the future anymore: %s",
+                                self.function.__name__,
                                 e2,
                             )
                 except Exception as e:
@@ -298,11 +304,17 @@ class TaskAsyncio(Task[P, R]):
                     try:
                         call_event_loop.call_soon_threadsafe(future.set_exception, e)
                     except Exception as e2:
-                        if not self._is_context_closed():
+                        if not self._is_future_orphaned(call_event_loop):
                             logger.exception(
                                 "error setting exception from for task %s. Original exception: %s\nReason for failing to set exception: %s",
                                 self.function.__name__,
                                 e,
+                                e2,
+                            )
+                        else:
+                            logger.debug(
+                                "ignoring error setting exception for task %s, nobody can await the future anymore: %s",
+                                self.function.__name__,
                                 e2,
                             )
                     raise
@@ -327,6 +339,14 @@ class TaskAsyncio(Task[P, R]):
             return False
         return context.closed_event.is_set()
 
+    def _is_future_orphaned(self, call_event_loop: asyncio.AbstractEventLoop) -> bool:
+        # When a page disconnects, the event loop the task was called from (the websocket
+        # thread's loop) is closed while the kernel context stays alive until the cull
+        # timeout. A task finishing in that window cannot deliver its result to the future,
+        # but nothing can await that future anymore either (any awaiter lived on the same
+        # loop), so failing to deliver is expected and harmless, just like a closed context.
+        return call_event_loop.is_closed() or self._is_context_closed()
+
     async def _async_run(self, call_event_loop: asyncio.AbstractEventLoop, future: asyncio.Future, args, kwargs) -> None:
         self._start_event.wait()
 
@@ -346,7 +366,7 @@ class TaskAsyncio(Task[P, R]):
                 try:
                     call_event_loop.call_soon_threadsafe(future.set_result, value)
                 except Exception as e:
-                    if not self._is_context_closed():
+                    if not self._is_future_orphaned(call_event_loop):
                         logger.exception(
                             "error setting result from for task %s. Original exception: %s\nReason for failing to set result: %s", self.function.__name__, e, e
                         )
@@ -364,13 +384,21 @@ class TaskAsyncio(Task[P, R]):
                 try:
                     call_event_loop.call_soon_threadsafe(future.set_exception, e)
                 except Exception as e2:
-                    # we don't know if it is still useful to show this error, so we show it regardless if the context is closed or not
-                    logger.exception(
-                        "error setting exception from for task %s. Original exception: %s\nReason for failing to set exception: %s",
-                        self.function.__name__,
-                        e,
-                        e2,
-                    )
+                    if not self._is_future_orphaned(call_event_loop):
+                        # the delivery failure has an unexpected cause, so we show it
+                        logger.exception(
+                            "error setting exception from for task %s. Original exception: %s\nReason for failing to set exception: %s",
+                            self.function.__name__,
+                            e,
+                            e2,
+                        )
+                    else:
+                        # the task exception itself was already logged above (when current)
+                        logger.debug(
+                            "ignoring error setting exception for task %s, nobody can await the future anymore: %s",
+                            self.function.__name__,
+                            e2,
+                        )
             # Although this seems like an easy way to handle cancellation, an early cancelled task will never execute
             # so this code will never execute, so we need to handle this in the cancel function in __call__
             # except asyncio.CancelledError as e:
@@ -385,7 +413,22 @@ class TaskAsyncio(Task[P, R]):
                 except asyncio.CancelledError as e:
                     if self.is_current():
                         self._result.value = TaskResult[R](latest=self._last_value, _state=TaskState.CANCELLED)
-                    call_event_loop.call_soon_threadsafe(future.set_exception, e)
+                    try:
+                        call_event_loop.call_soon_threadsafe(future.set_exception, e)
+                    except Exception as e2:
+                        if not self._is_future_orphaned(call_event_loop):
+                            logger.exception(
+                                "error setting exception from for task %s. Original exception: %s\nReason for failing to set exception: %s",
+                                self.function.__name__,
+                                e,
+                                e2,
+                            )
+                        else:
+                            logger.debug(
+                                "ignoring error setting exception for task %s, nobody can await the future anymore: %s",
+                                self.function.__name__,
+                                e2,
+                            )
 
         await runner()
 

--- a/tests/unit/task_test.py
+++ b/tests/unit/task_test.py
@@ -1,4 +1,6 @@
 import asyncio
+import logging
+import threading
 import time
 import warnings
 
@@ -681,3 +683,61 @@ def test_task_decorator_warning_in_component():
             return solara.Text("ComponentWithTaskInMemo")
 
         solara.render_fixed(ComponentWithTaskInMemo(), handle_error=False)
+
+
+@pytest.mark.parametrize("fail", [False, True])
+def test_task_finishing_after_call_event_loop_closed_is_not_an_error(fail, caplog, monkeypatch):
+    # When a page disconnects, the websocket thread's event loop is closed while the
+    # kernel context (and a running task) stays alive until the cull timeout. A task
+    # finishing in that window cannot deliver its result to the future on the closed
+    # loop, but nothing can await that future anymore either, so this is expected
+    # shutdown noise, not an error.
+    monkeypatch.setattr(solara.tasks, "_using_solara_server", lambda: True)
+    proceed = threading.Event()
+    context_holder = {}
+
+    @solara.tasks.task
+    async def finishes():
+        while not proceed.is_set():
+            await asyncio.sleep(0.001)
+        if fail:
+            raise RuntimeError("task failed for a test")
+        return 42
+
+    def page_thread():
+        async def run():
+            context = kernel_context.VirtualKernelContext(id="task-loop-closed", kernel=kernel.Kernel(), session_id="session-loop-closed")
+            context_holder["context"] = context
+            with context:
+                finishes()
+
+        # like the websocket thread in solara.server.starlette: asyncio.run closes the loop on disconnect
+        asyncio.run(run())
+
+    try:
+        with caplog.at_level(logging.DEBUG, logger="solara.task"):
+            thread = threading.Thread(target=page_thread)
+            thread.start()
+            thread.join()
+            assert context_holder["context"].event_loop.is_closed()
+            assert not context_holder["context"].closed_event.is_set()
+            proceed.set()
+
+            def delivery_records():
+                return [record for record in caplog.records if record.getMessage().startswith("ignoring error setting")]
+
+            deadline = time.time() + 10
+            while time.time() < deadline and not delivery_records():
+                time.sleep(0.01)
+
+        records = delivery_records()
+        assert len(records) == 1
+        assert records[0].levelno == logging.DEBUG
+        delivery_errors = [record for record in caplog.records if record.levelno >= logging.ERROR and record.getMessage().startswith("error setting")]
+        assert not delivery_errors
+        if fail:
+            # the exception raised by the task itself should still be logged
+            assert any(record.levelno == logging.ERROR and "task failed for a test" in record.getMessage() for record in caplog.records)
+    finally:
+        with context_holder["context"]:
+            context_holder["context"].close()


### PR DESCRIPTION
## What happens

When a page disconnects, the websocket thread's event loop is closed (`anyio.run` returns) while the kernel context — and any still-running `@task` — stays alive until the cull timeout. A task finishing in that window fails `call_event_loop.call_soon_threadsafe(future.set_result/set_exception, ...)` with `RuntimeError("Event loop is closed")`, and `solara.tasks` logs that at ERROR.

Nothing can await that future anymore — any awaiter lived on the same closed loop — so the failed delivery is expected shutdown noise, not an error. The task result itself is unaffected: it is stored via the task's reactive value before delivery, so a reconnecting page still sees it. In a production app (Sentry-monitored) this pattern produced **~90k error events over 30 days** across every task name in the app; any task still running when a user closes the tab hits it.

The existing `_is_context_closed()` guard was added for exactly this kind of shutdown noise, but cannot catch this window: the context is not closed yet, only its loop is.

## Fix

Add `_is_future_orphaned(call_event_loop)` = loop closed **or** context closed, and use it at all five delivery sites (one of which — the cancel-from-own-task path — was previously unguarded and let the `RuntimeError` propagate). Orphaned delivery failures now log at DEBUG; any other delivery failure still logs at ERROR. A task's own exception is still logged at ERROR as before.

## Test

`test_task_finishing_after_call_event_loop_closed_is_not_an_error` reproduces the production sequence: kernel context created and task started inside `asyncio.run()` on a separate thread (like the websocket thread), loop closes while the task still runs, then the task finishes (both the return-value and the raise path). Fails on master, passes with this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)