### PR TITLE
fix: task.cancel()/retry() during kernel close must not raise

### DIFF
--- a/solara/tasks.py
+++ b/solara/tasks.py
@@ -236,14 +236,24 @@ class TaskAsyncio(Task[P, R]):
     def cancel(self) -> None:
         if self._cancel:
             self._cancel()
-        else:
+        elif self.not_called:
             raise RuntimeError("Cannot cancel task, never started")
+        else:
+            # the task ran, but the call bookkeeping (including _cancel) is
+            # gone: _drop_call_state ran because the kernel context is closing,
+            # while the reactive state still reads pending. Cleanup code doing
+            # `if task.pending: task.cancel()` during that close must be a
+            # no-op, not an error - there is nothing left to cancel.
+            pass
 
     def retry(self):
         if self._retry:
             self._retry()
-        else:
+        elif self.not_called:
             raise RuntimeError("Cannot retry task, never started")
+        else:
+            # see cancel(): call state dropped at kernel close
+            pass
 
     def __call__(self, *args: P.args, **kwargs: P.kwargs) -> None:
         self._last_progress = None

--- a/tests/unit/task_test.py
+++ b/tests/unit/task_test.py
@@ -951,3 +951,67 @@ def test_task_async_cancel_from_other_thread_wakes_sleeping_loop():
     assert finished.wait(10), "cancel from another thread did not wake the sleeping task loop"
     assert time.monotonic() - t0 < 5
     assert sleeper.cancelled
+
+
+def test_cancel_after_context_close_is_a_noop(monkeypatch):
+    # At kernel close, _drop_call_state (registered via context.on_close) drops the
+    # call bookkeeping - including _cancel - while the reactive state still reads
+    # pending. App code commonly guards on-close cleanup with
+    # `if task.pending: task.cancel()`; arriving a moment after the drop must be a
+    # no-op, not "RuntimeError: Cannot cancel task, never started".
+    monkeypatch.setattr(solara.tasks, "_using_solara_server", lambda: True)
+    proceed = threading.Event()
+    context_holder = {}
+
+    @solara.tasks.task
+    async def runs_forever():
+        while not proceed.is_set():
+            await asyncio.sleep(0.001)
+
+    outcome: dict = {}
+
+    def app_like_guard():
+        # what app cleanup does during kernel close. on_close callbacks run
+        # LIFO, so registering this BEFORE the task starts makes it run AFTER
+        # _drop_call_state (registered at task start) - the production order
+        # where the call bookkeeping is gone but the state still reads pending
+        try:
+            if runs_forever.pending:
+                runs_forever.cancel()
+            outcome["ok"] = True
+        except RuntimeError as e:
+            outcome["error"] = str(e)
+
+    def page_thread():
+        async def run():
+            context = kernel_context.VirtualKernelContext(id="task-cancel-after-close", kernel=kernel.Kernel(), session_id="session-cancel-after-close")
+            context_holder["context"] = context
+            with context:
+                context.on_close(app_like_guard)
+                runs_forever()
+
+        asyncio.run(run())
+
+    try:
+        thread = threading.Thread(target=page_thread)
+        thread.start()
+        thread.join()
+        context = context_holder["context"]
+        with context:
+            assert runs_forever.pending
+        proceed.set()
+        with context:
+            context.close()
+        assert outcome == {"ok": True}, outcome
+    finally:
+        proceed.set()
+
+    # a genuinely never-started task still raises (misuse detection unchanged)
+    @solara.tasks.task
+    async def never_started():
+        pass
+
+    with pytest.raises(RuntimeError, match="never started"):
+        never_started.cancel()
+    with pytest.raises(RuntimeError, match="never started"):
+        never_started.retry()


### PR DESCRIPTION
Found by integration-testing current master in a large solara application: **three tracebacked warnings on every kernel close**, from `RuntimeError: Cannot cancel task, never started`.

## Sequence

1. A `@task` runs; `_drop_call_state` is registered via `context.on_close` (the recent memory fix that unpins contexts at close).
2. Kernel closes → `_drop_call_state` nulls `_cancel`/`_retry`/futures — but the reactive state still reads `pending`.
3. Application cleanup running later in the same close does the natural `if task.pending: task.cancel()` → `cancel()` finds `_cancel is None` → raises "never started", which is wrong on both counts: it started, and there is simply nothing left to cancel.

## Fix

A task that ran always has `_cancel` set, so *state ≠ NOTCALLED with `_cancel is None`* can only mean the call state was dropped at close: `cancel()`/`retry()` are now a no-op in that case, and keep raising only for genuinely never-started tasks (misuse detection unchanged).

The regression test reproduces the production ordering: `on_close` callbacks run LIFO, so a guard registered *before* the task starts runs *after* `_drop_call_state`. Verified: fails on master with exactly the production error, passes with the fix; full task suite (24) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)