### PR TITLE
fix: free closed virtual kernels promptly instead of leaving them to the gc

### DIFF
--- a/solara/server/kernel_context.py
+++ b/solara/server/kernel_context.py
@@ -234,8 +234,14 @@ class VirtualKernelContext:
                 self.page_status[key] = PageStatus.CLOSED
             if self._last_kernel_cull_task:
                 self._last_kernel_cull_task.cancel()
+                # drop our reference: a cancelled task keeps its CancelledError whose
+                # traceback holds the kernel_cull frame, whose closure holds `self` -
+                # keeping the reference would turn that into a reference cycle through
+                # the whole context, which refcounting cannot free
+                self._last_kernel_cull_task = None
             if self._last_kernel_cull_future:
                 self._last_kernel_cull_future.cancel()
+                self._last_kernel_cull_future = None
             if self.closed_event.is_set():
                 logger.error("Tried to close a kernel context that is already closed: %s", self.id)
                 return
@@ -249,6 +255,9 @@ class VirtualKernelContext:
                     except Exception as e:
                         logger.exception("Could not close render context: %s", e)
                         # we want to continue, so we at least close all widgets
+                # drop the reference: anything that still (indirectly) references this
+                # closed context should not keep the whole render tree alive with it
+                self.app_object = None
             widgets.Widget.close_all()
             # what if we reference each other
             # import gc
@@ -269,6 +278,8 @@ class VirtualKernelContext:
                 if _ctx is self:
                     del current_context[key]
             self.closed_event.set()
+        if solara.server.settings.kernel.gc_after_close:
+            _schedule_gc_after_kernel_close()
 
     def _state_reset(self):
         state_directory = Path(".") / "states"
@@ -480,6 +491,42 @@ except RuntimeError:
     keep_alive_event_loop = asyncio.get_event_loop()
 
 contexts: Dict[str, VirtualKernelContext] = {}
+
+# Closed kernel contexts are reference cycles (widgets, reacton render contexts and the
+# IPython shell all reference each other), so plain refcounting cannot free them: they wait
+# for a generation-2 garbage collection. Under load that shows up as a memory sawtooth whose
+# peaks scale with per-kernel state (see docs/memory-usage-inspection.md). We therefore run
+# a gc shortly after a kernel closes - deferred to a background thread so the close path
+# (and the user awaiting closed_event) stays fast, and coalesced so a burst of closing
+# kernels (server shutdown, mass disconnect) triggers one collection, not hundreds.
+_gc_after_close_lock = threading.Lock()
+_gc_after_close_pending = False
+GC_AFTER_CLOSE_DELAY = 1.0  # seconds; also gives the closing code time to drop its own references
+
+
+def _schedule_gc_after_kernel_close():
+    global _gc_after_close_pending
+    with _gc_after_close_lock:
+        if _gc_after_close_pending:
+            return
+        _gc_after_close_pending = True
+
+    def collect():
+        global _gc_after_close_pending
+        time.sleep(GC_AFTER_CLOSE_DELAY)
+        with _gc_after_close_lock:
+            _gc_after_close_pending = False
+        import gc
+
+        gc.collect()
+
+    thread = threading.Thread(target=collect, daemon=True, name="solara-gc-after-kernel-close")
+    # the patched Thread captures the current kernel context at creation; this thread must
+    # not run inside the (closing) context, nor keep it alive until the collect is done
+    thread.current_context = None  # type: ignore
+    thread.start()
+
+
 # maps from thread key to VirtualKernelContext, if VirtualKernelContext is None, it exists, but is not set as current
 current_context: Dict[str, Optional[VirtualKernelContext]] = {}
 

--- a/solara/server/kernel_context.py
+++ b/solara/server/kernel_context.py
@@ -248,6 +248,7 @@ class VirtualKernelContext:
             logger.info("Shut down virtual kernel: %s", self.id)
             for f in reversed(self._on_close_callbacks):
                 f()
+            had_app = self.app_object is not None
             if self.app_object is not None:
                 if isinstance(self.app_object, reacton.core._RenderContext):
                     try:
