### PR TITLE
refactor: give use_task a component-scoped result store instead of cleanup code

### DIFF
--- a/solara/tasks.py
+++ b/solara/tasks.py
@@ -203,7 +203,25 @@ class Task(Generic[P, R], abc.ABC):
     def is_current(self) -> bool: ...
 
     def _prestart(self):
-        self._result.value = TaskResult[R](latest=self._last_value, _state=TaskState.STARTING)
+        self._set_result(TaskResult[R](latest=self._last_value, _state=TaskState.STARTING))
+
+    # set by _drop_call_state (use_task component unmount); a worker thread that already
+    # passed its is_current() check must not resurrect the cleared store entry
+    _call_state_dropped = False
+
+    def _set_result(self, result: "TaskResult[R]") -> None:
+        """Write the task result, without racing a use_task unmount cleanup.
+
+        The unmount cleanup clears this task's kernel-store entries, but a worker thread
+        that passed its is_current() check just before the cleanup ran would re-create the
+        entry with its write - pinning the result (and everything it references) until the
+        kernel closes. Re-checking after the write makes the last writer lose in every
+        interleaving: either the cleanup clears after our write, or we see the dropped flag
+        (set before the cleanup clears) and clear our own write again.
+        """
+        self._result.value = result
+        if self._call_state_dropped:
+            self._result._storage.clear()
 
 
 class _CancelledErrorInOurTask(BaseException):
@@ -254,7 +272,7 @@ class TaskAsyncio(Task[P, R]):
                     raise _CancelledErrorInOurTask()
                 else:
                     current_task.cancel()
-                    self._result.value = TaskResult[R](latest=self._last_value, _state=TaskState.CANCELLED)
+                    self._set_result(TaskResult[R](latest=self._last_value, _state=TaskState.CANCELLED))
             else:
                 try:
                     running_loop: Optional[asyncio.AbstractEventLoop] = asyncio.get_running_loop()
@@ -273,7 +291,7 @@ class TaskAsyncio(Task[P, R]):
                     except RuntimeError:
                         # the loop is already closed: the task's thread is gone with it
                         pass
-                self._result.value = TaskResult[R](latest=self._last_value, _state=TaskState.CANCELLED)
+                self._set_result(TaskResult[R](latest=self._last_value, _state=TaskState.CANCELLED))
 
         self._cancel = cancel
         self._retry = retry
@@ -349,12 +367,12 @@ class TaskAsyncio(Task[P, R]):
                     # selector file descriptor until the garbage collector gets to it
                     thread_event_loop.close()
 
-            self._result.value = TaskResult[R](latest=self._last_value, _state=TaskState.STARTING)
+            self._set_result(TaskResult[R](latest=self._last_value, _state=TaskState.STARTING))
             thread = threading.Thread(target=runs_in_thread, daemon=True, name=f"TaskAsyncio-{self.function.__name__}")
             thread.start()
         else:
             self.current_task = current_task = asyncio.create_task(self._async_run(call_event_loop, future, args, kwargs))
-            self._result.value = TaskResult[R](latest=self._last_value, _state=TaskState.STARTING)
+            self._set_result(TaskResult[R](latest=self._last_value, _state=TaskState.STARTING))
 
     def is_current(self):
         running_task = self.current_task
@@ -371,6 +389,9 @@ class TaskAsyncio(Task[P, R]):
         # the context graph into one big reference cycle that has to wait for a gen-2 gc
         # (measured as a memory sawtooth under load). Drop the call bookkeeping at close
         # so plain refcounting can free the context right away.
+        # The flag must be set before the cleanup clears the stores: a worker thread that
+        # passed its is_current() check re-checks it after writing (see _set_result).
+        self._call_state_dropped = True
         self.current_task = None
         self.current_future = None
         self._cancel = None
@@ -423,21 +444,21 @@ class TaskAsyncio(Task[P, R]):
         task_for_this_call = _get_current_task()
         assert task_for_this_call is not None
         if self.is_current():
