### PR TITLE
fix: deliver cross-thread task cancellation via call_soon_threadsafe

### DIFF
--- a/solara/tasks.py
+++ b/solara/tasks.py
@@ -64,11 +64,16 @@ except RuntimeError:
 
 
 def _get_current_task():
-    # asyncio.current_task() is not available in Python 3.6
-    if sys.version_info >= (3, 7):
-        return asyncio.current_task()
-    else:
-        return asyncio.Task.current_task()
+    try:
+        # asyncio.current_task() is not available in Python 3.6
+        if sys.version_info >= (3, 7):
+            return asyncio.current_task()
+        else:
+            return asyncio.Task.current_task()
+    except RuntimeError:
+        # called from a thread without a running event loop (e.g. Task.cancel()
+        # from a plain thread): there is no current task there
+        return None
 
 
 class TaskState(Enum):
@@ -251,7 +256,23 @@ class TaskAsyncio(Task[P, R]):
                     current_task.cancel()
                     self._result.value = TaskResult[R](latest=self._last_value, _state=TaskState.CANCELLED)
             else:
-                current_task.cancel()
+                try:
+                    running_loop: Optional[asyncio.AbstractEventLoop] = asyncio.get_running_loop()
+                except RuntimeError:
+                    running_loop = None
+                if running_loop is event_loop:
+                    current_task.cancel()
+                else:
+                    # asyncio.Task.cancel is not thread-safe. Called from another thread it
+                    # only appends the wakeup to the loop's ready queue without writing the
+                    # self-pipe, so a loop parked in run_until_complete on its own thread
+                    # (run_in_thread tasks awaiting e.g. asyncio.sleep) does not notice the
+                    # cancellation until its current await completes on its own.
+                    try:
+                        event_loop.call_soon_threadsafe(current_task.cancel)
+                    except RuntimeError:
+                        # the loop is already closed: the task's thread is gone with it
+                        pass
                 self._result.value = TaskResult[R](latest=self._last_value, _state=TaskState.CANCELLED)
 
         self._cancel = cancel

--- a/tests/unit/task_test.py
+++ b/tests/unit/task_test.py
@@ -834,3 +834,28 @@ def test_task_finishing_after_future_cancelled_is_not_an_error(fail, caplog, mon
     finally:
         with context_holder["context"]:
             context_holder["context"].close()
+
+
+def test_task_async_cancel_from_other_thread_wakes_sleeping_loop():
+    # a run_in_thread async task parks its private event loop in run_until_complete;
+    # cancelling from another thread (e.g. a kernel close callback) must wake that
+    # loop via call_soon_threadsafe — a plain Task.cancel() only lands when the
+    # current await finishes on its own (here: 20 seconds later)
+    started = threading.Event()
+    finished = threading.Event()
+
+    @solara.lab.task
+    async def sleeper():
+        started.set()
+        try:
+            await asyncio.sleep(20)
+        finally:
+            finished.set()
+
+    sleeper()
+    assert started.wait(5)
+    t0 = time.monotonic()
+    sleeper.cancel()
+    assert finished.wait(10), "cancel from another thread did not wake the sleeping task loop"
+    assert time.monotonic() - t0 < 5
+    assert sleeper.cancelled


### PR DESCRIPTION
## Problem

`asyncio.Task.cancel` is not thread-safe: called from another thread it appends the wakeup to the loop's ready queue without writing the self-pipe. A `run_in_thread` async task parks its private event loop in `run_until_complete`, so a `Task.cancel()` from any other thread — a kernel-close callback, a component-unmount cleanup (#1180), any UI thread — is silently deferred until the current await finishes on its own. For a watcher-style task sleeping between ticks that means minutes, during which the thread pins its kernel context and everything it references.

Measured on a production app (cycle protocol from `docs/memory-usage-inspection.md`): a close-time `cancel()` made no difference at all versus not cancelling — watcher threads and their kernel contexts lingered until the natural end of a 5-minute `asyncio.sleep`.

There is also a pre-existing crash on the same path: `_get_current_task()` calls `asyncio.current_task()`, which **raises** `RuntimeError` when the calling thread has no running loop, so `cancel()` from a plain thread never even reached the cancel logic.

## Fix

- `cancel()` from off-loop routes the cancellation through the task's own loop with `event_loop.call_soon_threadsafe(current_task.cancel)` (ignoring a closed loop — its thread is already gone). On-loop behavior is unchanged.
- `_get_current_task()` returns `None` instead of raising when there is no running event loop.

## Testing

New `test_task_async_cancel_from_other_thread_wakes_sleeping_loop`: a task awaiting `asyncio.sleep(20)` is cancelled from the pytest main thread and must finish within seconds. Red on master (RuntimeError, and with that fixed, a 20 s wait), green with the fix in 0.75 s. Full unit suite: 411 passed, 23 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)