@@ -278,7 +279,10 @@ class VirtualKernelContext:
                 if _ctx is self:
                     del current_context[key]
             self.closed_event.set()
-        if solara.server.settings.kernel.gc_after_close:
+        # only when the kernel rendered an app: a bare context holds nothing worth a full
+        # collection, and a gc storm from many short-lived contexts (e.g. the unit test
+        # suite closes one per test) pauses all threads, breaking timing-sensitive code
+        if had_app and solara.server.settings.kernel.gc_after_close:
             _schedule_gc_after_kernel_close()
 
     def _state_reset(self):

--- a/solara/server/patch.py
+++ b/solara/server/patch.py
@@ -302,6 +302,11 @@ def _WidgetContextAwareThread__bootstrap(self):
     if not hasattr(self, "current_context"):
         # this happens when a thread was running before we patched
         return Thread__bootstrap(self)
+    if self.current_context and self.current_context.kernel is None:
+        # the context closed between thread creation and start (close() sets kernel to
+        # None): run without a kernel context instead of crashing before _started is
+        # set, which would hang the Thread.start() caller forever
+        self.current_context = None
     if self.current_context:
         # we need to call this manually, because set_context_for_thread
         # uses this, and the original _bootstrap calls it too late for us

--- a/solara/server/settings.py
+++ b/solara/server/settings.py
@@ -111,6 +111,10 @@ class Kernel(BaseSettings):
     cull_timeout: str = "24h"
     max_count: Optional[int] = None
     threaded: bool = solara.util.has_threads
+    # Closed kernel contexts are reference cycles and otherwise wait for a gen-2 gc, which
+    # under load shows as a memory sawtooth (see docs/memory-usage-inspection.md). This runs
+    # a deferred, coalesced gc.collect() after a kernel closes so memory returns promptly.
+    gc_after_close: bool = True
     # Cap on live kernels a single session cookie may create. kernel_id is client-chosen and a
     # brand-new id accepts any cookie, so without this one session can spawn unbounded contexts,
     # threads and (with persistence) Redis keys. The default is far above any legitimate multi-tab

--- a/solara/tasks.py
+++ b/solara/tasks.py
@@ -211,6 +211,7 @@ class TaskAsyncio(Task[P, R]):
     _cancel: Optional[Callable[[], None]] = None
     _retry: Optional[Callable[[], None]] = None
     _context: Optional["weakref.ReferenceType[solara.server.kernel_context.VirtualKernelContext]"] = None
+    _drop_call_state_on_close_registered = False
 
     def __init__(self, run_in_thread: bool, function: Callable[P, Coroutine[Any, Any, R]], key: str):
         self.run_in_thread = run_in_thread
@@ -261,6 +262,11 @@ class TaskAsyncio(Task[P, R]):
             context = solara.server.kernel_context.get_current_context()
             self._context = weakref.ref(context)
             call_event_loop = context.event_loop
+            if not self._drop_call_state_on_close_registered:
+                # the task instance is per kernel (it lives in a kernel store), so one
+                # registration covers all calls
+                self._drop_call_state_on_close_registered = True
+                context.on_close(self._drop_call_state)
         else:
             call_event_loop = _main_event_loop or asyncio.get_event_loop()
         try:
@@ -291,43 +297,24 @@ class TaskAsyncio(Task[P, R]):
 
             def runs_in_thread():
                 try:
-                    thread_event_loop.run_until_complete(current_task)
-                except asyncio.CancelledError as e:
                     try:
