### PR TITLE
fix: use_task leaked a task instance and its result per component mount

### DIFF
--- a/docs/memory-measurement/churn_app.py
+++ b/docs/memory-measurement/churn_app.py
@@ -1,0 +1,44 @@
+"""Component churn INSIDE a live kernel: every click unmounts or remounts a
+subcomponent holding a use_task and a ~4.5 MB payload.
+
+The session-cycle protocol (open pages -> use -> close) only catches leaks
+that are visible at kernel close. This app makes the harness exercise the
+other axis: state that accumulates per component mount/unmount while the
+kernel stays alive (the use_task leak was exactly that). Drive it with a
+higher click count, e.g.:
+
+    MEASURE_CLICKS=20 python measure.py churn_app.py
+
+The payload-holding subcomponent is mounted on even click counts, so use an
+even MEASURE_CLICKS. A leak shows up as idle-point growth proportional to
+clicks x pages x cycles; healthy behavior is the same plateau as
+kitchen_sink_app.py.
+"""
+
+import asyncio
+
+import solara
+import solara.lab
+
+clicks = solara.reactive(0)
+
+
+@solara.component
+def TaskUser():
+    async def work():
+        await asyncio.sleep(0.01)
+        return list(range(125_000))  # ~4.5 MB per mount
+
+    result = solara.lab.use_task(work, dependencies=[])
+    if result.finished:
+        assert result.value is not None
+        solara.Text(f"payload: {len(result.value)}")
+
+
+@solara.component
+def Page():
+    solara.Button(label=f"Clicked: {clicks.value}", on_click=lambda: clicks.set(clicks.value + 1))
+    if clicks.value % 2 == 0:
+        TaskUser()
+    else:
+        solara.Text("unmounted")

--- a/docs/memory-measurement/measure.py
+++ b/docs/memory-measurement/measure.py
@@ -30,11 +30,11 @@ import urllib.request
 import psutil
 from playwright.async_api import async_playwright
 
-PORT = 18765
+PORT = int(os.environ.get("MEASURE_PORT", "18765"))
 BASE = f"http://localhost:{PORT}"
 N_PAGES = 10
 CYCLES = 10
-CLICKS_PER_PAGE = 3
+CLICKS_PER_PAGE = int(os.environ.get("MEASURE_CLICKS", "3"))
 HERE = os.path.dirname(os.path.abspath(__file__))
 APP = sys.argv[1] if len(sys.argv) > 1 else "click_app.py"
 MARKER = sys.argv[2] if len(sys.argv) > 2 else None

--- a/docs/memory-measurement/measure_docker.py
+++ b/docs/memory-measurement/measure_docker.py
@@ -22,11 +22,11 @@ import urllib.request
 
 from playwright.async_api import async_playwright
 
-PORT = 18766
+PORT = int(os.environ.get("MEASURE_PORT", "18766"))
 BASE = f"http://localhost:{PORT}"
 N_PAGES = 10
 CYCLES = 10
-CLICKS_PER_PAGE = 3
+CLICKS_PER_PAGE = int(os.environ.get("MEASURE_CLICKS", "3"))
 HERE = os.path.dirname(os.path.abspath(__file__))
 REPO = os.path.abspath(os.path.join(HERE, "..", ".."))  # the solara repo root
 NAME = "solara-mem"

--- a/docs/memory-usage-inspection.md
+++ b/docs/memory-usage-inspection.md
@@ -32,6 +32,12 @@ alive* once you know something leaks.
 5. Verify cleanup independently of memory: an app-level counter endpoint
    (Solara: `/resourcez`) must return to baseline every cycle. "Memory not
    freed" is often just "cleanup didn't run".
+6. **Also churn WITHIN a session**: repeatedly create and destroy the app's
+   sub-resources while the session stays open (mount/unmount components,
+   open/close panels — `churn_app.py`). The session cycle only catches leaks
+   visible at session close; per-mount accumulation inside a live session is
+   invisible to it (that blind spot hid a real `use_task` leak, see the case
+   study below).
 
 ## Why the OS number does not tell the full story
 
