### PR TITLE
docs: memory measurement handbook with reproducible harness

### DIFF
--- a/docs/memory-measurement/check_assumptions.py
+++ b/docs/memory-measurement/check_assumptions.py
@@ -1,0 +1,135 @@
+"""Verify the claims made in docs/memory-usage-inspection.md by measuring.
+
+Each check prints PASS/FAIL/INFO with numbers.
+"""
+
+import gc
+import resource
+import sys
+
+import psutil
+
+MB = 1e6
+
+
+def rss():
+    return psutil.Process().memory_info().rss
+
+
+def check_maxrss_units():
+    """Claim: ru_maxrss is bytes on macOS, KiB on Linux."""
+    r = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    current = rss()
+    # if units were KiB on macOS, r*1024 would be ~1000x larger than RSS
+    ratio = r / current
+    print(f"[maxrss-units] ru_maxrss={r} rss={current} ratio={ratio:.2f}")
+    if sys.platform == "darwin":
+        ok = 0.5 < ratio < 20  # same order of magnitude => bytes
+        print(f"[maxrss-units] macOS ru_maxrss is in BYTES: {'PASS' if ok else 'FAIL'}")
+
+
+def check_pymalloc_retention():
+    """Claim: freeing millions of small objects does not fully return RSS to the OS,
+    and one surviving object per arena-region keeps memory pinned (fragmentation)."""
+    gc.collect()
+    before = rss()
+
+    # 4 million small tuples ~ hundreds of MB
+    data = [(i, i + 1) for i in range(4_000_000)]
+    peak = rss()
+
+    # free 100% of them
+    del data
+    gc.collect()
+    after_full_free = rss()
+
+    # now fragmentation: keep every 1000th object alive
+    data = [(i, i + 1) for i in range(4_000_000)]
+    survivors = data[::1000]
+    del data
+    gc.collect()
+    after_fragmented = rss()
+    del survivors
+    gc.collect()
+
+    grown = peak - before
+    retained_full = after_full_free - before
+    retained_frag = after_fragmented - before
+    print(f"[pymalloc] baseline={before / MB:.0f}MB peak={peak / MB:.0f}MB (+{grown / MB:.0f}MB)")
+    print(f"[pymalloc] after freeing ALL:        rss delta = {retained_full / MB:+.0f} MB")
+    print(f"[pymalloc] after freeing 99.9%:      rss delta = {retained_frag / MB:+.0f} MB (fragmentation)")
+    print(f"[pymalloc] fragmentation retains more than full free: {'PASS' if retained_frag > retained_full + grown * 0.2 else 'FAIL'}")
+
+
+def check_debugmallocstats():
+    """Claim: sys._debugmallocstats() shows arena usage."""
+    import io
+    import contextlib
+
+    f = io.StringIO()
+    try:
+        with contextlib.redirect_stderr(f):
+            sys._debugmallocstats()
+    except Exception as e:
+        print(f"[debugmallocstats] FAIL: {e}")
+        return
+    out = f.getvalue()
+    has_arenas = "arenas" in out
+    print(f"[debugmallocstats] output has arena stats: {'PASS' if has_arenas else 'FAIL'} ({len(out)} chars)")
+    for line in out.splitlines():
+        if "arenas allocated current" in line or "Total" in line and "arena" in line:
+            print(f"[debugmallocstats]   {line.strip()}")
+
+
+def check_tracemalloc_numpy():
+    """Claim in doc: tracemalloc does NOT see native buffers (e.g. numpy).
+    Modern numpy explicitly reports its buffers to tracemalloc, so this may be WRONG."""
+    import tracemalloc
+
+    try:
+        import numpy as np
+    except ImportError:
+        print("[tracemalloc-numpy] numpy not installed, skip")
+        return
+    tracemalloc.start()
+    snap1 = tracemalloc.take_snapshot()
+    arr = np.zeros(50 * 1024 * 1024, dtype=np.uint8)  # 50 MB native buffer
+    arr[:] = 1  # touch pages
+    snap2 = tracemalloc.take_snapshot()
+    tracemalloc.stop()
+    diff = snap2.compare_to(snap1, "lineno")
+    total = sum(s.size_diff for s in diff)
+    sees_it = total > 40 * MB
+    print(f"[tracemalloc-numpy] tracemalloc saw {total / MB:.0f} MB of the 50 MB numpy buffer")
+    print(f"[tracemalloc-numpy] numpy IS visible to tracemalloc: {'YES' if sees_it else 'NO'}")
+    del arr
+
+
+def check_raw_malloc_invisible():
+    """Claim: raw malloc via a C extension that does NOT integrate with tracemalloc is invisible.
+    Use ctypes to malloc directly."""
+    import ctypes
+    import ctypes.util
+    import tracemalloc
+
+    libc = ctypes.CDLL(ctypes.util.find_library("c"))
+    libc.malloc.restype = ctypes.c_void_p
+    libc.free.argtypes = [ctypes.c_void_p]
+    tracemalloc.start()
+    snap1 = tracemalloc.take_snapshot()
+    ptr = libc.malloc(50 * 1024 * 1024)
+    ctypes.memset(ptr, 1, 50 * 1024 * 1024)
+    snap2 = tracemalloc.take_snapshot()
+    tracemalloc.stop()
+    total = sum(s.size_diff for s in snap2.compare_to(snap1, "lineno"))
+    print(f"[raw-malloc] tracemalloc saw {total / MB:.1f} MB of a 50 MB raw malloc")
+    print(f"[raw-malloc] raw malloc invisible to tracemalloc: {'PASS' if total < 5 * MB else 'FAIL'}")
+    libc.free(ptr)
+
+
+if __name__ == "__main__":
+    check_maxrss_units()
+    check_debugmallocstats()
+    check_pymalloc_retention()
+    check_tracemalloc_numpy()
+    check_raw_malloc_invisible()

--- a/docs/memory-measurement/click_app.py
+++ b/docs/memory-measurement/click_app.py
@@ -1,0 +1,8 @@
+import solara
+
+clicks = solara.reactive(0)
+
+
+@solara.component
+def Page():
+    solara.Button(label=f"Clicked: {clicks.value}", on_click=lambda: clicks.set(clicks.value + 1))