-                        call_event_loop.call_soon_threadsafe(future.set_exception, e)
-                    except Exception as e2:
-                        if not self._is_future_orphaned(call_event_loop):
-                            logger.exception(
-                                "error setting exception from for task %s. Original exception: %s\nReason for failing to set exception: %s",
-                                self.function.__name__,
-                                e,
-                                e2,
-                            )
-                        else:
-                            logger.debug(
-                                "ignoring error setting exception for task %s, nobody can await the future anymore: %s",
-                                self.function.__name__,
-                                e2,
-                            )
-                except Exception as e:
-                    logger.exception("error running in thread")
-                    try:
-                        call_event_loop.call_soon_threadsafe(future.set_exception, e)
-                    except Exception as e2:
-                        if not self._is_future_orphaned(call_event_loop):
-                            logger.exception(
-                                "error setting exception from for task %s. Original exception: %s\nReason for failing to set exception: %s",
-                                self.function.__name__,
-                                e,
-                                e2,
-                            )
-                        else:
-                            logger.debug(
-                                "ignoring error setting exception for task %s, nobody can await the future anymore: %s",
-                                self.function.__name__,
-                                e2,
-                            )
-                    raise
+                        thread_event_loop.run_until_complete(current_task)
+                    except asyncio.CancelledError:
+                        # deliver the cancellation via future.cancel(): awaiters still get a
+                        # CancelledError, but no exception object (with a traceback that pins
+                        # the coroutine frames and the kernel context) crosses the thread.
+                        self._finish_future_threadsafe(call_event_loop, future, lambda f: f.cancel(), "cancellation")
+                    except Exception as e:
+                        logger.exception("error running in thread")
+                        # bind to a fresh name: `e` is unbound when the except block exits,
+                        # but the delivery lambda runs later on the call loop
+                        exception = e
+                        self._finish_future_threadsafe(call_event_loop, future, lambda f: f.set_exception(exception), "exception")
+                        raise
+                finally:
+                    # each call creates a fresh event loop; not closing it would leak its
+                    # selector file descriptor until the garbage collector gets to it
+                    thread_event_loop.close()
 
             self._result.value = TaskResult[R](latest=self._last_value, _state=TaskState.STARTING)
             thread = threading.Thread(target=runs_in_thread, daemon=True, name=f"TaskAsyncio-{self.function.__name__}")
@@ -338,8 +325,23 @@ class TaskAsyncio(Task[P, R]):
 
     def is_current(self):
         running_task = self.current_task
-        assert running_task is not None
+        if running_task is None:
+            # the kernel context closed (which drops the call state): any still-running
+            # call is stale and should stop
+            return False
         return (self.current_task == _get_current_task()) and not running_task.cancelled()
+
+    def _drop_call_state(self):
+        # A finished or cancelled asyncio.Task keeps its contextvars copy (which references
+        # the kernel context) and its exception traceback (which pins coroutine frames)
+        # alive. Keeping the task in `current_task` after the kernel context closes turns
+        # the context graph into one big reference cycle that has to wait for a gen-2 gc
+        # (measured as a memory sawtooth under load). Drop the call bookkeeping at close
+        # so plain refcounting can free the context right away.
+        self.current_task = None
+        self.current_future = None
+        self._cancel = None
+        self._retry = None
 
     def _is_context_closed(self):
         if self._context is None:
@@ -357,6 +359,31 @@ class TaskAsyncio(Task[P, R]):
         # loop), so failing to deliver is expected and harmless, just like a closed context.
         return call_event_loop.is_closed() or self._is_context_closed()
 
+    def _finish_future_threadsafe(self, call_event_loop: asyncio.AbstractEventLoop, future: asyncio.Future, finish: Callable[[asyncio.Future], Any], what: str):
+        """Complete the future from the task's thread, tolerating the expected shutdown races.
+
+        The future can already be done (a page close or shutdown cancelled it while our
+        completion was in flight) and the call loop can be closed (page close): both are
+        normal races, and completing a done future would raise InvalidStateError inside
+        the loop callback — asyncio then logs that with the exception traceback attached,
+        and exception tracebacks pin every frame they passed through (including the whole
+        kernel context), creating large reference cycles that stay around until a gen-2
+        gc. So we check done() inside the loop callback and skip delivery silently.
+        """
+
+        def deliver():
+            if not future.done():
+                finish(future)
+
+        try:
+            call_event_loop.call_soon_threadsafe(deliver)
+        except Exception as e:
+            if not self._is_future_orphaned(call_event_loop):
+                # the delivery failure has an unexpected cause, so we show it
+                logger.exception("error delivering %s for task %s: %s", what, self.function.__name__, e)
+            else:
+                logger.debug("ignoring failure to deliver %s for task %s, nobody can await the future anymore: %s", what, self.function.__name__, e)
+
     async def _async_run(self, call_event_loop: asyncio.AbstractEventLoop, future: asyncio.Future, args, kwargs) -> None:
         self._start_event.wait()
 