@@ -138,14 +144,31 @@ The transferable core. Adapt the constants, keep the structure:
    - counters (sessions/threads/websockets) must return to baseline every
      cycle — if they don't, fix that first; the memory question is moot.
 
+**The second axis: churn within a session.** The cycle above varies the
+number of *sessions*; every leak it can catch is one that survives session
+close. State that accumulates per *component* (or per sub-resource) while
+the session stays open is invisible to it — closing the session frees the
+accumulation before the measurement can see it, and a handful of
+interactions per session is lost in the noise. So also run the protocol
+with a workload that repeatedly creates and destroys sub-resources inside
+each session (`churn_app.py`: every click mounts or unmounts a
+`use_task` + 4.5 MB payload subcomponent; drive it with
+`MEASURE_CLICKS=10` or more). Same read-out: idle-point plateau vs line.
+The object-level twin is a weakref test: mount/unmount N times in one live
+kernel and assert at most the mounted instance's payload stays alive
+(`tests/unit/task_test.py::test_use_task_unmounted_instance_is_collected`).
+
 Reference implementation in [memory-measurement/](memory-measurement/):
 
 - `click_app.py` — minimal one-button app (framework floor)
 - `kitchen_sink_app.py` — exercises reactive/computed/task/use_task/
-  use_reactive plus ~1 MB per-session payload; renders `ALL-DONE` when every
-  feature finished (the harness waits for it)
+  use_reactive plus ~4.5 MB per-session payload; renders `ALL-DONE` when
+  every feature finished (the harness waits for it)
+- `churn_app.py` — within-session churn: each click mounts/unmounts a
+  subcomponent holding a `use_task` + ~4.5 MB payload
 - `measure.py [app.py] [marker]` — host run (psutil + vmmap), prints per-cycle
-  table, writes `report-<app>.json`
+  table, writes `report-<app>.json`; `MEASURE_CLICKS`/`MEASURE_PORT` override
+  the defaults
 - `measure_docker.py [app.py] [marker]` — same protocol against a 512 MB
   `python:3.11-slim` container, reading cgroup v2 numbers (the browser stays
   on the host so the cgroup contains only the server)
@@ -415,6 +438,59 @@ pauses all threads — the unit test suite closes one context per test, and
 the GIL pauses broke timing-sensitive tests on loaded CI runners (hence the
 rendered-an-app gate).
 