-            self._result.value = TaskResult[R](latest=self._last_value, _state=TaskState.STARTING)
+            self._set_result(TaskResult[R](latest=self._last_value, _state=TaskState.STARTING))
 
         async def runner():
             try:
                 if self.is_current():
-                    self._result.value = TaskResult[R](latest=self._last_value, _state=TaskState.RUNNING)
+                    self._set_result(TaskResult[R](latest=self._last_value, _state=TaskState.RUNNING))
                 self._last_value = value = await self.function(*args, **kwargs)
                 if self.is_current() and not task_for_this_call.cancelled():  # type: ignore
-                    self._result.value = TaskResult[R](value=value, latest=value, _state=TaskState.FINISHED, progress=self._last_progress)
+                    self._set_result(TaskResult[R](value=value, latest=value, _state=TaskState.FINISHED, progress=self._last_progress))
                 logger.info("setting result to %r", value)
                 self._finish_future_threadsafe(call_event_loop, future, lambda f: f.set_result(value), "result")
             except Exception as e:
                 if self.is_current():
                     logger.exception(e)
-                    self._result.value = TaskResult[R](latest=self._last_value, exception=e, _state=TaskState.ERROR)
+                    self._set_result(TaskResult[R](latest=self._last_value, exception=e, _state=TaskState.ERROR))
                 # bind to a fresh name: `e` is unbound when the except block exits,
                 # but the delivery lambda runs later on the call loop
                 exception = e
@@ -450,7 +471,7 @@ class TaskAsyncio(Task[P, R]):
             # But... if we call cancel in our own task, we still need to do it from this place
             except _CancelledErrorInOurTask:
                 if self.is_current():
-                    self._result.value = TaskResult[R](latest=self._last_value, _state=TaskState.CANCELLED)
+                    self._set_result(TaskResult[R](latest=self._last_value, _state=TaskState.CANCELLED))
                 self._finish_future_threadsafe(call_event_loop, future, lambda f: f.cancel(), "cancellation")
 
         await runner()
@@ -504,7 +525,7 @@ class TaskThreaded(Task[P, R]):
             self._current_thread = current_thread = threading.Thread(
                 target=lambda: self._run(_last_finished_event, previous_thread, cancel_event, args, kwargs), daemon=False
             )
-        self._result.value = TaskResult[R](latest=self._last_value, _state=TaskState.STARTING)
+        self._set_result(TaskResult[R](latest=self._last_value, _state=TaskState.STARTING))
         current_thread.start()
 
     def is_current(self):
@@ -521,6 +542,7 @@ class TaskThreaded(Task[P, R]):
         # See TaskAsyncio._drop_call_state: called when a use_task component unmounts, so
         # a stale worker thread stops updating state (is_current() returns False) and the
         # call bookkeeping does not outlive the component.
+        self._call_state_dropped = True
         self._current_thread = None
         self._current_cancel_event = None
         self._last_finished_event = None
@@ -538,14 +560,14 @@ class TaskThreaded(Task[P, R]):
             if wait_on_previous:
                 if previous_thread and previous_thread.is_alive():
                     if self.is_current():
-                        self._result.value = TaskResult[R](latest=self._last_value, _state=TaskState.WAITING)
+                        self._set_result(TaskResult[R](latest=self._last_value, _state=TaskState.WAITING))
                     # don't start before the previous is stopped
                     try:
                         previous_thread.join()
                     except:  # noqa
                         pass
             if self.is_current():
-                self._result.value = TaskResult[R](latest=self._last_value, _state=TaskState.RUNNING)
+                self._set_result(TaskResult[R](latest=self._last_value, _state=TaskState.RUNNING))
             else:
                 # early stop
                 return
@@ -569,20 +591,20 @@ class TaskThreaded(Task[P, R]):
                                 with guard:
                                     self._last_value = value = next(generator)
                                     if self.is_current():