@@ -373,72 +400,25 @@ class TaskAsyncio(Task[P, R]):
                 if self.is_current() and not task_for_this_call.cancelled():  # type: ignore
                     self._result.value = TaskResult[R](value=value, latest=value, _state=TaskState.FINISHED, progress=self._last_progress)
                 logger.info("setting result to %r", value)
-                try:
-                    call_event_loop.call_soon_threadsafe(future.set_result, value)
-                except Exception as e:
-                    if not self._is_future_orphaned(call_event_loop):
-                        logger.exception(
-                            "error setting result from for task %s. Original exception: %s\nReason for failing to set result: %s", self.function.__name__, e, e
-                        )
-                    else:
-                        logger.debug(
-                            "ignoring error setting result from for task %s. Original exception: %s\nReason for failing to set result: %s",
-                            self.function.__name__,
-                            e,
-                            e,
-                        )
+                self._finish_future_threadsafe(call_event_loop, future, lambda f: f.set_result(value), "result")
             except Exception as e:
                 if self.is_current():
                     logger.exception(e)
                     self._result.value = TaskResult[R](latest=self._last_value, exception=e, _state=TaskState.ERROR)
-                try:
-                    call_event_loop.call_soon_threadsafe(future.set_exception, e)
-                except Exception as e2:
-                    if not self._is_future_orphaned(call_event_loop):
-                        # the delivery failure has an unexpected cause, so we show it
-                        logger.exception(
-                            "error setting exception from for task %s. Original exception: %s\nReason for failing to set exception: %s",
-                            self.function.__name__,
-                            e,
-                            e2,
-                        )
-                    else:
-                        # the task exception itself was already logged above (when current)
-                        logger.debug(
-                            "ignoring error setting exception for task %s, nobody can await the future anymore: %s",
-                            self.function.__name__,
-                            e2,
-                        )
+                # bind to a fresh name: `e` is unbound when the except block exits,
+                # but the delivery lambda runs later on the call loop
+                exception = e
+                self._finish_future_threadsafe(call_event_loop, future, lambda f: f.set_exception(exception), "exception")
             # Although this seems like an easy way to handle cancellation, an early cancelled task will never execute
             # so this code will never execute, so we need to handle this in the cancel function in __call__
             # except asyncio.CancelledError as e:
             #    if self.is_current():
             #        self._result.value = TaskResult[R](latest=self._last_value, _state=TaskState.CANCELLED)
-            #    call_event_loop.call_soon_threadsafe(future.set_exception, e)
             # But... if we call cancel in our own task, we still need to do it from this place
-            except _CancelledErrorInOurTask as e:
-                try:
-                    # maybe there is a different way to get a full stack trace?
-                    raise asyncio.CancelledError() from e
-                except asyncio.CancelledError as e:
-                    if self.is_current():
-                        self._result.value = TaskResult[R](latest=self._last_value, _state=TaskState.CANCELLED)
-                    try:
-                        call_event_loop.call_soon_threadsafe(future.set_exception, e)
-                    except Exception as e2:
-                        if not self._is_future_orphaned(call_event_loop):
-                            logger.exception(
-                                "error setting exception from for task %s. Original exception: %s\nReason for failing to set exception: %s",
-                                self.function.__name__,
-                                e,
-                                e2,
-                            )
-                        else:
-                            logger.debug(
-                                "ignoring error setting exception for task %s, nobody can await the future anymore: %s",
-                                self.function.__name__,
-                                e2,
-                            )
+            except _CancelledErrorInOurTask:
+                if self.is_current():
+                    self._result.value = TaskResult[R](latest=self._last_value, _state=TaskState.CANCELLED)
+                self._finish_future_threadsafe(call_event_loop, future, lambda f: f.cancel(), "cancellation")
 
         await runner()
 

