### PR TITLE
feat: synchronous websocket frame writing (SOLARA_SERVER_SYNC_WS_WRITE)

### DIFF
--- a/solara/server/settings.py
+++ b/solara/server/settings.py
@@ -221,6 +221,11 @@ class Server(BaseSettings):
     # gzip HTTP responses (SOLARA_SERVER_HTTP_GZIP=false when a fronting proxy
     # like nginx/caddy does the compressing)
     http_gzip: bool = True
+    # write websocket frames synchronously from the sending thread instead of
+    # scheduling every message on the event loop (SOLARA_SERVER_SYNC_WS_WRITE).
+    # Requires uvicorn's websockets implementation; falls back to the default
+    # path (with a log message) when unavailable. See starlette.py.
+    sync_ws_write: bool = False
 
     class Config:
         env_prefix = "solara_server_"

--- a/solara/server/starlette.py
+++ b/solara/server/starlette.py
@@ -117,6 +117,13 @@ class WebsocketWrapper(websocket.WebsocketWrapper):
     def __init__(self, ws: starlette.websockets.WebSocket, portal: Optional[anyio.from_thread.BlockingPortal]) -> None:
         self.ws = ws
         self.portal = portal
+        self.sync_writer = None
+        if settings.server.sync_ws_write:
+            from . import sync_ws_write
+
+            # frames are written synchronously from the sending thread; falls
+            # back to the default path (None) when unsupported, see the module
+            self.sync_writer = sync_ws_write.SyncFrameWriter.try_create(ws)
         self.to_send: List[Union[str, bytes]] = []
         # following https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task
         # we store a strong reference
@@ -183,6 +190,12 @@ class WebsocketWrapper(websocket.WebsocketWrapper):
             self.portal.call(_close_exc)
 
     def send_text(self, data: str) -> None:
+        if self.sync_writer is not None:
+            try:
+                self.sync_writer.send_text(data)
+            except OSError as e:
+                raise websocket.WebSocketDisconnect() from e
+            return
         if self.portal is None:
             task = self.event_loop.create_task(self._send_text_exc(data))
             self.tasks.add(task)
@@ -206,6 +219,12 @@ await to_thread.run_sync(my_update)
                     self.portal.call(self._send_text_exc, data)
 
     def send_bytes(self, data: bytes) -> None:
+        if self.sync_writer is not None:
+            try:
+                self.sync_writer.send_bytes(data)
+            except OSError as e:
+                raise websocket.WebSocketDisconnect() from e
+            return
         if self.portal is None:
             task = self.event_loop.create_task(self._send_bytes_exc(data))
             self.tasks.add(task)