+### Case study 2: the use_task leak the protocol missed
+
+After all of the above was measured, verified, and released, a user found a
+leak in `use_task` — a lesson in methodology, because every measurement and
+test above was green while it existed.
+
+**Why it was invisible**: every workload cycled *sessions* — mount, use
+briefly, close, assert everything freed. `use_task` leaked **per component
+mount**: each mount created a `Task` inside a `Singleton`, whose constructor
+registered a reset callback in the process-global `on_kernel_start` list and
+discarded the returned unregister-cleanup. Fine for module-level `@task`
+(one instance per process, the module pins it anyway); for `use_task` every
+mount permanently pinned a task instance plus its `._last_value` result. A
+session that mounts/unmounts such components grows without bound — but close
+the session and everything except the global registrations is freed, so
+close-path tests pass, and three clicks per session is invisible in the
+per-session noise. The kitchen-sink app never unmounted anything.
+
+**The fix** (`use_task` cleanup on unmount, solara #1180) had its own
+instructive race: clearing the kernel-store entries at unmount was not
+enough, because a worker thread *just finishing* re-created the entry via
+its result write. The cleanup must first drop the call state — making
+`is_current()` return `False`, which gates all result writes — then cancel,
+unregister, and clear.
+
+**Measured** (`churn_app.py`, 10 pages × 10 cycles × 5 mount/unmounts per
+page = 500 mounts, macOS physical footprint): with the leak, idle climbs
+`149 → 247 → 278 → 303 → 350 → 381 → ~390 MB` (peak 425 MB) and the first
+sessions cost 27 MB each; with the unmount cleanup, idle stays flat at
+~160–170 MB (peak 171 MB) and sessions cost ~0–2 MB at steady state. Same
+workload, 2.4× the memory — and still climbing — versus a plateau.
+
+**The general rules this adds**:
+
+- Sub-session resources need their own churn test: create/destroy them many
+  times *within* a live session (`churn_app.py` for the benchmark;
+  a weakref mount/unmount test for the object level).
+- Any registration in a long-lived registry (process-global lists,
+  session-scoped callback lists) must be paired with deregistration at the
+  registrant's *own* lifetime end — "the registry is cleaned at close" is
+  only true for objects whose lifetime matches the registry's. A bound
+  method in a callback list is a strong reference to the whole instance;
+  register a `weakref.WeakMethod` when the callback is a courtesy rather
+  than an ownership.
+- Cleanup that races a worker must first flip the flag the worker checks
+  (`is_current()`-style), then clear the state — clearing first re-leaks.
+
+One more diagnosis trap found on the way (py3.11+): `gc.get_referrers` on a
+coroutine's local shows the **coroutine object** as the referrer, not a
+frame — so diagnosis code running inside a coroutine finds itself and cannot
+be filtered by `f_code.co_name`. Put referrer-walking diagnosis in a
+separate plain function and filter by its function names.
+
 ### Leak or retention? The shape answers it
 
 Linux `anon` at the idle point of each click-app cycle:
@@ -468,6 +544,10 @@ Executing a "measure memory / find the leak" task, in order:
 5. **Judge by shape**: decaying increments = retention (healthy plateau);
    constant increments = leak (report MB/cycle); counters not returning to
    baseline = cleanup bug, fix before memory analysis.
+5b. **Run the churn variant too**: repeatedly create/destroy sub-resources
+   *inside* live sessions (component mount/unmount). The session cycle is
+   blind to per-mount accumulation — it freed everything at close before you
+   could see it (this hid a real `use_task` leak; see the case study).
 6. **If leak**: `memray flamegraph --leaks` (with `PYTHONMALLOC=malloc`) for
    *what allocated it*; weakref + objgraph per
    [memory-leak-detection.md](memory-leak-detection.md) for *why it is alive*.

--- a/solara/_stores.py
+++ b/solara/_stores.py
@@ -57,6 +57,10 @@ class MutateDetectorStore(ValueBase[S]):
         public_value = cast(S, store_value.public)
         return public_value
 
+    def clear(self):
+        # remove the wrapped store's entry for the current scope (e.g. use_task unmount)
+        self._storage.clear()
+
     def set(self, value: S):
         self.check_mutations()
         self._ensure_public_exists()

--- a/solara/tasks.py
+++ b/solara/tasks.py
@@ -284,10 +284,22 @@ class TaskAsyncio(Task[P, R]):
             self._context = weakref.ref(context)
             call_event_loop = context.event_loop
             if not self._drop_call_state_on_close_registered:
-                # the task instance is per kernel (it lives in a kernel store), so one
-                # registration covers all calls
+                # one registration covers all calls of this instance. Register weakly:
+                # use_task creates a Task instance per component mount, and a strong
+                # reference (a bound method) would pin every instance that ever ran -
+                # including its ._last_value result - until the KERNEL closes, growing
+                # without bound in a long-lived session that mounts/unmounts components.
+                # A collected instance took its call state with it, so there is nothing
+                # left to drop at close.
                 self._drop_call_state_on_close_registered = True
-                context.on_close(self._drop_call_state)
+                drop_call_state_ref = weakref.WeakMethod(self._drop_call_state)
+
+                def drop_call_state():
+                    drop = drop_call_state_ref()
+                    if drop is not None:
+                        drop()
+
+                context.on_close(drop_call_state)
         else:
             call_event_loop = _main_event_loop or asyncio.get_event_loop()
         try:
@@ -499,7 +511,21 @@ class TaskThreaded(Task[P, R]):
         cancel_event = getattr(self._local, "cancel_event", None)
         if cancel_event is not None and cancel_event.is_set():
             return False
+        if self._current_thread is None:
+            # the call state was dropped (component unmount): any still-running call is
+            # stale and should stop
+            return False
         return self._current_thread == threading.current_thread()
+
+    def _drop_call_state(self):
+        # See TaskAsyncio._drop_call_state: called when a use_task component unmounts, so
+        # a stale worker thread stops updating state (is_current() returns False) and the
+        # call bookkeeping does not outlive the component.
+        self._current_thread = None
+        self._current_cancel_event = None
+        self._last_finished_event = None
+        self._cancel = None
+        self._retry = None
 
     def _run(self, _last_finished_event, previous_thread: Optional[threading.Thread], cancel_event, args, kwargs) -> None:
         # use_thread has this as default, which can make code run 10x slower
@@ -1055,6 +1081,32 @@ def use_task(
         task_instance = solara.use_memo(create_task, dependencies=[])
         # we always update the function so we do not have stale data in the function
         task_instance.function = f  # type: ignore
+
+        def cleanup_on_unmount():
+            def cleanup():
+                # unlike a module-level @task (one instance per process), this task instance
+                # belongs to this component instance: drop everything that outlives the
+                # component, or a session that mounts/unmounts components leaks a task
+                # instance + its result per mount:
+                # 1. stop a still-running call, and drop the call state FIRST: that makes
+                #    is_current() False, so a worker thread that is just finishing skips its
+                #    result write instead of recreating the store entry we clear below
+                try:
+                    task_instance.cancel()
+                except RuntimeError:
+                    pass  # never called
+                task_instance._drop_call_state()  # type: ignore
+                singleton = task_instance._instance  # type: ignore
+                # 2. the process-global on_kernel_start registration (pins the instance forever)
+                singleton._on_kernel_start_cleanup()
+                # 3. this kernel's entries in the kernel stores (pinned until kernel close):
+                #    the instance itself, and its TaskResult (which holds .value/.latest)
+                singleton._storage.clear()
+                task_instance._result._storage.clear()  # type: ignore
+
+            return cleanup
+
+        solara.use_effect(cleanup_on_unmount, dependencies=[])
 
         def _prestart():
             if dependencies is not None:

--- a/solara/tasks.py
+++ b/solara/tasks.py
@@ -1088,13 +1088,14 @@ def use_task(
                 # belongs to this component instance: drop everything that outlives the
                 # component, or a session that mounts/unmounts components leaks a task
                 # instance + its result per mount:
-                # 1. stop a still-running call, and drop the call state FIRST: that makes
-                #    is_current() False, so a worker thread that is just finishing skips its
-                #    result write instead of recreating the store entry we clear below
-                try:
-                    task_instance.cancel()
-                except RuntimeError:
-                    pass  # never called
+                # 1. drop the call state FIRST: that makes is_current() False, so a still
+                #    running call stops updating state, and a worker thread that is just
+                #    finishing skips its result write instead of recreating the store entry
+                #    we clear below. Deliberately no cancel(): its called-from-our-own-task
+                #    detection misfires when this cleanup runs inside the task's own render
+                #    cascade (a result write triggering the unmounting render), raising
+                #    _CancelledErrorInOurTask through the render machinery. An orphaned call
+                #    running to completion unobserved matches the pre-cleanup behavior.
                 task_instance._drop_call_state()  # type: ignore
                 singleton = task_instance._instance  # type: ignore
                 # 2. the process-global on_kernel_start registration (pins the instance forever)

--- a/solara/toestand.py
+++ b/solara/toestand.py
@@ -142,6 +142,14 @@ class ValueBase(Generic[T]):
     def lock(self):
         raise NotImplementedError
 
+    def clear(self):
+        """Remove the stored value for the current scope (e.g. this kernel).
+
+        No-op for storage without per-scope entries; kernel-scoped stores drop
+        this kernel's entry (used by use_task when its component unmounts).
+        """
+        pass
+
     @property
     def value(self) -> T:
         return self.get()

--- a/solara/toestand.py
+++ b/solara/toestand.py
@@ -747,7 +747,11 @@ class Singleton(Reactive[S]):
 
             return cleanup
 
-        solara.lifecycle.on_kernel_start(reset)
+        # the registration appends to a process-global list, pinning self (and, through the
+        # kernel store, the per-kernel values) forever. Fine for module-level singletons -
+        # the module pins them anyway - but per-component-instance singletons (use_task)
+        # must call this cleanup on unmount or every mount leaks until process exit.
+        self._on_kernel_start_cleanup = solara.lifecycle.on_kernel_start(reset)
 
     def __set__(self, obj, value):
         raise AttributeError("Can't set a singleton")

--- a/tests/unit/task_test.py
+++ b/tests/unit/task_test.py
@@ -784,6 +784,9 @@ def test_use_task_unmounted_instance_is_collected(monkeypatch):
         async def run():
             context = kernel_context.VirtualKernelContext(id="use-task-unmount", kernel=kernel.Kernel(), session_id="session-unmount")
             holder["context"] = context
+            await run_in_context(context)
+
+        async def run_in_context(context):
             with context:
                 box, rc = solara.render(Page(), handle_error=False)
                 n = 5
@@ -812,12 +815,17 @@ def test_use_task_unmounted_instance_is_collected(monkeypatch):
                 holder["alive"] = alive
                 rc.close()
 
-        asyncio.run(run())
+        try:
+            asyncio.run(run())
+        except BaseException as e:  # noqa: BLE001 - re-raised in the main thread
+            holder["exception"] = e
 
     try:
         thread = threading.Thread(target=page_thread)
         thread.start()
         thread.join()
+        if "exception" in holder:
+            raise holder["exception"]
         alive = holder["alive"]
         assert alive <= 1, f"unmounted use_task results are pinned: {alive}/{len(payload_refs)} alive while the kernel is still open"
     finally:

--- a/tests/unit/task_test.py
+++ b/tests/unit/task_test.py
@@ -1,7 +1,9 @@
 import asyncio
+import gc
 import logging
 import threading
 import time
+import weakref
 import warnings
 
 import ipyvuetify as v
@@ -741,6 +743,86 @@ def test_task_finishing_after_call_event_loop_closed_is_not_an_error(fail, caplo
     finally:
         with context_holder["context"]:
             context_holder["context"].close()
+
+
+def test_use_task_unmounted_instance_is_collected(monkeypatch):
+    # use_task creates a Task instance per component mount. Registering the close-time
+    # cleanup with a strong reference (context.on_close(self._drop_call_state)) pinned
+    # every instance that ever ran - together with its ._last_value result - until the
+    # KERNEL closed. A long-lived session that mounts/unmounts use_task components then
+    # grows without bound. The registration must not keep an unmounted instance alive.
+    monkeypatch.setattr(solara.tasks, "_using_solara_server", lambda: True)
+
+    class Payload(list):
+        pass
+
+    payload_refs: list = []
+    show = solara.reactive(True)
+
+    @solara.component
+    def TaskUser():
+        async def work():
+            data = Payload(range(1000))
+            payload_refs.append(weakref.ref(data))
+            return data
+
+        result = use_task(work, dependencies=[])
+        solara.Text("done" if result.finished else "pending")
+
+    @solara.component
+    def Page():
+        if show.value:
+            TaskUser()
+        else:
+            solara.Text("hidden")
+
+    holder: dict = {}
+
+    def page_thread():
+        # like production: the kernel context's event loop is a RUNNING loop (the
+        # websocket thread's), so future-delivery callbacks actually get processed
+        async def run():
+            context = kernel_context.VirtualKernelContext(id="use-task-unmount", kernel=kernel.Kernel(), session_id="session-unmount")
+            holder["context"] = context
+            with context:
+                box, rc = solara.render(Page(), handle_error=False)
+                n = 5
+                for _ in range(n):
+                    show.value = False
+                    show.value = True
+                    await asyncio.sleep(0.05)  # let task threads finish and deliveries drain
+                deadline = time.time() + 10
+                while len(payload_refs) < n + 1 and time.time() < deadline:
+                    await asyncio.sleep(0.01)
+                alive = len(payload_refs)
+                deadline = time.time() + 10
+                while time.time() < deadline:
+                    # pytest's LogCaptureHandler retains LogRecords whose args hold the
+                    # task results ("setting result to %r"); clear them or they pin the
+                    # payloads for the duration of the test
+                    for logger_obj in [logging.getLogger()] + [logging.getLogger(name) for name in logging.root.manager.loggerDict]:
+                        for handler in getattr(logger_obj, "handlers", []):
+                            if hasattr(handler, "records"):
+                                handler.records.clear()
+                    gc.collect()
+                    alive = sum(1 for ref in payload_refs if ref() is not None)
+                    if alive <= 1:  # only the currently mounted instance may hold one
+                        break
+                    await asyncio.sleep(0.05)
+                holder["alive"] = alive
+                rc.close()
+
+        asyncio.run(run())
+
+    try:
+        thread = threading.Thread(target=page_thread)
+        thread.start()
+        thread.join()
+        alive = holder["alive"]
+        assert alive <= 1, f"unmounted use_task results are pinned: {alive}/{len(payload_refs)} alive while the kernel is still open"
+    finally:
+        with holder["context"]:
+            holder["context"].close()
 
 
 def test_task_async_future_receives_exception(monkeypatch):


### PR DESCRIPTION
## Summary

A long-lived session that mounts/unmounts components using `use_task` leaked one task instance — including its `._last_value` result — **per mount**, until process exit. Reproduced with a weakref-based mount/unmount test (red on master). Measured with the churn benchmark (`churn_app.py`, 500 mounts): idle footprint climbs `149 → 390 MB and keeps rising` on master, flat `~165 MB` with this fix.

## The retainers (found with a gc-referrer walk on a live kernel)

1. **Process-global** (pre-existing, the main leak): each `use_task` mount creates a `Task` wrapped in a `Singleton`, whose `__init__` registers a reset callback in `solara.lifecycle._on_kernel_start_callbacks` and discards the returned cleanup. That list entry pins the Singleton → kernel store → task instance → result, forever. Harmless for module-level `@task` (one per process); unbounded for `use_task`.
2. **Kernel-lifetime**: the instance and its `TaskResult` also stay in the kernel stores (`user_dicts`) until kernel close.
3. **Kernel-lifetime** (from #1176, this branch replaces that mechanism for the same goal): `context.on_close(self._drop_call_state)` held a bound method — a strong reference per instance. Now registered via `weakref.WeakMethod`, so a collected instance is a no-op at close.

## The fix

`use_task` registers a `use_effect` cleanup that runs at unmount: **drop the call state first** (so `is_current()` turns False and a worker thread that is *just finishing* skips its result write instead of recreating the store entry we clear — this race is why clearing alone was not enough), unregister the lifecycle callback (`Singleton` now keeps the cleanup it used to discard), and clear this kernel's store entries for the instance and its `TaskResult`. `TaskThreaded` gets the same `_drop_call_state` as `TaskAsyncio`, so coroutine and plain-function tasks behave identically.

Two CI-found refinements:
- **No `cancel()` on unmount**: cancel's called-from-our-own-task detection misfires when the cleanup runs inside the task's own render cascade (a result write triggering the unmounting render), raising `_CancelledErrorInOurTask` through the render machinery — seen as matrix-random failures. An orphaned call running to completion unobserved matches the pre-cleanup unmount behavior exactly.
- **`clear()` is now part of the `ValueBase` store interface** and `MutateDetectorStore` delegates it: the "solara 2.0" CI run (`SOLARA_STORAGE_MUTATION_DETECTION=1`) wraps kernel stores in it, and the cleanup crashed with AttributeError there.

## Docs

The handbook (`docs/memory-usage-inspection.md`) gains the second workload axis this leak exposed: **churn within a session**. The session-cycle protocol only catches leaks visible at session close; per-mount accumulation inside a live kernel was structurally invisible to it (everything above was green while this leaked). Adds `churn_app.py` + `MEASURE_CLICKS`/`MEASURE_PORT` to the harness, the measured before/after, case study 2 with three transferable rules (churn-test sub-session resources; registrations in longer-lived registries need deregistration at the registrant's lifetime end or a `WeakMethod`; cleanup must flip the worker's guard flag before clearing state), and the py3.11 coroutine-referrer diagnosis trap.

## Testing

- New `test_use_task_unmounted_instance_is_collected`: 5 mount/unmount cycles in a live kernel (running event loop, like production), asserts at most the mounted instance's payload stays alive; exceptions in its page thread re-raise in the main thread. Red on master → green, repeated runs, in both normal and solara-2.0 mode.
- Full unit suite: 411 passed normal, 413 passed 2.0-mode. Integration leak tests (kitchen-sink + memleak, starlette): green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)