### PR TITLE
fix: gzip + immutable cdn caching for both server entrypoints

### DIFF
--- a/solara/server/fastapi.py
+++ b/solara/server/fastapi.py
@@ -2,4 +2,6 @@ from fastapi import FastAPI
 
 from . import starlette
 
-app = FastAPI(routes=starlette.routes)
+# reuse the middleware stack of the starlette app (gzip, and the session
+# middleware when auth is configured), so both entrypoints behave the same
+app = FastAPI(routes=starlette.routes, middleware=starlette.middleware)

--- a/solara/server/settings.py
+++ b/solara/server/settings.py
@@ -214,6 +214,9 @@ if is_mac_os_conda or is_wsl_windows:
 
 class Server(BaseSettings):
     ignore_nbextensions: List[str] = []
+    # gzip HTTP responses (SOLARA_SERVER_HTTP_GZIP=false when a fronting proxy
+    # like nginx/caddy does the compressing)
+    http_gzip: bool = True
 
     class Config:
         env_prefix = "solara_server_"

--- a/solara/server/starlette.py
+++ b/solara/server/starlette.py
@@ -685,6 +685,18 @@ class StaticCdn(StaticFilesOptionalAuth):
             return "", None
         return full_path, os.stat(full_path)
 
+    async def get_response(self, path: str, scope):
+        response = await super().get_response(path, scope)
+        # cdn urls embed the package version in the path (e.g.
+        # @widgetti/solara-vuetify-app@10.1.1/...), so any upgrade changes the
+        # url and the response can be cached forever. Without this, proxies and
+        # browsers re-download multi-MB bundles on every cold visit (and behind
+        # proxies that add a Set-Cookie, e.g. Cloud Run session affinity, the
+        # response is even marked private).
+        if response.status_code in (200, 304):
+            response.headers["Cache-Control"] = "public, max-age=31536000, immutable"
+        return response
+
 
 def on_startup():
     appmod.ensure_apps_initialized()
@@ -921,7 +933,9 @@ async def resourcez(request: Request):
 
 
 middleware = [
-    Middleware(GZipMiddleware, minimum_size=1000),
+    # SOLARA_SERVER_HTTP_GZIP=false to disable, e.g. when a fronting proxy
+    # (nginx/caddy) does the compressing
+    *([Middleware(GZipMiddleware, minimum_size=1000)] if settings.server.http_gzip else []),
 ]
 
 if has_auth_support:

--- a/solara/server/starlette.py
+++ b/solara/server/starlette.py
@@ -2,6 +2,7 @@ import asyncio
 import concurrent.futures
 from contextlib import asynccontextmanager
 import hashlib
+import re
 import hmac
 import json
 import logging
@@ -685,15 +686,22 @@ class StaticCdn(StaticFilesOptionalAuth):
             return "", None
         return full_path, os.stat(full_path)
 
+    # exact npm version in the path (e.g. @10.1.1/ or @2.3.6/): npm forbids
+    # republishing a version, so the content behind such a url can never change
+    _exact_version = re.compile(r"@\d+\.\d+\.\d+(?:[-+][\w.]+)?/")
+
     async def get_response(self, path: str, scope):
         response = await super().get_response(path, scope)
-        # cdn urls embed the package version in the path (e.g.
-        # @widgetti/solara-vuetify-app@10.1.1/...), so any upgrade changes the
-        # url and the response can be cached forever. Without this, proxies and
-        # browsers re-download multi-MB bundles on every cold visit (and behind
-        # proxies that add a Set-Cookie, e.g. Cloud Run session affinity, the
-        # response is even marked private).
-        if response.status_code in (200, 304):
+        # All urls solara itself puts through this proxy pin an exact version
+        # (@widgetti/solara-vuetify-app@10.1.1/..., requirejs@2.3.6/...), so a
+        # solara upgrade changes the url and busts the cache by construction.
+        # Without this header, browsers re-download multi-MB bundles on every
+        # cold visit (and behind proxies that add a Set-Cookie, e.g. Cloud Run
+        # session affinity, the response is even marked private).
+        # Semver-RANGE urls (user-constructed, e.g. pkg@^1/...) are resolved by
+        # the cdn at fetch time and can change content under the same url, so
+        # they are deliberately not marked immutable.
+        if response.status_code in (200, 304) and self._exact_version.search(path):
             response.headers["Cache-Control"] = "public, max-age=31536000, immutable"
         return response
 

