### PR TITLE
fix: comm_info_request ignored the target_name filter, leaking control comms to the widget manager

### DIFF
--- a/solara/server/server.py
+++ b/solara/server/server.py
@@ -246,7 +246,10 @@ def process_kernel_messages(kernel: Kernel, msg: Dict) -> bool:
         return True
     elif msg_type in ["comm_info_request"]:
         content = msg["content"]
-        target_name = msg.get("target_name", None)
+        # target_name lives in the message CONTENT (Jupyter protocol); reading it from the
+        # top-level msg made the filter always None, so the reply leaked non-widget comms
+        # (solara.control) to the widget manager, which then request_state's them.
+        target_name = content.get("target_name", None)
 
         comms = {
             k: dict(target_name=v.target_name)

--- a/tests/unit/kernel_test.py
+++ b/tests/unit/kernel_test.py
@@ -55,3 +55,38 @@ def test_comm_close_after_kernel_closed(kernel_context, no_kernel_context):
     # outside the context now: get_comm_manager() resolves to the global manager,
     # which never saw this comm
     c.close()
+
+
+def test_comm_info_request_filters_on_target_name():
+    # The widget manager's fetchAll (_loadFromKernel) asks for comms with
+    # target_name="jupyter.widget" and then sends request_state to every comm id
+    # in the reply. The solara.control comm (run/reload/app-status) must therefore
+    # never appear in that reply: it does not speak the widget protocol, so each
+    # leaked id produces an "Unknown comm method called on solara.control comm:
+    # request_state" error on the server (seen in production since the reconnect
+    # state machine started calling fetchAll on every hot reconnect).
+    from unittest.mock import Mock
+
+    from solara.server import kernel as kernel_mod
+    from solara.server.server import process_kernel_messages
+
+    kernel = kernel_mod.Kernel()
+    try:
+        websocket = Mock()
+        kernel.session.websockets.add(websocket)
+        kernel.shell_stream = kernel_mod.WebsocketStreamWrapper(websocket, "shell")
+        kernel.comm_manager.comms["widget-comm-id"] = Mock(target_name="jupyter.widget")  # type: ignore
+        kernel.comm_manager.comms["control-comm-id"] = Mock(target_name="solara.control")  # type: ignore
+
+        msg = kernel.session.msg("comm_info_request", content={"target_name": "jupyter.widget"})
+        msg["channel"] = "shell"
+        process_kernel_messages(kernel, msg)
+
+        replies = [json.loads(call.args[0]) for call in websocket.send.call_args_list]
+        comm_info_replies = [m for m in replies if m["header"]["msg_type"] == "comm_info_reply"]
+        assert len(comm_info_replies) == 1
+        comms = comm_info_replies[0]["content"]["comms"]
+        assert comms == {"widget-comm-id": {"target_name": "jupyter.widget"}}
+    finally:
+        kernel.comm_manager.comms.clear()  # type: ignore
+        kernel.close()


### PR DESCRIPTION
## Summary

Fixes a production error seen on reconnects:

```
Unknown comm method called on solara.control comm: request_state
```

The Jupyter protocol puts `target_name` inside the message **content**, but the `comm_info_request` handler read it from the top-level message dict. The filter was therefore always `None`, and `comm_info_reply` returned every comm on the kernel — including `solara.control` — instead of only the `jupyter.widget` comms the widget manager asked for.

`comm_info` is only consulted on the widget manager's fallback resync path (`_loadFromKernelModels`): the primary path fetches all widget state in bulk over `jupyter.widget.control`, and falls back when that request times out (4s, e.g. a busy kernel) or the kernel runs ipywidgets ≤ 7.6. On that fallback, the client sends `request_state` to every comm id in the reply and waits for an `update` per id, with no timeout. A leaked `solara.control` id therefore not only logs the error above — it also breaks the fallback itself: the control comm never answers, so the resync never completes, and a leaked id that is still registered on the client connection makes `createComm` throw `Comm is already created`, rejecting the whole batch (the same mid-map failure mode the `purgeStaleComms` comment in `main-vuetify.js` describes for stale widget comms).

The bug is ancient, but it only became visible now: the reconnect state machine (#1171) calls `fetchAll()` on every hot reconnect (RESUME), at a point where control comms are always open (the long-lived run/reload comm, plus the never-closed app-status probe comms). It is unrelated to running on multiple machines — a same-instance reconnect is enough.

## Changes

- `solara/server/server.py`: read `target_name` from `msg["content"]` (which was already extracted but unused).
- `tests/unit/kernel_test.py`: red→green test that registers a `jupyter.widget` comm and a `solara.control` comm and asserts the reply only contains the widget comm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