--- a/docs/memory-measurement/kitchen_sink_app.py
+++ b/docs/memory-measurement/kitchen_sink_app.py
@@ -1,0 +1,68 @@
+"""Exercises the main solara state/async features in one small app, so the
+memory harness stresses more code paths than the plain click app:
+
+- a top-level ``solara.reactive`` (per-kernel copy via the context)
+- ``solara.lab.computed`` derived from it (auto-subscription machinery)
+- a top-level ``@solara.lab.task`` (asyncio task tied to the kernel context)
+- ``solara.lab.use_task`` inside the component (per-render task lifecycle)
+- ``solara.use_reactive`` (component-local reactive)
+- ~4.5 MB per-kernel payload (a list built in ``use_memo``) so each kernel owns
+  real data that must be freed on cull
+
+The harness clicks the button 3 times and then waits for the ``ALL-DONE``
+text, which only renders when every feature has produced its final value.
+"""
+
+import asyncio
+
+import solara
+import solara.lab
+
+counter = solara.reactive(0)
+
+
+@solara.lab.computed
+def counter_squared():
+    return counter.value**2
+
+
+@solara.lab.task
+async def background_work():
+    await asyncio.sleep(0.02)
+    return f"task done for {counter.value}"
+
+
+@solara.component
+def Page():
+    local = solara.use_reactive(0)
+    # ~4.5 MB of per-kernel payload (125k boxed ints + list) that must be freed on cull
+    payload = solara.use_memo(lambda: list(range(125_000)), dependencies=[])
+
+    async def compute_local():
+        await asyncio.sleep(0.02)
+        return local.value * 2
+
+    result = solara.lab.use_task(compute_local, dependencies=[local.value])
+
+    def on_click():
+        counter.value += 1
+        local.value += 1
+        background_work()
+
+    solara.Button(label=f"Clicked: {counter.value}", on_click=on_click)
+    solara.Text(f"squared: {counter_squared.value}")
+    solara.Text(f"payload: {len(payload)}")
+    if result.finished:
+        solara.Text(f"use_task: {result.value}")
+    if background_work.finished:
+        solara.Text(f"task: {background_work.value}")
+    if (
+        counter.value == 3
+        and counter_squared.value == 9
+        and local.value == 3
+        and result.finished
+        and result.value == 6
+        and background_work.finished
+        and background_work.value == "task done for 3"
+    ):
+        solara.Text("ALL-DONE")