--- a/solara/website/pages/documentation/getting_started/content/07-deploying/10-self-hosted.md
+++ b/solara/website/pages/documentation/getting_started/content/07-deploying/10-self-hosted.md
@@ -303,3 +303,48 @@ For a complete example, you can take a look at:
   * [https://huggingface.co/spaces/solara-dev/template](https://huggingface.co/spaces/solara-dev/template)
   * [https://huggingface.co/spaces/giswqs/solara-template/tree/main](https://huggingface.co/spaces/giswqs/solara-template/tree/main)
   * [https://github.com/opengeos/solara-template](https://github.com/opengeos/solara-template)
+
+## HTTP compression and caching
+
+The Solara server compresses HTTP responses larger than 1KB with gzip. This matters
+in production: the main JavaScript bundle is ~2MB, and without compression every
+cold page load downloads all of it (~4x more than needed).
+
+Both entrypoints (`solara.server.starlette.app` and `solara.server.fastapi.app`)
+apply the same middleware stack, so this also holds when you embed Solara in your
+own Starlette or FastAPI application by mounting one of these apps.
+
+When a fronting proxy should do the compressing instead (nginx `gzip on`, Caddy
+`encode zstd gzip` — often faster, and zstd compresses better), turn the built-in
+compression off:
+
+```bash
+SOLARA_SERVER_HTTP_GZIP=false solara run sol.py --production
+```
+
+### Asset caching
+
+Assets served under `/_solara/cdn/` (the CDN proxy, on by default in production)
+are marked `Cache-Control: public, max-age=31536000, immutable` **when their path
+pins an exact package version**, e.g.
+`/_solara/cdn/@widgetti/solara-vuetify-app@10.1.1/dist/solara-vuetify-app8.min.js`.
+
+This is safe by construction:
+
+- npm forbids republishing a version, so the content behind an exact-version url
+  can never change at the origin.
+- every url Solara itself generates through the proxy pins an exact version, and
+  upgrading Solara changes that version — a new url, so browsers fetch the new
+  file. There is nothing to invalidate manually.
+- urls with a semver *range* (e.g. `pkg@^1/index.js`, only possible when
+  user code constructs such a url) are resolved by the CDN at fetch time and can
+  change content under the same url; those are deliberately **not** marked
+  immutable.
+
+If you point `SOLARA_ASSETS_CDN` at a custom origin, make sure it follows the same
+rule (an exact-version path always returns the same bytes); otherwise browsers may
+cache stale files for up to a year.
+
+Other asset routes have their own cache-busting and are unaffected:
+`/static/public` (content-hash `?v=` urls), and nbextensions (hash-versioned
+query arguments).


### PR DESCRIPTION
Diagnosing a production deployment (which mounts `solara.server.fastapi.app`) serving the 2.1MB `solara-vuetify-app8.min.js` uncompressed and uncached on every cold page load surfaced three server gaps:

## 1. The FastAPI entrypoint drops the middleware stack

```python
app = FastAPI(routes=starlette.routes)   # middleware lost
```

`solara run` (starlette entrypoint) gzips responses; mounting `solara.server.fastapi.app` serves identity — and silently loses the session middleware too when auth is configured. Fixed by passing `starlette.middleware` through.

## 2. `/_solara/cdn/*` was never cache-friendly

The recent content-hash caching work covered `/static/public/*?v=<hash>` (`StaticPublic`), but the cdn proxy route — which serves the biggest assets — sent no `Cache-Control` at all. Its urls embed the package version (`@widgetti/solara-vuetify-app@10.1.1/...`), so they're safe to cache forever: now `public, max-age=31536000, immutable` on 200/304. Bonus: behind proxies that add a `Set-Cookie` (Cloud Run session affinity), the absent header previously got auto-stamped `private`, actively defeating browser caching.

## 3. Compression wasn't configurable

Deployments that compress in a fronting proxy (nginx/caddy `encode zstd gzip`) want app-level gzip off. New setting `SOLARA_SERVER_HTTP_GZIP` (default `true`, preserving current starlette behavior), honored by both entrypoints.

Verified: both entrypoints carry `GZipMiddleware` by default and drop it with `SOLARA_SERVER_HTTP_GZIP=false`; settings + cdn helper tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)