--- a/solara/server/sync_ws_write.py
+++ b/solara/server/sync_ws_write.py
@@ -1,0 +1,149 @@
+"""Synchronous websocket frame writing for the kernel connection.
+
+The default send path schedules every websocket message on the event loop
+(``portal.call`` per message from the render thread): a thread handoff, a task,
+and a loop wakeup per message. A page render sends hundreds of messages, so on
+a small instance this machinery costs more than building and serializing the
+widgets themselves (measured: dropping it halves the server-side render wall).
+
+With ``SOLARA_SERVER_SYNC_WS_WRITE=true`` frames are written synchronously from
+whatever thread sends them:
+
+- ``write_frame_sync`` on uvicorn's websockets protocol object is the single
+  funnel for every post-handshake frame (data, ping/pong, close — see
+  ``websockets.legacy.protocol``), and it already applies negotiated extensions
+  (permessage-deflate) via ``Frame.write``. We replace it *per connection* with
+  a version that serializes frame construction under a lock and writes to the
+  socket file descriptor with a blocking retry loop, instead of
+  ``transport.write``.
+- Because the loop's own control frames also go through the same (patched)
+  funnel, data and control frames cannot interleave mid-frame, and the deflate
+  context stays single-threaded under the lock.
+- The asyncio transport is no longer handed bytes after the patch; reading
+  stays fully on the event loop, untouched.
+- Backpressure is the OS socket buffer: a slow client blocks the sending
+  (render) thread instead of growing an unbounded queue.
+
+Requirements and fallbacks (checked per connection, falling back to the
+default path with one log message):
+
+- uvicorn must use the ``websockets`` implementation (the default when
+  installed; not ``wsproto``).
+- plain TCP transport (no TLS terminated in uvicorn itself — writing the raw
+  fd would bypass the SSL layer; TLS-terminating proxies in front are fine).
+"""
+
+import errno
+import logging
+import os
+import socket
+import threading
+import time
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger("solara.server.sync_ws_write")
+
+_unavailable_logged = False
+
+
+def _log_unavailable_once(reason: str) -> None:
+    global _unavailable_logged
+    if not _unavailable_logged:
+        _unavailable_logged = True
+        logger.warning("sync_ws_write requested but unavailable (%s), using the default send path", reason)
+
+
+def _find_websockets_protocol(send: Optional[Callable], depth: int = 0) -> Optional[Any]:
+    """The uvicorn protocol object, unwrapped from starlette's middleware closures.
+
+    starlette wraps the raw ASGI ``send`` (a bound method of uvicorn's
+    ``WebSocketProtocol``) in plain function closures; walk them.
+    """
+    try:
+        from websockets.legacy.protocol import WebSocketCommonProtocol
+    except ImportError:
+        return None
+    if depth > 10 or send is None:
+        return None
+    self_ = getattr(send, "__self__", None)
+    if isinstance(self_, WebSocketCommonProtocol):
+        return self_
+    for cell in getattr(send, "__closure__", None) or ():
+        value = cell.cell_contents
+        if callable(value):
+            found = _find_websockets_protocol(value, depth + 1)
+            if found is not None:
+                return found
+    return None
+
+
+class SyncFrameWriter:
+    """Owns all frame writes of one websocket connection, synchronously."""
+
+    def __init__(self, protocol: Any, sock_fd: int) -> None:
+        from websockets.frames import Opcode
+        from websockets.legacy.framing import Frame
+
+        self._Frame = Frame
+        self._OP_TEXT = Opcode.TEXT
+        self._OP_BINARY = Opcode.BINARY
+        self.protocol = protocol
+        self.fd = sock_fd
+        self.lock = threading.Lock()
+        # every frame the protocol writes from now on (ping/pong/close included)
+        # goes through us: single writer, no transport.write interleaving
+        protocol.write_frame_sync = self._write_frame_sync
+
+    @classmethod
+    def try_create(cls, ws: Any) -> Optional["SyncFrameWriter"]:
+        """ws is a starlette WebSocket; returns None (with one log) when unsupported."""
+        protocol = _find_websockets_protocol(getattr(ws, "_send", None))
+        if protocol is None:
+            _log_unavailable_once("uvicorn websockets protocol not found; wsproto or unknown server?")
+            return None
+        transport = getattr(protocol, "transport", None)
+        if transport is None:
+            _log_unavailable_once("protocol has no transport")
+            return None
+        if transport.get_extra_info("ssl_object") is not None:
+            _log_unavailable_once("TLS is terminated in-process; raw fd writes would bypass it")
+            return None
+        sock: Optional[socket.socket] = transport.get_extra_info("socket")
+        if sock is None:
+            _log_unavailable_once("transport exposes no socket")
+            return None
+        if transport.get_write_buffer_size() > 0:
+            # pending asyncio-buffered bytes (handshake tail) would reorder with
+            # our direct writes; extremely unlikely at kernel-connect time
+            _log_unavailable_once("transport write buffer not empty at connection setup")
+            return None
+        logger.info("sync_ws_write active for this connection")
+        return cls(protocol, sock.fileno())
+
+    # -- the funnel (replaces protocol.write_frame_sync, same signature) --------
+    def _write_frame_sync(self, fin: bool, opcode: int, data: bytes) -> None:
+        frame = self._Frame(fin, opcode, data)
+        with self.lock:
+            frame.write(self._os_write, mask=self.protocol.is_client, extensions=self.protocol.extensions)
+
+    def _os_write(self, data: bytes) -> None:
+        view = memoryview(data)
+        while view:
+            try:
+                n = os.write(self.fd, view)
+                view = view[n:]
+            except BlockingIOError as e:
+                if e.errno not in (errno.EAGAIN, errno.EWOULDBLOCK):
+                    raise
+                # socket buffer full: block the sending thread briefly
+                # (backpressure), not the event loop
+                time.sleep(0.0005)
+            except InterruptedError:
+                continue
+
+    # -- used by WebsocketWrapper.send_text/send_bytes ---------------------------
+    def send_text(self, data: str) -> None:
+        self._write_frame_sync(True, self._OP_TEXT, data.encode())
+
+    def send_bytes(self, data: bytes) -> None:
+        self._write_frame_sync(True, self._OP_BINARY, data)