--- a/docs/memory-measurement/measure.py
+++ b/docs/memory-measurement/measure.py
@@ -1,0 +1,215 @@
+"""Measure memory of a solara server serving a small test app.
+
+Usage: python measure.py [app.py] [marker-text]
+
+  app.py       app file in this directory (default: click_app.py)
+  marker-text  optional text to wait for after the clicks, so apps can signal
+               "every feature finished" (kitchen_sink_app.py renders ALL-DONE)
+
+Starts `solara run <app> --production` as a subprocess, drives it with
+real Chromium pages (playwright), and measures the server process RSS from the
+outside with psutil. Per cycle:
+
+  idle -> open N pages (each clicks the button 3x and verifies the render) ->
+  measure loaded RSS -> close pages -> wait until /resourcez reports 0 kernels ->
+  settle -> measure idle RSS again.
+
+Repeats CYCLES times so we can tell allocator retention (plateau) from a leak
+(linear growth). Prints a per-cycle table and a JSON blob at the end.
+"""
+
+import asyncio
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+import urllib.request
+
+import psutil
+from playwright.async_api import async_playwright
+
+PORT = 18765
+BASE = f"http://localhost:{PORT}"
+N_PAGES = 10
+CYCLES = 10
+CLICKS_PER_PAGE = 3
+HERE = os.path.dirname(os.path.abspath(__file__))
+APP = sys.argv[1] if len(sys.argv) > 1 else "click_app.py"
+MARKER = sys.argv[2] if len(sys.argv) > 2 else None
+
+
+def phys_footprint(pid: int):
+    """macOS: physical footprint via vmmap (what Activity Monitor shows).
+
+    Includes compressed and swapped dirty pages, unlike RSS. Returns (current, peak)
+    in bytes, or (None, None) off-macOS / on failure.
+    """
+    if sys.platform != "darwin":
+        return None, None
+    try:
+        out = subprocess.run(["vmmap", "-summary", str(pid)], capture_output=True, text=True, timeout=30).stdout
+    except Exception:
+        return None, None
+    cur = peak = None
+    units = {"K": 1024, "M": 1024**2, "G": 1024**3}
+    for line in out.splitlines():
+        if line.startswith("Physical footprint:"):
+            val = line.split(":")[1].strip()
+            cur = float(val[:-1]) * units[val[-1]]
+        elif line.startswith("Physical footprint (peak):"):
+            val = line.split(":")[1].strip()
+            peak = float(val[:-1]) * units[val[-1]]
+    return cur, peak
+
+
+def rss_of(proc: psutil.Process) -> int:
+    total = proc.memory_info().rss
+    for child in proc.children(recursive=True):
+        try:
+            total += child.memory_info().rss
+        except psutil.Error:
+            pass
+    return total
+
+
+def uss_of(proc: psutil.Process):
+    try:
+        return proc.memory_full_info().uss
+    except psutil.Error:
+        return None
+
+
+def resourcez(verbose=False):
+    url = f"{BASE}/resourcez" + ("?verbose=1" if verbose else "")
+    with urllib.request.urlopen(url, timeout=10) as f:
+        return json.loads(f.read())
+
+
+def wait_for_kernels(n: int, timeout: float = 30.0) -> float:
+    """Poll /resourcez until kernel count == n. Returns seconds waited."""
+    start = time.monotonic()
+    while True:
+        data = resourcez()
+        if data["kernels"]["total"] == n:
+            return time.monotonic() - start
+        if time.monotonic() - start > timeout:
+            raise TimeoutError(f"kernels stuck at {data['kernels']['total']}, wanted {n}")
+        time.sleep(0.25)
+
+
+async def open_and_click(browser, results):
+    context = await browser.new_context()
+    page = await context.new_page()
+    await page.goto(BASE, wait_until="networkidle")
+    button = page.locator("button:has-text('Clicked')")
+    await button.wait_for(timeout=30000)
+    for i in range(CLICKS_PER_PAGE):
+        await button.click()
+        await page.locator(f"button:has-text('Clicked: {i + 1}')").wait_for(timeout=10000)
+    if MARKER:
+        await page.locator(f"text={MARKER}").wait_for(timeout=10000)
+    results.append(context)
+
+
+async def main():
+    env = os.environ.copy()
+    env["SOLARA_KERNEL_CULL_TIMEOUT"] = "0.5s"
+    solara_bin = os.path.join(os.path.dirname(sys.executable), "solara")
+    server = subprocess.Popen(
+        [solara_bin, "run", os.path.join(HERE, APP), "--port", str(PORT), "--no-open", "--production"],
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.STDOUT,
+    )
+    proc = psutil.Process(server.pid)
+    report: dict = {"cycles": [], "platform": sys.platform}
+    try:
+        # wait for server up
+        for _ in range(120):
+            try:
+                resourcez()
+                break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            raise RuntimeError("server did not start")
+
+        report["rss_startup"] = rss_of(proc)
+
+        async with async_playwright() as p:
+            browser = await p.chromium.launch()
+
+            # warmup: one full cycle so imports/JIT/caches are paid for
+            contexts: list = []
+            await open_and_click(browser, contexts)
+            for c in contexts:
+                await c.close()
+            wait_for_kernels(0)
+            time.sleep(2.0)
+            report["rss_warm_baseline"] = rss_of(proc)
+            report["uss_warm_baseline"] = uss_of(proc)
+
+            for cycle in range(CYCLES):
+                fp_idle_before, _ = phys_footprint(server.pid)
+                rss_idle_before = rss_of(proc)
+                contexts = []
+                # sequential open: cleaner attribution, avoids load spikes
+                for _ in range(N_PAGES):
+                    await open_and_click(browser, contexts)
+                r = resourcez()
+                assert r["kernels"]["total"] == N_PAGES, r["kernels"]
+                time.sleep(1.0)
+                rss_loaded = rss_of(proc)
+                fp_loaded, _ = phys_footprint(server.pid)
+                ws_open = r["websockets"]["open"]
+                threads_active = r["threads"]["active"]
+                for c in contexts:
+                    await c.close()
+                cull_wait = wait_for_kernels(0)
+                time.sleep(2.0)
+                rss_idle_after = rss_of(proc)
+                fp_idle_after, fp_peak = phys_footprint(server.pid)
+                row = {
+                    "cycle": cycle,
+                    "rss_idle_before": rss_idle_before,
+                    "rss_loaded": rss_loaded,
+                    "rss_idle_after": rss_idle_after,
+                    "fp_idle_before": fp_idle_before,
+                    "fp_loaded": fp_loaded,
+                    "fp_idle_after": fp_idle_after,
+                    "fp_peak": fp_peak,
+                    "per_kernel": (fp_loaded - fp_idle_before) / N_PAGES if fp_loaded else (rss_loaded - rss_idle_before) / N_PAGES,
+                    "cull_wait_s": round(cull_wait, 2),
+                    "ws_open": ws_open,
+                    "threads_active": threads_active,
+                    "kernels_after": resourcez()["kernels"]["total"],
+                }
+                report["cycles"].append(row)
+                print(
+                    f"cycle {cycle}: fp idle {fp_idle_before / 1e6:7.1f} MB -> loaded {fp_loaded / 1e6:7.1f} MB "
+                    f"-> idle {fp_idle_after / 1e6:7.1f} MB (peak {fp_peak / 1e6:.1f}) | per-kernel {row['per_kernel'] / 1e6:5.2f} MB | "
+                    f"rss {rss_idle_before / 1e6:.0f}/{rss_loaded / 1e6:.0f}/{rss_idle_after / 1e6:.0f} | "
+                    f"threads {threads_active} | kernels after close: {row['kernels_after']}",
+                    flush=True,
+                )
+            await browser.close()
+
+        report["uss_final"] = uss_of(proc)
+        report["resourcez_verbose"] = resourcez(verbose=True)
+    finally:
+        server.send_signal(signal.SIGINT)
+        try:
+            server.wait(10)
+        except subprocess.TimeoutExpired:
+            server.kill()
+
+    report_name = f"report-{os.path.splitext(APP)[0]}.json"
+    with open(os.path.join(HERE, report_name), "w") as f:
+        json.dump(report, f, indent=2)
+    print(f"wrote {report_name}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/memory-measurement/measure_docker.py
+++ b/docs/memory-measurement/measure_docker.py
@@ -1,0 +1,179 @@
+"""Ground-truth memory measurement: solara server in a memory-limited docker container.
+
+The server (this worktree's code) runs in python:3.11-slim with --memory 512m
+--memory-swap 512m. The browser (playwright chromium) runs on the host, so the
+cgroup numbers are the server and nothing else. Per cycle we read:
+
+  /sys/fs/cgroup/memory.current  - bytes charged right now (incl. page cache)
+  /sys/fs/cgroup/memory.peak     - high-water mark
+  memory.stat: anon              - anonymous (heap) pages: closest to "what the app needs"
+
+Same cycle protocol as measure.py: open N pages, click, close, wait for kernel
+cull via /resourcez, settle, measure.
+"""
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.request
+
+from playwright.async_api import async_playwright
+
+PORT = 18766
+BASE = f"http://localhost:{PORT}"
+N_PAGES = 10
+CYCLES = 10
+CLICKS_PER_PAGE = 3
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.abspath(os.path.join(HERE, "..", ".."))  # the solara repo root
+NAME = "solara-mem"
+APP = sys.argv[1] if len(sys.argv) > 1 else "click_app.py"
+MARKER = sys.argv[2] if len(sys.argv) > 2 else None
+
+
+def sh(cmd, **kw):
+    return subprocess.run(cmd, capture_output=True, text=True, **kw)
+
+
+def cgroup_mem():
+    out = sh(
+        ["docker", "exec", NAME, "sh", "-c", "cat /sys/fs/cgroup/memory.current /sys/fs/cgroup/memory.peak; grep '^anon ' /sys/fs/cgroup/memory.stat"]
+    ).stdout.split()
+    return {"current": int(out[0]), "peak": int(out[1]), "anon": int(out[3])}
+
+
+def resourcez(verbose=False):
+    url = f"{BASE}/resourcez" + ("?verbose=1" if verbose else "")
+    with urllib.request.urlopen(url, timeout=10) as f:
+        return json.loads(f.read())
+
+
+def wait_for_kernels(n: int, timeout: float = 30.0) -> float:
+    start = time.monotonic()
+    while True:
+        if resourcez()["kernels"]["total"] == n:
+            return time.monotonic() - start
+        if time.monotonic() - start > timeout:
+            raise TimeoutError(f"kernels != {n}")
+        time.sleep(0.25)
+
+
+async def open_and_click(browser, contexts):
+    context = await browser.new_context()
+    page = await context.new_page()
+    await page.goto(BASE, wait_until="networkidle")
+    button = page.locator("button:has-text('Clicked')")
+    await button.wait_for(timeout=30000)
+    for i in range(CLICKS_PER_PAGE):
+        await button.click()
+        await page.locator(f"button:has-text('Clicked: {i + 1}')").wait_for(timeout=10000)
+    if MARKER:
+        await page.locator(f"text={MARKER}").wait_for(timeout=10000)
+    contexts.append(context)
+
+
+async def main():
+    sh(["docker", "rm", "-f", NAME])
+    run = sh(
+        [
+            "docker",
+            "run",
+            "-d",
+            "--name",
+            NAME,
+            "--memory",
+            "512m",
+            "--memory-swap",
+            "512m",
+            "-p",
+            f"{PORT}:{PORT}",
+            "-v",
+            f"{REPO}:/repo:ro",
+            "-v",
+            f"{HERE}:/scratch:ro",
+            "-e",
+            "SOLARA_KERNEL_CULL_TIMEOUT=0.5s",
+            "-e",
+            f"SOLARA_KERNEL_GC_AFTER_CLOSE={os.environ.get('SOLARA_KERNEL_GC_AFTER_CLOSE', 'true')}",
+            "python:3.11-slim",
+            "bash",
+            "-c",
+            f"pip install -q /repo '/repo/packages/solara-server[starlette]' && solara run /scratch/{APP} --host 0.0.0.0 --port {PORT} --no-open --production",
+        ]
+    )
+    if run.returncode != 0:
+        raise RuntimeError(run.stderr)
+    print("container starting, installing solara...", flush=True)
+    report: dict = {"cycles": []}
+    try:
+        for _ in range(360):  # pip install takes a while
+            try:
+                resourcez()
+                break
+            except Exception:
+                time.sleep(1)
+        else:
+            print(sh(["docker", "logs", NAME]).stdout[-3000:])
+            raise RuntimeError("server did not start")
+        print("server up", flush=True)
+        report["mem_startup"] = cgroup_mem()
+
+        async with async_playwright() as p:
+            browser = await p.chromium.launch()
+            # warmup cycle
+            contexts: list = []
+            await open_and_click(browser, contexts)
+            for c in contexts:
+                await c.close()
+            wait_for_kernels(0)
+            time.sleep(2)
+            report["mem_warm_baseline"] = cgroup_mem()
+
+            for cycle in range(CYCLES):
+                m_before = cgroup_mem()
+                contexts = []
+                for _ in range(N_PAGES):
+                    await open_and_click(browser, contexts)
+                r = resourcez()
+                assert r["kernels"]["total"] == N_PAGES, r["kernels"]
+                time.sleep(1)
+                m_loaded = cgroup_mem()
+                for c in contexts:
+                    await c.close()
+                cull_wait = wait_for_kernels(0)
+                time.sleep(2)
+                m_after = cgroup_mem()
+                row = {
+                    "cycle": cycle,
+                    "before": m_before,
+                    "loaded": m_loaded,
+                    "after": m_after,
+                    "per_kernel_anon": (m_loaded["anon"] - m_before["anon"]) / N_PAGES,
+                    "cull_wait_s": round(cull_wait, 2),
+                    "threads": r["threads"]["active"],
+                    "kernels_after": resourcez()["kernels"]["total"],
+                }
+                report["cycles"].append(row)
+                print(
+                    f"cycle {cycle}: anon {m_before['anon'] / 1e6:6.1f} -> {m_loaded['anon'] / 1e6:6.1f} -> {m_after['anon'] / 1e6:6.1f} MB "
+                    f"| current {m_after['current'] / 1e6:6.1f} MB | peak {m_after['peak'] / 1e6:6.1f} MB "
+                    f"| per-kernel {row['per_kernel_anon'] / 1e6:5.2f} MB | threads {row['threads']} | kernels after: {row['kernels_after']}",
+                    flush=True,
+                )
+            await browser.close()
+        report["resourcez_final"] = resourcez(verbose=True)
+        report["mem_final"] = cgroup_mem()
+    finally:
+        sh(["docker", "rm", "-f", NAME])
+
+    report_name = f"report_docker-{os.path.splitext(APP)[0]}.json"
+    with open(os.path.join(HERE, report_name), "w") as f:
+        json.dump(report, f, indent=2)
+    print(f"wrote {report_name}", flush=True)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/memory-usage-inspection.md
+++ b/docs/memory-usage-inspection.md
@@ -1,0 +1,480 @@
+# Memory Measurement Handbook
+
+A handoff document for measuring memory use of a long-running Python server
+(any project — the worked examples are Solara apps). It tells you **how to
+measure**, **which numbers to trust on which platform**, **what healthy looks
+like**, and **how to decide "leak or not"**. It is written to be executable by
+an LLM agent or a human without extra context.
+
+Every claim marked **Measured**/**Verified** was confirmed by experiment
+(July 2026, macOS/arm64 + docker Linux, Python 3.11, solara 1.59.0). The
+reference harness lives in [memory-measurement/](memory-measurement/) and
+`check_assumptions.py` there re-verifies the micro-claims.
+
+Companion: [memory-leak-detection.md](memory-leak-detection.md) — object-level
+leak hunting (weakrefs, objgraph, retention chains). This document tells you
+*whether and where* memory grows; that one tells you *why an object is still
+alive* once you know something leaks.
+
+## TL;DR protocol (start here)
+
+1. Run the server under a **cycle workload**: open N realistic sessions, use
+   them, close them, wait until the app confirms cleanup, let it settle,
+   measure. Repeat ≥ 10 cycles. (Reference implementation: `measure.py` /
+   `measure_docker.py`.)
+2. Measure **from outside the process**, using the right metric:
+   - Linux: `anon` from cgroup `memory.stat` (best) or `psutil` RSS/USS
+   - macOS: `vmmap -summary <pid>` "Physical footprint" — **never RSS**
+3. Plot the idle-point number per cycle and read the shape:
+   - **Decaying increments → plateau**: healthy. That is allocator retention.
+   - **Constant increment per cycle**: leak. The increment is your leak rate.
+4. Per-session cost = (loaded − idle) / N, after at least one warmup cycle.
+5. Verify cleanup independently of memory: an app-level counter endpoint
+   (Solara: `/resourcez`) must return to baseline every cycle. "Memory not
+   freed" is often just "cleanup didn't run".
+
+## Why the OS number does not tell the full story
+
+There are three layers of memory management stacked on top of each other.
+Memory freed at one layer is often *not* returned to the layer below:
+
+```
+Python objects        (gc, refcounting)
+      ↓ freed objects go back to...
+pymalloc arenas       (CPython's small-object allocator, obmalloc)
+      ↓ empty arenas go back to...
+libc malloc / mmap    (glibc holds freed memory in arenas too)
+      ↓ trimmed pages go back to...
+OS                    (this is what RSS measures)
+```
+
+Consequences:
+
+- **pymalloc only returns an arena to the OS when it is completely empty.**
+  One surviving small object (a few hundred bytes) can pin an entire arena
+  (1 MiB on Python 3.10+, 256 KiB before). **Measured** (macOS, Python 3.11):
+  allocating 4 million small tuples grows RSS by ~548 MB; freeing *all* of
+  them returns almost everything (+36 MB left); but freeing 99.9% and keeping
+  every 1000th tuple returns *nothing* (+582 MB still resident).
+  Fragmentation, not volume, is what pins memory.
+- **glibc malloc keeps freed memory too** (per-thread arenas, trim
+  thresholds). Threads make this worse: `MALLOC_ARENA_MAX=2` is a common
+  mitigation on thread-heavy Linux servers.
+- **RSS counts shared pages** (loaded `.so` files, forked copy-on-write
+  pages). For per-process cost, USS (unique set size) is more honest.
+
+**The one rule this implies:** never judge a single absolute number. A
+high-but-stable value after load is allocator retention; a value that keeps
+*growing* under a repeated identical workload is a leak. Measure the trend
+over cycles.
+
+## Which metric to trust, per platform
+
+Ranked by trustworthiness. All of this is **measured**, see the worked
+example below.
+
+1. **Linux cgroup `anon`** (`grep '^anon ' /sys/fs/cgroup/memory.stat`) —
+   anonymous (heap) pages, no page-cache pollution, no compressor games. The
+   production metric. Trap: `memory.current` includes page cache — measured
+   405 MB `current` when `anon` was 109 MB (the difference was pip's page
+   cache). Never size pods on `memory.current` without checking `memory.stat`.
+   `memory.peak` is the high-water mark you size pods with (same caveat).
+2. **macOS physical footprint** (`vmmap -summary <pid> | grep "Physical
+   footprint"`) — what Activity Monitor shows; includes compressed pages.
+   Stable and load-correlated. Fine for local development.
+3. **Process RSS via psutil** — fine on Linux; on macOS **do not use for
+   trends**: the memory compressor takes idle dirty pages out of RSS, so it
+   *drops* while the app is idle and bounces unpredictably. Measured on a
+   solara server: RSS swung 70–142 MB across identical load cycles; per-user
+   deltas computed from it were pure noise (−5 to +5 MB for the same
+   workload).
+
+More macOS traps (measured):
+
+- `psutil.Process().memory_full_info()` (USS) raises `AccessDenied` unless
+  root. USS is effectively a Linux metric.
+- `resource.getrusage(...).ru_maxrss` (peak, useful in tests) is **bytes** on
+  macOS but **kilobytes** on Linux.
+
+```python
+import psutil
+p = psutil.Process()
+p.memory_info().rss          # OK on Linux; macOS: trends unreliable
+p.memory_full_info().uss     # Linux only in practice
+```
+
+```bash
+vmmap -summary <pid> | grep "Physical footprint"
+# Physical footprint:         119.3M
+# Physical footprint (peak):  145.6M
+```
+
+## The cycle protocol, in detail
+
+The transferable core. Adapt the constants, keep the structure:
+
+1. **Start the server** as a subprocess (measure from outside — in-process
+   measurement changes what you measure). Set cleanup timeouts low so the
+   test does not wait hours (Solara: `SOLARA_KERNEL_CULL_TIMEOUT=0.5s`).
+2. **Warm up**: one full session open/use/close, wait for cleanup. The first
+   session pays one-time import and cache costs; never include it in
+   per-session math.
+3. **Per cycle** (≥ 10 cycles):
+   a. record idle memory,
+   b. open N real sessions (real browser pages, not bare HTTP — a session
+      must exercise the websocket/kernel/render path), N ≥ 10 so per-session
+      cost dominates noise,
+   c. *use* each session (click, wait for the rendered result — otherwise you
+      measure connection setup, not the app), and if the app has async work,
+      wait for a completion marker,
+   d. record loaded memory,
+   e. close all sessions,
+   f. **wait for the app to confirm cleanup** (poll the counter endpoint
+      until sessions == 0) — never use a fixed sleep,
+   g. settle ~2 s, record idle memory again.
+4. **Read the results**:
+   - per-session cost = (loaded − idle-before) / N,
+   - idle-point series over cycles → plateau (healthy) or line (leak),
+   - counters (sessions/threads/websockets) must return to baseline every
+     cycle — if they don't, fix that first; the memory question is moot.
+
+Reference implementation in [memory-measurement/](memory-measurement/):
+
+- `click_app.py` — minimal one-button app (framework floor)
+- `kitchen_sink_app.py` — exercises reactive/computed/task/use_task/
+  use_reactive plus ~1 MB per-session payload; renders `ALL-DONE` when every
+  feature finished (the harness waits for it)
+- `measure.py [app.py] [marker]` — host run (psutil + vmmap), prints per-cycle
+  table, writes `report-<app>.json`
+- `measure_docker.py [app.py] [marker]` — same protocol against a 512 MB
+  `python:3.11-slim` container, reading cgroup v2 numbers (the browser stays
+  on the host so the cgroup contains only the server)
+- `check_assumptions.py` — re-verifies the measured micro-claims in this doc
+
+## Ground truth: run under a hard memory limit
+
+When the question is operational — "how many users fit in a 512 MB pod?" —
+let the kernel be the judge. A cgroup limit counts *real* pages, including
+allocator retention and native buffers, exactly like production:
+
+```bash
+# Disable swap headroom (--memory-swap == --memory) so the container OOMs
+# instead of silently thrashing.
+docker run --rm -it --memory 512m --memory-swap 512m \
+    -p 8765:8765 -v $PWD:/app -w /app python:3.11-slim \
+    sh -c "pip install solara && solara run app.py --host 0.0.0.0"
+
+docker stats                        # live per-container usage
+# inside the container (cgroup v2):
+cat /sys/fs/cgroup/memory.current   # in use now (incl. page cache!)
+cat /sys/fs/cgroup/memory.peak      # high-water mark
+grep '^anon ' /sys/fs/cgroup/memory.stat   # the honest heap number
+```
+
+- On macOS, docker runs a Linux VM, so this also gives you production glibc
+  behavior — more representative than profiling the Mac host.
+- `resource.setrlimit(RLIMIT_AS)` / `ulimit -v` is a docker-free variant on
+  Linux, but it limits *virtual* address space and trips over harmless big
+  `mmap` reservations; not enforced on macOS. Prefer the cgroup.
+
+## Tool layers for diagnosis
+
+Once the protocol says "memory grows", use these to find where.
+
+### Python-level: tracemalloc, gc, _debugmallocstats
+
+```python
+import tracemalloc
+tracemalloc.start(10)                      # keep 10 stack frames per allocation
+snap1 = tracemalloc.take_snapshot()
+# ... one or more workload cycles ...
+snap2 = tracemalloc.take_snapshot()
+for stat in snap2.compare_to(snap1, "lineno")[:15]:
+    print(stat)
+```
+
+Enable without code changes: `PYTHONTRACEMALLOC=10 solara run app.py`.
+
+Coverage — **measured**: a 50 MB numpy array *is* visible to tracemalloc
+(modern numpy registers its buffers), but 50 MB of raw `malloc` via ctypes
+shows up as 0 bytes. C extensions that allocate outside the Python allocator
+(zmq buffers, arrow pools, GUI toolkits) are invisible — that's memray's job.
+
+```python
+import sys, gc
+from collections import Counter
+
+sys.getallocatedblocks()   # live allocations Python knows about
+sys._debugmallocstats()    # pymalloc arena/pool stats: how full are the arenas?
+# writes to C-level stderr: contextlib.redirect_stderr CANNOT capture it,
+# redirect fd 2 instead (python app.py 2>stats.txt)
+
+Counter(type(o).__name__ for o in gc.get_objects()).most_common(20)
+```
+
+`_debugmallocstats` answers "Python does its own memory management — what is
+it holding?": many arenas at low utilization = fragmentation; the space will
+be reused before the OS is asked for more.
+
+### Whole-process: memray
+
+[memray](https://bloomberg.github.io/memray/) (Linux + macOS) intercepts the
+allocator functions themselves (`malloc`, `free`, `mmap`, plus Python
+allocator hooks), so it sees native C-extension memory too. Know your mode:
+
+- **Default:** pymalloc stays on — small Python objects appear as big arena
+  `mmap`s attributed to whatever triggered arena creation. Good for native
+  memory, misleading for fine-grained Python attribution.
+- **`--trace-python-allocators`:** records individual Python allocations.
+  Slower, bigger files, per-object attribution.
+- **`PYTHONMALLOC=malloc` + `memray flamegraph --leaks`:** for leak analysis
+  disable pymalloc so every Python object is a real `malloc`; otherwise block
+  reuse makes freed memory look leaked and vice versa.
+- **`--native`:** adds C/C++ frames — finds *which extension* owns the memory.
+
+```bash
+memray run -o out.bin -m solara run app.py --production
+# exercise, Ctrl-C, then:
+memray flamegraph out.bin           # who holds memory at the peak
+memray flamegraph --leaks out.bin   # what was never freed (PYTHONMALLOC=malloc!)
+memray stats out.bin
+memray run --live -m solara run app.py    # live TUI
+memray attach <pid>                       # running process (needs lldb/gdb)
+```
+
+**Verified** on a real solara server: `memray run -m solara run app.py` works
+as-is; its reported peak (118.4 MB) matched the vmmap physical footprint of an
+unprofiled server (~119 MB) within 1 MB; the flamegraph attributed ~37 MB
+(~30% of peak) to module imports at startup. Verified in a synthetic test:
+a never-freed ctypes `malloc` and kept-alive Python objects both appear in
+`--leaks` output under the correct function names. Traps: `memray tree` opens
+an interactive TUI (use `flamegraph`/`stats`/`summary` in scripts); the
+temporal view is `memray flamegraph --temporal`.
+
+What memray does *not* answer: **why** an object is still alive. For
+retention chains use `objgraph` per
+[memory-leak-detection.md](memory-leak-detection.md).
+
+## What to expect: measured baselines (Solara, calibration numbers)
+
+Protocol: 10 pages/cycle × 10 cycles = 100 kernel lifecycles per run, 3 clicks
+per page, `solara run --production`, real Chromium sessions.
+
+### Minimal click app (framework floor)
+
+| Metric | Value |
+|--------|-------|
+| Startup heap (Linux cgroup `anon`) | ~96 MB |
+| Steady-state plateau | ~109 MB |
+| macOS physical footprint idle / startup-peak | ~119–125 MB / 146 MB |
+| Per-kernel, first cycle (cold pools) | ~0.6 MB |
+| Per-kernel, steady state | ~0.02–0.1 MB (reuses warm pools) |
+| Threads | stable ~19–23 over 100 kernels |
+| Module imports share of baseline | ~37 MB (memray) |
+
+### Kitchen-sink app (reactive + computed + task + use_task + use_reactive + ~4.5 MB payload/kernel)
+
+`kitchen_sink_app.py` exercises the async/state machinery and gives every
+kernel a ~4.5 MB payload. Same protocol, and a very different — and
+instructive — result:
+
+| Metric | Value |
+|--------|-------|
+| Per-kernel, first cycle | ~4.5–5 MB (the payload, as expected) |
+| Idle heap over cycles (Linux `anon`) | **sawtooth**: 100 → 213 → drop to 181 → 221 → drop to 209 MB |
+| macOS physical footprint | same sawtooth: 174 → 231 → drop to 175 → ~195 MB |
+| `/resourcez` after every cycle | kernels 0, websockets closed == attempts, threads bounded (~28 active after 1540 created) |
+| Weakref leak test, naive harness | **flaky**: leaked in 4/7 runs |
+| Weakref leak test, log-records cleared | 8/8 pass in ~3.5 s → **no production leak** |
+
+**Interpretation (this is the case study to learn from):**
+
+1. The sawtooth (rise, periodic sharp drop) means the memory *is* reclaimable
+   but only when a generation-2 GC runs: the closed kernels became **cyclic
+   garbage**, not leaked objects. Solara deliberately avoids `gc.collect()` on
+   kernel close (latency), so big per-kernel payloads wait for the collector's
+   own schedule. A plain "it keeps growing" reading over too few cycles would
+   have called this a leak; the drops disprove that. When in doubt, run more
+   cycles or force `gc.collect()` inside the server and see if the level
+   resets.
+2. Root cause of the cycles: a task-cancel race. Re-clicking / disconnecting
+   cancels a running `@solara.lab.task`; the task thread schedules
+   `future.set_exception(CancelledError)` onto the kernel loop, the future is
+   sometimes already done, and the resulting `InvalidStateError` is logged by
+   asyncio **with the exception traceback attached**. Exception tracebacks are
+   reference bombs: the `CancelledError.__traceback__` held 5 coroutine frames
+   whose locals referenced the whole `VirtualKernelContext` (and its 4.5 MB
+   payload). Those exception→frames→context chains sit in reference cycles
+   (partly on the closed kernel event loop's pending-callback list) until
+   gen-2 GC.
+3. **In tests this becomes a hard, flaky leak**: pytest's `LogCaptureHandler`
+   retains every `LogRecord`, including the traceback, so whether the weakref
+   test failed depended on whether the race fired (it did in roughly half the
+   runs). The fix in the leak test (`tests/integration/kitchen_sink_leak_test.py`)
+   is to clear captured log records *continuously* in the GC loop — records
+   can be emitted seconds later while task threads wind down (a one-time clear
+   still failed; continuous clearing passed 8/8 in ~3.5 s). Any leak-test
+   harness that captures logs needs this, or it will report phantom leaks.
+4. Bounded, expected retention that is *not* a leak: task threads hold frames
+   (and thus the context) for a few seconds after close; log records hold
+   tracebacks until dropped. Distinguish "held for seconds" from "held
+   forever" by letting the GC loop run tens of seconds before concluding.
+
+Practical consequences: apps that trigger task cancellations (fast re-clicks,
+disconnects mid-task) will idle at a higher, spikier memory level than
+plateau apps — size capacity on the sawtooth peaks, not the plateau. And any
+`Exception` object stored in a long-lived structure should be stripped
+(`exc.__traceback__ = None`) or it pins every frame it passed through.
+
+### The follow-up: hunting and breaking the cycles at the source
+
+The sawtooth was fixed by making closed kernel contexts collectable by plain
+refcounting. The hunting technique is general and worth stealing:
+
+1. **Disable gc and watch a weakref.** `gc.disable()` stops *automatic*
+   collection but leaves refcounting intact (and explicit `gc.collect()` still
+   works). Run one session, close it, wait a few seconds, and check a weakref
+   to the session object. If it resolves, whatever holds it is a reference
+   cycle (or a genuine external root) you can now inspect *intact* — forced
+   collection would have destroyed the evidence.
+2. **Walk `gc.get_referrers()` upward, printing edges** as
+   `OwnerType.attribute` (find a dict's owner by checking which object has it
+   as `__dict__`). Two traps: your analyzer's own result lists show up as
+   referrers (track and filter their `id()`s), and your own stack frames do
+   too (filter by `f_code.co_name`).
+3. **Break the edge in the close/cleanup path**, rerun, repeat until the
+   weakref dies by refcount alone.
+
+What this found in solara (all fixed by breaking the edge in the close path):
+
+- `context._last_kernel_cull_task` → cancelled asyncio task →
+  `CancelledError.__traceback__` → `kernel_cull` frame → closure cell `self`
+  → context. Fix: drop the task/future references in `close()` right after
+  cancelling them. This one affected *every* app, even the minimal one.
+- `TaskAsyncio.current_task` → finished/cancelled asyncio task → its
+  contextvars copy and exception traceback → kernel context. Fix: a
+  `context.on_close` callback clears the task bookkeeping
+  (`_drop_call_state`).
+- `context.app_object` kept referencing the closed render context. Fix:
+  `close()` drops it after closing.
+
+What it found one layer down (**not yet fixed, lives in reacton**): the hook
+state tree stores `use_state` setter closures
+(`reacton.core._RenderContext.make_setter.<locals>.set_`) whose cells point
+back at the render context, and the setters are also captured by
+solara/ipywidgets callback closures. So the render tree — which owns
+`use_memo` payloads — stays one big cycle even after `rc.close()`. The clean
+upstream fix is for `make_setter` to capture the render context weakly (or
+for `close()` to tear down hook state). Until then the gc backstop below
+covers it.
+
+And one non-solara ghost to know about: **playwright's sync API captures
+`inspect.stack()`** (`__pw_stack__`) on every `goto`/`click`/`wait_for`, so in
+a playwright-driven test the test function's own frame (and every local in
+it) is retained by playwright, not by your server. A gc-disabled leak check
+cannot pass under playwright for this reason — do refcount-hygiene checks
+with the diagnostic above, and keep CI leak tests on the forced-gc pattern.
+
+The backstop: `settings.kernel.gc_after_close` (default on) schedules one
+deferred, coalesced `gc.collect()` on a background thread ~1 s after a kernel
+closes. **Measured** (kitchen-sink app, macOS physical footprint): with the
+fixes + backstop the idle level converges to a smooth ~170 MB plateau with
+peak 174 MB — versus a sawtooth peaking at 231 MB before. With the backstop
+disabled (`SOLARA_KERNEL_GC_AFTER_CLOSE=false`) the sawtooth returns
+(Linux `anon` 100→221 MB with drops), which is exactly the remaining reacton
+cycle at work. Two traps from implementing it: a thread started while a
+context closes must not inherit that context (solara patches `Thread` to
+propagate contexts, and a context whose `kernel` is already `None` hung
+`Thread.start()` forever), and the collect thread must not itself keep the
+closing context alive.
+
+### Leak or retention? The shape answers it
+
+Linux `anon` at the idle point of each click-app cycle:
+`95.8 → 101.7 → 105.4 → 106.9 → 107.5 → 107.8 → 108.0 → 108.2 → 108.9 → 109.1 → 109.2 MB`.
+The increments decay (+5.9, +3.7, +1.5, +0.6, … +0.1): an asymptotic
+plateau — allocator/pool warmup, **not** a leak. A leak adds a constant
+amount per cycle. Also measured: memory allocated while 10 kernels are open
+is *not* returned to the OS on cull (pymalloc/glibc retention), but the next
+cycle *reuses* it — that is why the steady-state per-kernel delta is almost
+zero, and why "RSS didn't go down after the user left" is not, by itself, a
+leak.
+
+The same run on macOS told the same story only in the physical footprint
+(119.5 → 124.6 MB, decaying); RSS bounced 70–142 MB with no correlation to
+load at all.
+
+### Cleanup correctness
+
+Across all runs (400+ kernel lifecycles), after every cycle `/resourcez`
+reported kernels = 0, websockets open = 0 (attempts == closed), threads back
+to baseline; culls completed in 1–2 s with `SOLARA_KERNEL_CULL_TIMEOUT=0.5s`.
+At the object level, `tests/integration/memleak_test.py` (weakref assertions
+on context/kernel/shell/session) passed 10/10 repeated runs on both flask and
+starlette.
+
+## Solara specifics
+
+- **`/resourcez`** (JSON): kernel counts (total/connected/disconnected),
+  websocket counts (attempts/connecting/open/closed), thread counts, state
+  backend health. `?verbose=1` adds CPU and memory — note the memory block is
+  `psutil.virtual_memory()`, i.e. **the whole machine**, not the solara
+  process. Use the counters as cleanup ground truth; get process memory from
+  the OS tools above.
+- `SOLARA_KERNEL_CULL_TIMEOUT` — kernel cleanup delay after disconnect
+  (default 24h; set `0.5s` in measurement runs).
+- `SOLARA_KERNELS_MAX_COUNT` — hard cap on kernels, prevents unbounded growth.
+- Per-user state lives in the virtual kernel; per-kernel cost is dominated by
+  your app's state, not the framework (~0.6 MB floor, see baselines).
+
+## Checklist for agents
+
+Executing a "measure memory / find the leak" task, in order:
+
+1. **Define the workload cycle** first: open N sessions → use them → close →
+   confirmed cleanup. No cycle, no conclusion.
+2. **Pick the metric for the platform**: Linux cgroup `anon` > macOS
+   `vmmap` footprint > Linux RSS. Never macOS RSS trends.
+3. **Warm up one cycle** before measuring anything.
+4. **Run ≥ 10 cycles**, record idle/loaded/idle per cycle plus the app's own
+   cleanup counters.
+5. **Judge by shape**: decaying increments = retention (healthy plateau);
+   constant increments = leak (report MB/cycle); counters not returning to
+   baseline = cleanup bug, fix before memory analysis.
+6. **If leak**: `memray flamegraph --leaks` (with `PYTHONMALLOC=malloc`) for
+   *what allocated it*; weakref + objgraph per
+   [memory-leak-detection.md](memory-leak-detection.md) for *why it is alive*.
+7. **If overuse (no leak, just big)**: memray flamegraph at peak for
+   attribution; tracemalloc diff for Python-level growth; remember imports
+   are a fixed ~tens-of-MB baseline.
+8. **For capacity questions**: run in a memory-limited docker container and
+   read `memory.peak` / `anon`, not profilers.
+9. **Report** numbers with their metric and platform ("109 MB cgroup anon,
+   Linux"), the curve shape, and the counter evidence — not bare "RSS was X".
+
+Known traps, all measured: macOS RSS compressor noise; `memory.current`
+page-cache pollution; USS needs root on macOS; `ru_maxrss` bytes-vs-KB;
+`_debugmallocstats` writes to C stderr; `memray tree` is interactive;
+tracemalloc sees numpy but not raw native malloc; a busy port means you may be
+measuring (or clicking!) someone else's server — assert the pid you measure
+is the one you started; a sawtooth curve (rise + periodic sharp drops) is
+gen-2 GC lag on reference cycles, not a leak; exception tracebacks pin every
+frame they passed through (strip `__traceback__` before storing exceptions);
+log-capture handlers in test harnesses retain those tracebacks and turn them
+into phantom flaky leaks — clear captured records inside the GC loop.
+
+## Which tool for which question
+
+| Question | Tool |
+|----------|------|
+| How much memory does the process use right now? | Linux: `psutil` RSS/USS; macOS: `vmmap -summary <pid>` physical footprint (RSS is compressor noise) |
+| What was the peak? | `resource.getrusage(...).ru_maxrss` (mind the Linux/macOS unit trap), or cgroup `memory.peak` |
+| Is Python holding freed memory in its arenas? | `sys._debugmallocstats()` |
+| Which Python code allocated the growth? | `tracemalloc` snapshot diff |
+| Which code (incl. C extensions) owns the memory? | `memray flamegraph`, `--native` |
+| What was allocated and never freed? | `memray flamegraph --leaks` with `PYTHONMALLOC=malloc` |
+| Why is this object still alive? | `objgraph` — see [memory-leak-detection.md](memory-leak-detection.md) |
+| Which types dominate the heap? | `objgraph.most_common_types()` / `gc.get_objects()` counter |
+| Will it fit in a 512 MB pod under load? | docker `--memory` + cgroup `memory.peak` / `anon` |
+| Did the sessions actually get cleaned up? | the app's counter endpoint (Solara: `/resourcez`) |
+| Is this growth a leak or retention? | idle-point series over ≥10 cycles: line = leak, plateau = retention |

--- a/tests/integration/kitchen_sink_leak_test.py
+++ b/tests/integration/kitchen_sink_leak_test.py
@@ -1,0 +1,130 @@
+"""Object-level leak check for the kitchen-sink measurement app.
+
+The memory harness (docs/memory-measurement) showed a sawtooth memory pattern
+for kitchen_sink_app.py. This test decides "true leak vs delayed collection":
+it renders the app, exercises every feature (3 clicks + ALL-DONE marker),
+closes the page, waits for the kernel cull, forces GC, and asserts the kernel
+context and kernel are collected. If they are, the sawtooth is cyclic garbage
+waiting for a gen-2 GC, not a leak.
+"""
+
+import gc
+import threading
+import time
+import weakref
+from pathlib import Path
+
+import playwright.sync_api
+import pytest
+
+import solara
+import solara.server.kernel_context
+
+HERE = Path(__file__).parent
+APP = HERE.parent.parent / "docs" / "memory-measurement" / "kitchen_sink_app.py"
+
+
+@pytest.fixture
+def no_cull_timeout():
+    cull_timeout_previous = solara.server.settings.kernel.cull_timeout
+    solara.server.settings.kernel.cull_timeout = "0.0001s"
+    try:
+        yield
+    finally:
+        solara.server.settings.kernel.cull_timeout = cull_timeout_previous
+
+
+def _scoped(page_session: playwright.sync_api.Page, solara_server, solara_app):
+    with solara_app(str(APP)):
+        page_session.goto(solara_server.base_url)
+        button = page_session.locator("button:has-text('Clicked')")
+        button.wait_for()
+        for i in range(3):
+            button.click()
+            page_session.locator(f"button:has-text('Clicked: {i + 1}')").wait_for()
+        page_session.locator("text=ALL-DONE").wait_for()
+
+        assert len(solara.server.kernel_context.contexts) == 1
+        ctx = list(solara.server.kernel_context.contexts.values())[0]
+        context_ref = weakref.ref(ctx)
+        kernel_ref = weakref.ref(ctx.kernel)
+        shell = ctx.kernel.shell
+        shell_ref = weakref.ref(shell)
+        last_cull_task = ctx._last_kernel_cull_task
+        page_session.goto("about:blank")
+        if last_cull_task is not None and not last_cull_task.done():
+            event = threading.Event()
+            last_cull_task.add_done_callback(lambda _: event.set())
+            assert event.wait(10)
+        closed_event = ctx.closed_event
+        assert closed_event.wait(10)
+        del ctx, last_cull_task, closed_event
+        if shell_ref():
+            del shell_ref().__dict__
+        del shell
+    return context_ref, kernel_ref, shell_ref
+
+
+def test_kitchen_sink_no_leak(
+    pytestconfig,
+    browser: playwright.sync_api.Browser,
+    page_session: playwright.sync_api.Page,
+    solara_server,
+    solara_app,
+    no_cull_timeout,
+):
+    context_ref, kernel_ref, shell_ref = _scoped(page_session, solara_server, solara_app)
+    page_session.context.tracing.stop()
+
+    import logging
+
+    def clear_captured_log_records():
+        # pytest's LogCaptureHandler retains LogRecords whose exc_info tracebacks can
+        # reference the kernel context (e.g. the asyncio "Exception in callback" ERROR
+        # from the task-cancel race, or solara's own logger.exception in the task thread).
+        # Production has no such handler, so that retention is a test artifact. Records
+        # can be emitted at any point while background task threads wind down, so clear
+        # continuously, not once.
+        for logger_obj in [logging.getLogger()] + [logging.getLogger(name) for name in logging.root.manager.loggerDict]:
+            for handler in getattr(logger_obj, "handlers", []):
+                if hasattr(handler, "records"):
+                    handler.records.clear()
+
+    for i in range(200):
+        time.sleep(0.1)
+        clear_captured_log_records()
+        for gen in [2, 1, 0]:
+            gc.collect(gen)
+        if context_ref() is None and kernel_ref() is None and shell_ref() is None:
+            break
+    else:
+        import objgraph
+
+        for name, ref in [("context", context_ref), ("kernel", kernel_ref), ("shell", shell_ref)]:
+            obj = ref()
+            if obj is None:
+                continue
+            print(f"--- retention chain for leaked {name} ---")  # noqa
+            chain = objgraph.find_backref_chain(obj, objgraph.is_proper_module, max_depth=50)
+            for i, item in enumerate(chain):
+                type_name = type(item).__name__
+                if hasattr(item, "__name__"):
+                    type_name += f" ({item.__name__})"
+                print(f"  [{i:2d}] {type_name}")  # noqa
+            # objgraph found no module root: dump raw referrers two levels deep
+            if len(chain) <= 1:
+                import reprlib
+
+                short = reprlib.Repr()
+                short.maxstring = 120
+                short.maxother = 120
+                for r1 in gc.get_referrers(obj):
+                    if r1 is chain:
+                        continue
+                    print(f"  referrer L1: {type(r1).__name__}: {short.repr(r1)}")  # noqa
+                    for r2 in gc.get_referrers(r1):
+                        print(f"      referrer L2: {type(r2).__name__}: {short.repr(r2)}")  # noqa
+
+    assert context_ref() is None
+    assert kernel_ref() is None
+    assert shell_ref() is None


### PR DESCRIPTION
## Summary

A handoff document (`docs/memory-usage-inspection.md`) for measuring memory use of a long-running Python server — written so another project (or an LLM agent) can follow it without extra context. Companion to https://github.com/widgetti/solara/pull/1176, which fixes what these measurements found.

**Contents:**

- **TL;DR protocol**: cycle-based workload (open N real sessions → use → close → confirmed cleanup → settle → measure, ≥10 cycles) and the decision rule — decaying increments = allocator retention (healthy plateau), constant increments = leak, sawtooth = reference cycles waiting for gen-2 gc.
- **Which metric to trust per platform** (all measured): Linux cgroup `anon` > macOS `vmmap` physical footprint > Linux RSS; macOS RSS is compressor noise (swung 70–142 MB under identical load). Traps: `memory.current` includes page cache (405 MB when the real heap was 109 MB), USS needs root on macOS, `ru_maxrss` bytes-vs-KB.
- **Tool layers**: tracemalloc (sees numpy, not raw native malloc — measured), memray modes (`--trace-python-allocators`, `--leaks` + `PYTHONMALLOC=malloc`, `--native`; verified against a real solara server, peak within 1 MB of vmmap), docker `--memory` as operational ground truth.
- **Measured solara baselines**: ~96 MB startup heap, ~0.6 MB per kernel cold / ~0.02–0.1 MB warm, plus the kitchen-sink case study (task-cancel race, exception tracebacks as reference bombs, pytest log-capture phantom leaks) and the cycle-hunting recipe (gc-disabled weakref + referrer walking) with what it found — including the playwright `__pw_stack__` trap and the remaining reacton `make_setter` cycle.
- **Checklist for agents**: 9 steps + every measured trap.

**Reproducible harness** in `docs/memory-measurement/`: `click_app.py` (framework floor), `kitchen_sink_app.py` (reactive + computed + task + use_task + use_reactive + ~4.5 MB payload/kernel), `measure.py` / `measure_docker.py` (host and 512 MB-cgroup benchmarks), `check_assumptions.py` (re-verifies the doc's micro-claims).

**Regression test** `tests/integration/kitchen_sink_leak_test.py`: weakref-asserts that a kernel exercising all the state/async features is really collected after page close. Passes 8/8 on starlette, on flask, and with `REACTON_FAST=1`; green on master (it clears captured log records continuously — pytest's LogCaptureHandler retains exception tracebacks that pin the kernel context, which made a naive version flaky at ~50%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)