-                                        self._result.value = TaskResult[R](latest=value, value=value, _state=TaskState.RUNNING, progress=self._last_progress)
+                                        self._set_result(TaskResult[R](latest=value, value=value, _state=TaskState.RUNNING, progress=self._last_progress))
                             except StopIteration:
                                 break
                         if self.is_current():
-                            self._result.value = TaskResult[R](latest=self._last_value, _state=TaskState.FINISHED, progress=self._last_progress)
+                            self._set_result(TaskResult[R](latest=self._last_value, _state=TaskState.FINISHED, progress=self._last_progress))
                     else:
                         self._last_value = value
                         if self.is_current():
-                            self._result.value = TaskResult[R](latest=value, value=value, _state=TaskState.FINISHED, progress=self._last_progress)
+                            self._set_result(TaskResult[R](latest=value, value=value, _state=TaskState.FINISHED, progress=self._last_progress))
                 except Exception as e:
                     if self.is_current():
                         logger.exception(e)
                         self._last_value = None
-                        self._result.value = TaskResult[R](latest=self._last_value, exception=e, _state=TaskState.ERROR)
+                        self._set_result(TaskResult[R](latest=self._last_value, exception=e, _state=TaskState.ERROR))
                     return
                 except solara.util.CancelledError:
                     pass
@@ -593,7 +615,7 @@ class TaskThreaded(Task[P, R]):
                     self.running_thread = None
                     logger.info("thread done!")
                     if cancel_event.is_set():
-                        self._result.value = TaskResult[R](latest=self._last_value, _state=TaskState.CANCELLED)
+                        self._set_result(TaskResult[R](latest=self._last_value, _state=TaskState.CANCELLED))
                 _last_finished_event.set()
 
         try:
@@ -1087,23 +1109,29 @@ def use_task(
                 # unlike a module-level @task (one instance per process), this task instance
                 # belongs to this component instance: drop everything that outlives the
                 # component, or a session that mounts/unmounts components leaks a task
-                # instance + its result per mount:
-                # 1. drop the call state FIRST: that makes is_current() False, so a still
-                #    running call stops updating state, and a worker thread that is just
-                #    finishing skips its result write instead of recreating the store entry
-                #    we clear below. Deliberately no cancel(): its called-from-our-own-task
-                #    detection misfires when this cleanup runs inside the task's own render
-                #    cascade (a result write triggering the unmounting render), raising
-                #    _CancelledErrorInOurTask through the render machinery. An orphaned call
-                #    running to completion unobserved matches the pre-cleanup behavior.
-                task_instance._drop_call_state()  # type: ignore
+                # instance + its result per mount.
+                # Resolve the actual instance ONCE, before clearing anything: task_instance
+                # is a Proxy, and any attribute access on it after the singleton entry is
+                # cleared would make Singleton.get() re-create the entry via the factory.
                 singleton = task_instance._instance  # type: ignore
+                instance = singleton.value
+                # 1. drop the call state FIRST: that makes is_current() False, so a still
+                #    running call stops updating state, and a worker thread that already
+                #    passed its is_current() check re-clears its own write (see
+                #    Task._set_result). Deliberately no cancel(): its
+                #    called-from-our-own-task detection misfires when this cleanup runs
+                #    inside the task's own render cascade (a result write triggering the
+                #    unmounting render), raising _CancelledErrorInOurTask through the render
+                #    machinery. An orphaned call running to completion unobserved matches
+                #    the pre-cleanup behavior.
+                instance._drop_call_state()
                 # 2. the process-global on_kernel_start registration (pins the instance forever)
                 singleton._on_kernel_start_cleanup()
                 # 3. this kernel's entries in the kernel stores (pinned until kernel close):
-                #    the instance itself, and its TaskResult (which holds .value/.latest)
+                #    the TaskResult (which holds .value/.latest), then the instance itself -
+                #    the singleton entry LAST, so nothing re-creates it afterwards
+                instance._result._storage.clear()
                 singleton._storage.clear()
-                task_instance._result._storage.clear()  # type: ignore
 
             return cleanup
 

--- a/solara/tasks.py
+++ b/solara/tasks.py
@@ -117,14 +117,24 @@ class TaskResult(Generic[T]):
 
 
 class Task(Generic[P, R], abc.ABC):
-    def __init__(self, key: str):
-        self._result = solara.Reactive(
-            TaskResult[R](
-                value=None,
-                _state=TaskState.NOTCALLED,
-            ),
-            key="solara.tasks:TaskResult:" + key,
-        )
+    def __init__(self, key: Optional[str] = None, result: Optional[solara.Reactive] = None):
+        if result is not None:
+            # component-scoped (use_task): the result lives in an object owned by the
+            # component's hook state, so it dies with the component - no kernel-store
+            # entry to clean up on unmount, and a worker write that races the unmount
+            # cannot pin anything beyond the object itself
+            self._result: solara.Reactive = result
+        else:
+            # kernel-scoped (module-level @task): one instance per process, one value
+            # per kernel, living in the kernel store
+            assert key is not None
+            self._result = solara.Reactive(
+                TaskResult[R](
+                    value=None,
+                    _state=TaskState.NOTCALLED,
+                ),
+                key="solara.tasks:TaskResult:" + key,
+            )
         self._last_value: Optional[R] = None
         self._last_progress: Optional[float] = None
         self._latest = ref(self._result.fields.latest)
@@ -203,25 +213,7 @@ class Task(Generic[P, R], abc.ABC):
     def is_current(self) -> bool: ...
 
     def _prestart(self):
-        self._set_result(TaskResult[R](latest=self._last_value, _state=TaskState.STARTING))
-
-    # set by _drop_call_state (use_task component unmount); a worker thread that already
-    # passed its is_current() check must not resurrect the cleared store entry
-    _call_state_dropped = False
-
-    def _set_result(self, result: "TaskResult[R]") -> None:
-        """Write the task result, without racing a use_task unmount cleanup.
-
-        The unmount cleanup clears this task's kernel-store entries, but a worker thread
-        that passed its is_current() check just before the cleanup ran would re-create the
-        entry with its write - pinning the result (and everything it references) until the
-        kernel closes. Re-checking after the write makes the last writer lose in every
-        interleaving: either the cleanup clears after our write, or we see the dropped flag
-        (set before the cleanup clears) and clear our own write again.
-        """
-        self._result.value = result
-        if self._call_state_dropped:
-            self._result._storage.clear()
+        self._result.value = TaskResult[R](latest=self._last_value, _state=TaskState.STARTING)
 
 
 class _CancelledErrorInOurTask(BaseException):
@@ -236,10 +228,10 @@ class TaskAsyncio(Task[P, R]):
     _context: Optional["weakref.ReferenceType[solara.server.kernel_context.VirtualKernelContext]"] = None
     _drop_call_state_on_close_registered = False
 
-    def __init__(self, run_in_thread: bool, function: Callable[P, Coroutine[Any, Any, R]], key: str):
+    def __init__(self, run_in_thread: bool, function: Callable[P, Coroutine[Any, Any, R]], key: Optional[str] = None, result: Optional[solara.Reactive] = None):
         self.run_in_thread = run_in_thread
         self.function = function
-        super().__init__(key)
+        super().__init__(key, result=result)
 
     def cancel(self) -> None:
         if self._cancel:
@@ -272,7 +264,7 @@ class TaskAsyncio(Task[P, R]):
                     raise _CancelledErrorInOurTask()
                 else:
                     current_task.cancel()
-                    self._set_result(TaskResult[R](latest=self._last_value, _state=TaskState.CANCELLED))
+                    self._result.value = TaskResult[R](latest=self._last_value, _state=TaskState.CANCELLED)
             else:
                 try:
                     running_loop: Optional[asyncio.AbstractEventLoop] = asyncio.get_running_loop()
@@ -291,7 +283,7 @@ class TaskAsyncio(Task[P, R]):
                     except RuntimeError:
                         # the loop is already closed: the task's thread is gone with it
                         pass
-                self._set_result(TaskResult[R](latest=self._last_value, _state=TaskState.CANCELLED))
+                self._result.value = TaskResult[R](latest=self._last_value, _state=TaskState.CANCELLED)
 
         self._cancel = cancel
         self._retry = retry
@@ -367,12 +359,12 @@ class TaskAsyncio(Task[P, R]):
                     # selector file descriptor until the garbage collector gets to it
                     thread_event_loop.close()
 
-            self._set_result(TaskResult[R](latest=self._last_value, _state=TaskState.STARTING))
+            self._result.value = TaskResult[R](latest=self._last_value, _state=TaskState.STARTING)
             thread = threading.Thread(target=runs_in_thread, daemon=True, name=f"TaskAsyncio-{self.function.__name__}")
             thread.start()
         else:
             self.current_task = current_task = asyncio.create_task(self._async_run(call_event_loop, future, args, kwargs))
-            self._set_result(TaskResult[R](latest=self._last_value, _state=TaskState.STARTING))
+            self._result.value = TaskResult[R](latest=self._last_value, _state=TaskState.STARTING)
 
     def is_current(self):
         running_task = self.current_task
@@ -389,9 +381,6 @@ class TaskAsyncio(Task[P, R]):
         # the context graph into one big reference cycle that has to wait for a gen-2 gc
         # (measured as a memory sawtooth under load). Drop the call bookkeeping at close
         # so plain refcounting can free the context right away.
-        # The flag must be set before the cleanup clears the stores: a worker thread that
-        # passed its is_current() check re-checks it after writing (see _set_result).
-        self._call_state_dropped = True
         self.current_task = None
         self.current_future = None
         self._cancel = None
@@ -444,21 +433,21 @@ class TaskAsyncio(Task[P, R]):
         task_for_this_call = _get_current_task()
         assert task_for_this_call is not None
         if self.is_current():
-            self._set_result(TaskResult[R](latest=self._last_value, _state=TaskState.STARTING))
+            self._result.value = TaskResult[R](latest=self._last_value, _state=TaskState.STARTING)
 
         async def runner():
             try:
                 if self.is_current():
-                    self._set_result(TaskResult[R](latest=self._last_value, _state=TaskState.RUNNING))
+                    self._result.value = TaskResult[R](latest=self._last_value, _state=TaskState.RUNNING)
                 self._last_value = value = await self.function(*args, **kwargs)
                 if self.is_current() and not task_for_this_call.cancelled():  # type: ignore
-                    self._set_result(TaskResult[R](value=value, latest=value, _state=TaskState.FINISHED, progress=self._last_progress))
+                    self._result.value = TaskResult[R](value=value, latest=value, _state=TaskState.FINISHED, progress=self._last_progress)
                 logger.info("setting result to %r", value)
                 self._finish_future_threadsafe(call_event_loop, future, lambda f: f.set_result(value), "result")
             except Exception as e:
                 if self.is_current():
                     logger.exception(e)
-                    self._set_result(TaskResult[R](latest=self._last_value, exception=e, _state=TaskState.ERROR))
+                    self._result.value = TaskResult[R](latest=self._last_value, exception=e, _state=TaskState.ERROR)
                 # bind to a fresh name: `e` is unbound when the except block exits,
                 # but the delivery lambda runs later on the call loop
                 exception = e
@@ -471,7 +460,7 @@ class TaskAsyncio(Task[P, R]):
             # But... if we call cancel in our own task, we still need to do it from this place
             except _CancelledErrorInOurTask:
                 if self.is_current():
-                    self._set_result(TaskResult[R](latest=self._last_value, _state=TaskState.CANCELLED))
+                    self._result.value = TaskResult[R](latest=self._last_value, _state=TaskState.CANCELLED)
                 self._finish_future_threadsafe(call_event_loop, future, lambda f: f.cancel(), "cancellation")
 
         await runner()
@@ -484,8 +473,8 @@ class TaskThreaded(Task[P, R]):
     _cancel: Optional[Callable[[], None]] = None
     _retry: Optional[Callable[[], None]] = None
 
-    def __init__(self, function: Callable[P, R], key: str):
-        super().__init__(key)
+    def __init__(self, function: Callable[P, R], key: Optional[str] = None, result: Optional[solara.Reactive] = None):
+        super().__init__(key, result=result)
         self.__qualname__ = function.__qualname__
         self.function = function
         self.lock = threading.Lock()
@@ -525,7 +514,7 @@ class TaskThreaded(Task[P, R]):
             self._current_thread = current_thread = threading.Thread(
                 target=lambda: self._run(_last_finished_event, previous_thread, cancel_event, args, kwargs), daemon=False
             )
-        self._set_result(TaskResult[R](latest=self._last_value, _state=TaskState.STARTING))
+        self._result.value = TaskResult[R](latest=self._last_value, _state=TaskState.STARTING)
         current_thread.start()
 
     def is_current(self):
@@ -542,7 +531,6 @@ class TaskThreaded(Task[P, R]):
         # See TaskAsyncio._drop_call_state: called when a use_task component unmounts, so
         # a stale worker thread stops updating state (is_current() returns False) and the
         # call bookkeeping does not outlive the component.
-        self._call_state_dropped = True
         self._current_thread = None
         self._current_cancel_event = None
         self._last_finished_event = None
@@ -560,14 +548,14 @@ class TaskThreaded(Task[P, R]):
             if wait_on_previous:
                 if previous_thread and previous_thread.is_alive():
                     if self.is_current():
-                        self._set_result(TaskResult[R](latest=self._last_value, _state=TaskState.WAITING))
+                        self._result.value = TaskResult[R](latest=self._last_value, _state=TaskState.WAITING)
                     # don't start before the previous is stopped
                     try:
                         previous_thread.join()
                     except:  # noqa
                         pass
             if self.is_current():
-                self._set_result(TaskResult[R](latest=self._last_value, _state=TaskState.RUNNING))
+                self._result.value = TaskResult[R](latest=self._last_value, _state=TaskState.RUNNING)
             else:
                 # early stop
                 return
@@ -591,20 +579,20 @@ class TaskThreaded(Task[P, R]):
                                 with guard:
                                     self._last_value = value = next(generator)
                                     if self.is_current():
-                                        self._set_result(TaskResult[R](latest=value, value=value, _state=TaskState.RUNNING, progress=self._last_progress))
+                                        self._result.value = TaskResult[R](latest=value, value=value, _state=TaskState.RUNNING, progress=self._last_progress)
                             except StopIteration:
                                 break
                         if self.is_current():
-                            self._set_result(TaskResult[R](latest=self._last_value, _state=TaskState.FINISHED, progress=self._last_progress))
+                            self._result.value = TaskResult[R](latest=self._last_value, _state=TaskState.FINISHED, progress=self._last_progress)
                     else:
                         self._last_value = value
                         if self.is_current():
-                            self._set_result(TaskResult[R](latest=value, value=value, _state=TaskState.FINISHED, progress=self._last_progress))
+                            self._result.value = TaskResult[R](latest=value, value=value, _state=TaskState.FINISHED, progress=self._last_progress)
                 except Exception as e:
                     if self.is_current():
                         logger.exception(e)
                         self._last_value = None
-                        self._set_result(TaskResult[R](latest=self._last_value, exception=e, _state=TaskState.ERROR))
+                        self._result.value = TaskResult[R](latest=self._last_value, exception=e, _state=TaskState.ERROR)
                     return
                 except solara.util.CancelledError:
                     pass
@@ -615,7 +603,7 @@ class TaskThreaded(Task[P, R]):
                     self.running_thread = None
                     logger.info("thread done!")
                     if cancel_event.is_set():
-                        self._set_result(TaskResult[R](latest=self._last_value, _state=TaskState.CANCELLED))
+                        self._result.value = TaskResult[R](latest=self._last_value, _state=TaskState.CANCELLED)
                 _last_finished_event.set()
 
         try:
@@ -1098,44 +1086,41 @@ def use_task(
 
     def wrapper(f):
         def create_task() -> "Task[[], R]":
-            return task(f, prefer_threaded=prefer_threaded, check_for_render_context=False)
+            # Unlike a module-level @task (Proxy -> Singleton -> kernel store: one instance
+            # per process, one value per kernel), this task belongs to one component
+            # instance. Everything is therefore component-scoped by construction: the
+            # instance lives in this use_memo, and the result lives in a SharedStore
+            # OBJECT held by the instance - not in the kernel store dict. Unmount drops
+            # the hook state and everything dies by refcount: no lifecycle registration
+            # to undo, no store entries to clear, and a worker thread finishing after
+            # unmount writes into an object that is already garbage - it cannot pin
+            # anything beyond itself. (This mirrors how use_reactive scopes its state.)
+            from solara._stores import MutateDetectorStore, SharedStore, StoreValue, _PublicValueNotSet, _SetValueNotSet
+            from solara.toestand import ValueBase
+
+            initial = TaskResult[R](value=None, _state=TaskState.NOTCALLED)
+            store: ValueBase
+            if solara.settings.storage.mutation_detection is True:
+                shared_store = SharedStore[StoreValue[TaskResult[R]]](
+                    StoreValue[TaskResult[R]](
+                        private=initial, public=_PublicValueNotSet(), get_traceback=None, set_value=_SetValueNotSet(), set_traceback=None
+                    ),
+                    unwrap=lambda x: x.private,
+                )
+                store = MutateDetectorStore[TaskResult[R]](shared_store)
+            else:
+                store = SharedStore(initial)
+            result = solara.Reactive(store)
+            # no runtime generic subscription: TaskAsyncio[[], R] raises TypeError on
+            # Python <= 3.9 (ParamSpec arguments in subscripts are 3.10+ at runtime)
+            if inspect.iscoroutinefunction(f):
+                return cast("Task[[], R]", TaskAsyncio(prefer_threaded and has_threads, f, result=result))
+            else:
+                return cast("Task[[], R]", TaskThreaded(cast(Callable[[], R], f), result=result))
 
         task_instance = solara.use_memo(create_task, dependencies=[])
         # we always update the function so we do not have stale data in the function
         task_instance.function = f  # type: ignore
-
-        def cleanup_on_unmount():
-            def cleanup():
-                # unlike a module-level @task (one instance per process), this task instance
-                # belongs to this component instance: drop everything that outlives the
-                # component, or a session that mounts/unmounts components leaks a task
-                # instance + its result per mount.
-                # Resolve the actual instance ONCE, before clearing anything: task_instance
-                # is a Proxy, and any attribute access on it after the singleton entry is
-                # cleared would make Singleton.get() re-create the entry via the factory.
-                singleton = task_instance._instance  # type: ignore
-                instance = singleton.value
-                # 1. drop the call state FIRST: that makes is_current() False, so a still
-                #    running call stops updating state, and a worker thread that already
-                #    passed its is_current() check re-clears its own write (see
-                #    Task._set_result). Deliberately no cancel(): its
-                #    called-from-our-own-task detection misfires when this cleanup runs
-                #    inside the task's own render cascade (a result write triggering the
-                #    unmounting render), raising _CancelledErrorInOurTask through the render
-                #    machinery. An orphaned call running to completion unobserved matches
-                #    the pre-cleanup behavior.
-                instance._drop_call_state()
-                # 2. the process-global on_kernel_start registration (pins the instance forever)
-                singleton._on_kernel_start_cleanup()
-                # 3. this kernel's entries in the kernel stores (pinned until kernel close):
-                #    the TaskResult (which holds .value/.latest), then the instance itself -
-                #    the singleton entry LAST, so nothing re-creates it afterwards
-                instance._result._storage.clear()
-                singleton._storage.clear()
-
-            return cleanup
-
-        solara.use_effect(cleanup_on_unmount, dependencies=[])
 
         def _prestart():
             if dependencies is not None:

--- a/tests/unit/task_test.py
+++ b/tests/unit/task_test.py
@@ -798,7 +798,9 @@ def test_use_task_unmounted_instance_is_collected(monkeypatch):
                 while len(payload_refs) < n + 1 and time.time() < deadline:
                     await asyncio.sleep(0.01)
                 alive = len(payload_refs)
-                deadline = time.time() + 10
+                # generous deadline: on a loaded 1-2 core CI runner the tiny worker threads
+                # can be starved for seconds by this very loop's gc churn
+                deadline = time.time() + 30
                 while time.time() < deadline:
                     # pytest's LogCaptureHandler retains LogRecords whose args hold the
                     # task results ("setting result to %r"); clear them or they pin the
@@ -811,7 +813,7 @@ def test_use_task_unmounted_instance_is_collected(monkeypatch):
                     alive = sum(1 for ref in payload_refs if ref() is not None)
                     if alive <= 1:  # only the currently mounted instance may hold one
                         break
-                    await asyncio.sleep(0.05)
+                    await asyncio.sleep(0.1)
                 holder["alive"] = alive
                 rc.close()
 


### PR DESCRIPTION
## Summary

Structural alternative to the accumulated `use_task` unmount machinery, per Maarten's "do you see no better way?" — yes: **stop building component-scoped state out of kernel-scoped primitives.**

The dirtiness in #1180/#1185 all traces to one mismatch: `use_task` created a full module-level-style task (Proxy → Singleton → kernel-store entries + process-global lifecycle registration) for state that lives and dies with one component. Every fix was a patch fighting that: unregister the registration, clear the entries in the right order, never touch the Proxy after clearing (`Singleton.get()` re-creates the entry), re-check a dropped flag after every write to beat the worker race.

`use_reactive` never had any of these problems, because it stores component state in a **`SharedStore` object** held by hook state. This PR makes `use_task` do the same:

- `Task.__init__` accepts an optional pre-built result reactive; module-level `@task` is unchanged (kernel scoping is *correct* there).
- `use_task` constructs `TaskAsyncio`/`TaskThreaded` directly with `Reactive(SharedStore(TaskResult()))` (mirroring `use_reactive`'s mutation-detection branch), no Proxy, no Singleton, no registration.
- **Deleted**: the entire unmount cleanup, `_set_result` + `_call_state_dropped` flag+recheck on every write. Unmount cleans up by construction — instance and result die by refcount with the component. A worker thread finishing after unmount writes into an object that is already garbage; it cannot pin anything beyond itself.
- Kept: `_drop_call_state` via `WeakMethod` at kernel close (breaks task→context cycles; genuinely kernel-scoped, from #1176) and #1185's test hardening.

## Diff shape

Net **−17 lines** against the #1185 branch; the *combined* `tasks.py` change vs master is +50/−37 — smaller than the band-aid alone, with fewer concepts to review (no interleaving arguments, no clear-ordering invariants).

## Verification (same battery as the fixes it replaces)

- `test_use_task_unmounted_instance_is_collected`: **120/120** under 4-way CPU contention in solara-2.0 mode (slowest 11.3 s, the benign worker-starvation mode, within the 30 s deadline).
- Full unit suite: 419 passed normal mode, 421 passed solara-2.0 mode.
- ruff/mypy clean.

Based on #1185 so the delta is reviewable on its own; if preferred, #1185 can merge first (already green 34/34) and this retargets to master automatically — or take them together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)