--- a/solara/server/sync_ws_write.py
+++ b/solara/server/sync_ws_write.py
@@ -97,6 +97,11 @@ class SyncFrameWriter:
     @classmethod
     def try_create(cls, ws: Any) -> Optional["SyncFrameWriter"]:
         """ws is a starlette WebSocket; returns None (with one log) when unsupported."""
+        if os.name != "posix":
+            # os.write on a socket fileno is POSIX-only (Windows sockets are
+            # WSA handles, not CRT file descriptors)
+            _log_unavailable_once("synchronous socket writes require POSIX")
+            return None
         protocol = _find_websockets_protocol(getattr(ws, "_send", None))
         if protocol is None:
             _log_unavailable_once("uvicorn websockets protocol not found; wsproto or unknown server?")

--- a/tests/unit/sync_ws_write_test.py
+++ b/tests/unit/sync_ws_write_test.py
@@ -1,5 +1,6 @@
 """SyncFrameWriter: correct RFC6455 frames, single-writer locking, protocol funnel."""
 
+import os
 import socket
 import threading
 
@@ -8,6 +9,10 @@ import pytest
 websockets = pytest.importorskip("websockets")
 
 from solara.server.sync_ws_write import SyncFrameWriter, _find_websockets_protocol  # noqa: E402
+
+# the writer uses os.write on the socket fd: POSIX-only (and so is the feature;
+# on Windows try_create falls back to the default send path)
+fd_writes = pytest.mark.skipif(os.name != "posix", reason="os.write on sockets requires POSIX")
 
 
 class FakeProtocol:
@@ -45,6 +50,7 @@ def writer_and_peer():
     client_sock.close()
 
 
+@fd_writes
 def test_text_and_binary_frames(writer_and_peer):
     writer, _, peer = writer_and_peer
     writer.send_text("hello sync")
@@ -56,6 +62,7 @@ def test_text_and_binary_frames(writer_and_peer):
     assert (fin, opcode, payload) == (True, 0x2, b"\x00\x01binary")
 
 
+@fd_writes
 def test_large_frame_survives_partial_writes(writer_and_peer):
     writer, _, peer = writer_and_peer
     big = "x" * 300_000  # larger than default socketpair buffers -> EAGAIN path
@@ -74,6 +81,7 @@ def test_large_frame_survives_partial_writes(writer_and_peer):
     assert payload == big.encode()
 
 
+@fd_writes
 def test_protocol_control_frames_share_the_funnel(writer_and_peer):
     """ping/close written by the protocol go through the same patched writer."""
     writer, protocol, peer = writer_and_peer

--- a/tests/unit/sync_ws_write_test.py
+++ b/tests/unit/sync_ws_write_test.py
@@ -1,0 +1,107 @@
+"""SyncFrameWriter: correct RFC6455 frames, single-writer locking, protocol funnel."""
+
+import socket
+import threading
+
+import pytest
+
+websockets = pytest.importorskip("websockets")
+
+from solara.server.sync_ws_write import SyncFrameWriter, _find_websockets_protocol  # noqa: E402
+
+
+class FakeProtocol:
+    """Just enough of websockets.legacy.protocol for the writer: no extensions."""
+
+    is_client = False
+    extensions: list = []
+
+    def write_frame_sync(self, fin, opcode, data):  # replaced by the writer
+        raise AssertionError("should have been patched")
+
+
+def recv_frame(sock: socket.socket):
+    header = sock.recv(2)
+    fin = bool(header[0] & 0x80)
+    opcode = header[0] & 0x0F
+    length = header[1] & 0x7F
+    if length == 126:
+        length = int.from_bytes(sock.recv(2), "big")
+    elif length == 127:
+        length = int.from_bytes(sock.recv(8), "big")
+    payload = b""
+    while len(payload) < length:
+        payload += sock.recv(length - len(payload))
+    return fin, opcode, payload
+
+
+@pytest.fixture()
+def writer_and_peer():
+    server_sock, client_sock = socket.socketpair()
+    protocol = FakeProtocol()
+    writer = SyncFrameWriter(protocol, server_sock.fileno())
+    yield writer, protocol, client_sock
+    server_sock.close()
+    client_sock.close()
+
+
+def test_text_and_binary_frames(writer_and_peer):
+    writer, _, peer = writer_and_peer
+    writer.send_text("hello sync")
+    fin, opcode, payload = recv_frame(peer)
+    assert (fin, opcode, payload) == (True, 0x1, b"hello sync")
+
+    writer.send_bytes(b"\x00\x01binary")
+    fin, opcode, payload = recv_frame(peer)
+    assert (fin, opcode, payload) == (True, 0x2, b"\x00\x01binary")
+
+
+def test_large_frame_survives_partial_writes(writer_and_peer):
+    writer, _, peer = writer_and_peer
+    big = "x" * 300_000  # larger than default socketpair buffers -> EAGAIN path
+
+    received = {}
+
+    def drain():
+        received["frame"] = recv_frame(peer)
+
+    t = threading.Thread(target=drain)
+    t.start()
+    writer.send_text(big)
+    t.join(timeout=10)
+    fin, opcode, payload = received["frame"]
+    assert fin and opcode == 0x1
+    assert payload == big.encode()
+
+
+def test_protocol_control_frames_share_the_funnel(writer_and_peer):
+    """ping/close written by the protocol go through the same patched writer."""
+    writer, protocol, peer = writer_and_peer
+    protocol.write_frame_sync(True, 0x9, b"ping-payload")  # as the loop would
+    fin, opcode, payload = recv_frame(peer)
+    assert (fin, opcode, payload) == (True, 0x9, b"ping-payload")
+
+
+def test_find_protocol_unwraps_closures():
+    from websockets.legacy.protocol import WebSocketCommonProtocol
+
+    class P(WebSocketCommonProtocol):
+        def __init__(self):  # skip the real (loop-requiring) init
+            pass
+
+    protocol = P()
+
+    async def asgi_send(msg):  # bound-method stand-in
+        pass
+
+    bound = protocol.connection_lost.__get__(protocol)  # any bound method of P
+
+    def middleware_wrap(send):
+        async def sender(message):
+            await send(message)
+
+        return sender
+
+    wrapped = middleware_wrap(middleware_wrap(bound))
+    assert _find_websockets_protocol(wrapped) is protocol
+    assert _find_websockets_protocol(middleware_wrap(asgi_send)) is None