--- a/tests/unit/task_test.py
+++ b/tests/unit/task_test.py
@@ -724,7 +724,7 @@ def test_task_finishing_after_call_event_loop_closed_is_not_an_error(fail, caplo
             proceed.set()
 
             def delivery_records():
-                return [record for record in caplog.records if record.getMessage().startswith("ignoring error setting")]
+                return [record for record in caplog.records if record.getMessage().startswith("ignoring failure to deliver")]
 
             deadline = time.time() + 10
             while time.time() < deadline and not delivery_records():
@@ -733,7 +733,100 @@ def test_task_finishing_after_call_event_loop_closed_is_not_an_error(fail, caplo
         records = delivery_records()
         assert len(records) == 1
         assert records[0].levelno == logging.DEBUG
-        delivery_errors = [record for record in caplog.records if record.levelno >= logging.ERROR and record.getMessage().startswith("error setting")]
+        delivery_errors = [record for record in caplog.records if record.levelno >= logging.ERROR and record.getMessage().startswith("error delivering")]
+        assert not delivery_errors
+        if fail:
+            # the exception raised by the task itself should still be logged
+            assert any(record.levelno == logging.ERROR and "task failed for a test" in record.getMessage() for record in caplog.records)
+    finally:
+        with context_holder["context"]:
+            context_holder["context"].close()
+
+
+def test_task_async_future_receives_exception(monkeypatch):
+    # awaiting the future of a failing task must raise the task's exception
+    # (guards the delivery closure: the `except ... as e` name is unbound by the
+    # time the closure runs on the call loop, so it must capture a fresh binding)
+    monkeypatch.setattr(solara.tasks, "_using_solara_server", lambda: True)
+    holder: dict = {}
+
+    @solara.tasks.task
+    async def fails():
+        raise RuntimeError("boom for a test")
+
+    def page_thread():
+        async def run():
+            context = kernel_context.VirtualKernelContext(id="task-exception", kernel=kernel.Kernel(), session_id="session-exception")
+            holder["context"] = context
+            with context:
+                fails()
+                assert fails.current_future is not None  # type: ignore
+                try:
+                    await asyncio.wait_for(fails.current_future, timeout=10)  # type: ignore
+                except BaseException as e:
+                    holder["exception"] = e
+
+        asyncio.run(run())
+
+    try:
+        thread = threading.Thread(target=page_thread)
+        thread.start()
+        thread.join()
+        exception = holder.get("exception")
+        assert isinstance(exception, RuntimeError)
+        assert "boom for a test" in str(exception)
+    finally:
+        with holder["context"]:
+            holder["context"].close()
+
+
+@pytest.mark.parametrize("fail", [False, True])
+def test_task_finishing_after_future_cancelled_is_not_an_error(fail, caplog, monkeypatch):
+    # A page close or shutdown can cancel the pending future while the task thread's
+    # completion is already in flight. Delivering to a done future raises
+    # InvalidStateError inside the loop callback, which asyncio logs as an ERROR with
+    # the exception traceback attached - and exception tracebacks pin the coroutine
+    # frames and through them the whole kernel context in a reference cycle that waits
+    # for a gen-2 gc. The delivery must be skipped silently instead.
+    monkeypatch.setattr(solara.tasks, "_using_solara_server", lambda: True)
+    proceed = threading.Event()
+    context_holder = {}
+
+    @solara.tasks.task
+    async def finishes():
+        while not proceed.is_set():
+            await asyncio.sleep(0.001)
+        if fail:
+            raise RuntimeError("task failed for a test")
+        return 42
+
+    def page_thread():
+        async def run():
+            context = kernel_context.VirtualKernelContext(id="task-future-cancelled", kernel=kernel.Kernel(), session_id="session-future-cancelled")
+            context_holder["context"] = context
+            with context:
+                finishes()
+                future = finishes.current_future  # type: ignore
+                assert future is not None
+                future.cancel()
+                proceed.set()
+                # keep the loop alive so the delivery callback gets a chance to run (and misbehave)
+                for _ in range(200):
+                    await asyncio.sleep(0.005)
+                    if finishes.finished or finishes.error:
+                        break
+
+        asyncio.run(run())
+
+    try:
+        with caplog.at_level(logging.DEBUG):
+            thread = threading.Thread(target=page_thread)
+            thread.start()
+            thread.join()
+
+        asyncio_errors = [record for record in caplog.records if record.name == "asyncio" and record.levelno >= logging.ERROR]
+        assert not asyncio_errors
+        delivery_errors = [record for record in caplog.records if record.levelno >= logging.ERROR and record.getMessage().startswith("error delivering")]
         assert not delivery_errors
         if fail:
             # the exception raised by the task itself should still be logged


### PR DESCRIPTION
## Summary

Closed virtual kernel contexts were unreachable but stuck in **reference cycles**, so refcounting could not free them — they waited for a generation-2 `gc`, which under load shows as a memory sawtooth whose peaks scale with per-kernel state. Measured with a small task-heavy test app (10 pages x 10 cycles, real Chromium sessions): idle footprint bounced up to **231 MB**; after this PR it converges to a smooth **~170 MB plateau, peak 174 MB**. A companion docs PR adds the measurement handbook + harness used to find all of this.

## The cycles (found with a gc-disabled weakref diagnostic) and their fixes

1. **Kernel-cull task** (affects every app): `close()` cancelled `_last_kernel_cull_task` but kept the reference. A cancelled asyncio task retains its `CancelledError`, whose traceback holds the `kernel_cull` frame, whose closure holds the context: `context → task → traceback → frame → context`. `close()` now drops the task/future references after cancelling.
2. **Task bookkeeping**: `TaskAsyncio.current_task` keeps the finished/cancelled `asyncio.Task`, which pins the kernel context via its contextvars copy and exception traceback. A `context.on_close` callback now clears the call state (`_drop_call_state`), and `is_current()` returns `False` for stale calls after close.
3. **`app_object`**: `close()` closed the render context but never dropped the reference.

## Related fixes the investigation surfaced

- **Future delivery race**: a task finishing while the page closes could call `future.set_exception()` on an already-done future → `InvalidStateError` raised inside the loop callback → asyncio logs it *with the exception traceback attached*, recreating the frame-pinning cycle above (and log noise). Deliveries now go through a guarded threadsafe helper that checks `future.done()` inside the loop callback. Cancellation is delivered as `future.cancel()` so no exception object crosses the thread boundary. Red→green unit test included (`test_task_finishing_after_future_cancelled_is_not_an_error`).
- **Delivery closure bug**: the new delivery lambdas must not capture the `except ... as e` name (unbound when the block exits, the lambda runs later on the loop) — covered by `test_task_async_future_receives_exception`.
- **fd leak**: the per-call thread event loop in `TaskAsyncio` was never closed, leaking its selector fd until collected.
- **`Thread.start()` hang**: a thread started while its inherited kernel context closes (`kernel` already `None`) crashed solara's patched bootstrap *before* `_started` was set, hanging the caller forever. The bootstrap now degrades to no-context.

## What remains (upstream)

One cycle lives in reacton: `make_setter.<locals>.set_` closures capture the render context strongly and are stored in hook state and widget callbacks, so the render tree (which owns `use_memo` payloads) stays cyclic after `rc.close()`. Until that is fixed upstream, the new `kernel.gc_after_close` setting (default on, `SOLARA_KERNEL_GC_AFTER_CLOSE=false` to disable) schedules a **deferred, coalesced** `gc.collect()` ~1s after a kernel closes — off the close path, one collect per burst of closes. Measured: disabling it brings the sawtooth back; with it the plateau holds. It also covers cycles in user code.

## Testing

- `tests/unit/task_test.py`: two new tests (one red on master by design), full unit suite green (410 passed).
- Object-level leak tests (weakref on context/kernel/shell after page close) pass repeatedly on flask + starlette, with `REACTON_FAST=1` too (test lands in the docs PR alongside its test app).
- Memory benchmarks before/after in the companion docs PR (`docs/memory-usage-inspection.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)