### PR TITLE
fix: do not pin a kernel context in ThreadPoolExecutor worker threads

### DIFF
--- a/solara/server/patch.py
+++ b/solara/server/patch.py
@@ -272,6 +272,20 @@ Thread__init__ = threading.Thread.__init__
 Thread__bootstrap = threading.Thread._bootstrap  # type: ignore
 
 
+def _is_pool_worker_thread(args, kwargs) -> bool:
+    # a concurrent.futures.ThreadPoolExecutor grows its pool lazily: the worker
+    # thread is created by whoever happens to call submit() when no worker is idle.
+    # Pool workers are shared infrastructure that outlive the request that spawned
+    # them — inheriting the spawning kernel's context would pin that kernel's whole
+    # state for the lifetime of the pool, and any code on the worker would see an
+    # arbitrary, possibly closed, kernel context. Context must travel per submitted
+    # job (a contextvars copy or an explicit capture), not per worker thread.
+    target = kwargs.get("target")
+    if target is None and len(args) >= 2:
+        target = args[1]
+    return getattr(target, "__module__", None) == "concurrent.futures.thread" and getattr(target, "__qualname__", None) == "_worker"
+
+
 def WidgetContextAwareThread__init__(self, *args, **kwargs):
     Thread__init__(self, *args, **kwargs)
     with ThreadDebugInfo.lock:
@@ -280,7 +294,8 @@ def WidgetContextAwareThread__init__(self, *args, **kwargs):
     self.current_context = None
     # if we do this for the dummy threads, we got into a recursion
     # since threading.current_thread will call the _DummyThread constructor
-    if not ("name" in kwargs and kwargs["name"] is not None and "Dummy-" in kwargs["name"]):
+    is_dummy = "name" in kwargs and kwargs["name"] is not None and "Dummy-" in kwargs["name"]
+    if not is_dummy and not _is_pool_worker_thread(args, kwargs):
         try:
             self.current_context = kernel_context.get_current_context()
         except RuntimeError:

--- a/tests/unit/patch_test.py
+++ b/tests/unit/patch_test.py
@@ -41,3 +41,34 @@ def test_widget_dict(no_kernel_context):
     del btn2
     context1.close()
     context2.close()
+
+
+def test_pool_worker_thread_does_not_pin_kernel_context(no_kernel_context):
+    import gc
+    import threading
+    import weakref
+    from concurrent.futures import ThreadPoolExecutor
+
+    import solara.server.app  # noqa: F401 - importing applies the threading patch
+
+    kernel1 = kernel.Kernel()
+    context = kernel_context.VirtualKernelContext(id="pool-pin-1", kernel=kernel1, session_id="session-1")
+    executor = ThreadPoolExecutor(max_workers=1)
+    try:
+        with context:
+            # force the pool to spawn its worker inside the kernel context, like a
+            # request handler triggering lazy pool growth
+            executor.submit(lambda: None).result()
+            # a directly created thread still inherits the context
+            regular_thread = threading.Thread(target=lambda: None)
+            assert regular_thread.current_context is context  # type: ignore
+            regular_thread.current_context = None  # type: ignore
+        context_ref = weakref.ref(context)
+        with context:
+            context.close()
+        del context, kernel1, regular_thread
+        gc.collect()
+        # the pool worker is still alive; it must not keep the closed context alive
+        assert context_ref() is None
+    finally:
+        executor.shutdown(wait=False)


### PR DESCRIPTION
## Problem

The threading patch stamps `thread.current_context` on every thread created inside a kernel context. `concurrent.futures.ThreadPoolExecutor` grows its pool lazily — the worker thread is created by whoever calls `submit()` when no worker is idle — so a worker spawned while serving a user session permanently captures **that session's** kernel context. Pool workers never exit, so the closed session's entire state (render tree, widgets, user data) stays pinned for the lifetime of the pool.

Measured on a production app with a shared 100-worker executor (cycle protocol from `docs/memory-usage-inspection.md`): one leaked kernel context per pool-growth step, ~1 per session at ~4 MB each, growing until pool saturation (~100 dead sessions ≈ 0.4–1 GB). Retention chain via objgraph: `threading._active → Thread → thread.current_context → VirtualKernelContext`.

Beyond the leak, the inherited context is semantically wrong for a shared worker: jobs submitted later from *other* kernels would observe an arbitrary — possibly closed — kernel context. Context belongs to the submitted job (a contextvars copy or an explicit capture at submit time), not to the worker thread.

## Fix

Skip context inheritance when the thread target is the `concurrent.futures.thread._worker` loop. Directly created `threading.Thread`s keep the existing behavior.

Not covered here (worth a follow-up discussion): anyio's `to_thread` worker threads have the same shape but bounded impact — idle workers exit after ~10 s, so they pin a context only briefly.

## Testing

New `test_pool_worker_thread_does_not_pin_kernel_context`: spawns a pool worker inside a kernel context, closes the context while the worker lives, asserts a weakref to the context dies (and that a directly created Thread still inherits the context). Red on master, green with the fix. Full unit suite: 411 passed, 23 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)