### PR DESCRIPTION
## Why

The default send path schedules every websocket message on the event loop — `portal.call` per message from the render thread: a thread handoff, an asyncio task, and a loop wakeup each. A page render sends hundreds of messages. Layer-removal experiments on a production-image container at `--cpus=1` (a large solara application, ~160 messages/load) put numbers on it:

| send path | page render wall |
|---|---|
| default (blocking portal per message) | ~240 ms |
| fire-and-forget task per message | ~210 ms |
| `call_soon_threadsafe` + `transport.write` | ~160 ms |
| **raw synchronous socket writes** | **~115 ms** |
| serialize only, sends dropped | ~110 ms |

The actual socket writes cost ~5 ms; everything above that is per-message async machinery. (For scale: the entire widget construction + serialization compute is ~72 ms on that hardware.)

## How

`write_frame_sync` on uvicorn's websockets protocol object is the single funnel **every** post-handshake frame already goes through — data, ping/pong, close (see `websockets/legacy/protocol.py`) — and it applies the negotiated permessage-deflate via `Frame.write(..., extensions=...)`. With `SOLARA_SERVER_SYNC_WS_WRITE=true` (default **off**), we replace it *per connection* with a lock-serialized version that writes the socket fd with a blocking EAGAIN-retry loop instead of `transport.write`:

- loop-originated control frames and render-thread data frames go through the same lock → no mid-frame interleaving, deflate context stays single-threaded
- the asyncio transport is never handed bytes after the patch; **reads stay fully on the event loop**
- backpressure = the OS socket buffer (a slow client blocks the sending thread, no unbounded queue)

Falls back to the default path (one log line) when: uvicorn runs `wsproto`, TLS terminates in-process (raw fd writes would bypass it; TLS-terminating proxies in front are fine), or the protocol object can't be found.

## Measured

Same container, interleaved A/B, medians of 5 loads per round:

| round | baseline | `SOLARA_SERVER_SYNC_WS_WRITE` |
|---|---|---|
| 1 | 283 ms | 189 ms |
| 2 | 250 ms | 184 ms |
| 3 | 404 ms | 189 ms |
| 4 | 275 ms | 226 ms |

**~30% faster, and markedly more stable under host contention** — the per-message loop wakeups are exactly what contention amplifies (note the baseline's 250–404 ms spread vs 184–226 ms).

## Tests

`tests/unit/sync_ws_write_test.py`: RFC6455 frame correctness over a socketpair (text/binary), a 300 KB frame exercising the partial-write/EAGAIN path, protocol control frames sharing the funnel, and the middleware-closure unwrap that locates uvicorn's protocol. Full unit suite: no new failures vs master. Also verified end-to-end in the container above: engagement per connection, deflate active, clean disconnects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)