### PR TITLE
fix: make reactive subscription lifecycle leak-free

### DIFF
--- a/solara/server/kernel_context.py
+++ b/solara/server/kernel_context.py
@@ -18,6 +18,7 @@ import re
 import threading
 import time
 import typing
+import weakref
 from pathlib import Path
 from typing import Any, Callable, DefaultDict, Dict, List, Optional, Tuple, Union, cast
 
@@ -52,6 +53,13 @@ else:
 class PageStatus(enum.Enum):
     CONNECTED = "connected"
     DISCONNECTED = "disconnected"
+    CLOSED = "closed"
+
+
+class _LifecycleState(enum.Enum):
+    OPEN = "open"
+    RESTARTING = "restarting"
+    CLOSING = "closing"
     CLOSED = "closed"
 
 
@@ -120,6 +128,9 @@ class VirtualKernelContext:
     _teardown_lock: threading.Lock = dataclasses.field(default_factory=threading.Lock)
     _teardown_done: bool = False
     _on_close_callbacks: List[Callable[[], None]] = dataclasses.field(default_factory=list)
+    _lifecycle_lock: threading.Lock = dataclasses.field(default_factory=threading.Lock)
+    _lifecycle_state: _LifecycleState = _LifecycleState.OPEN
+    _generation_stores: Dict[int, Tuple["weakref.ReferenceType[Any]", str, Optional[Callable[[Any], None]], bool]] = dataclasses.field(default_factory=dict)
     lock: threading.RLock = dataclasses.field(default_factory=threading.RLock)
     event_loop: asyncio.AbstractEventLoop = dataclasses.field(default_factory=_get_or_create_event_loop)
 
@@ -131,18 +142,117 @@ class VirtualKernelContext:
                     self.on_close(cleanup)
 
     def restart(self):
-        # should we do this, or maybe close the context and create a new one?
-        with self:
-            for f in reversed(self._on_close_callbacks):
-                f()
-            self._on_close_callbacks.clear()
-            self.__post_init__()
+        with self._lifecycle_lock:
+            if self._lifecycle_state is not _LifecycleState.OPEN:
+                return
+            self._lifecycle_state = _LifecycleState.RESTARTING
+            callbacks = self._on_close_callbacks
+            self._on_close_callbacks = []
+
+        error = self._run_close_callbacks(callbacks)
+        try:
+            self._clear_generation_stores()
+            with self._lifecycle_lock:
+                initialize = self._lifecycle_state is _LifecycleState.RESTARTING
+            if initialize:
+                self.__post_init__()
+        except BaseException as caught:
+            if error is None:
+                error = caught
+        finally:
+            with self._lifecycle_lock:
+                if self._lifecycle_state is _LifecycleState.RESTARTING:
+                    self._lifecycle_state = _LifecycleState.OPEN
+                    finish_close = False
+                else:
+                    finish_close = self._lifecycle_state is _LifecycleState.CLOSING
+            if finish_close:
+                self._finish_close()
+        if error is not None:
+            raise error
 
     def display(self, *args):
         print(args)  # noqa
 
     def on_close(self, f: Callable[[], None]):
-        self._on_close_callbacks.append(f)
+        with self._lifecycle_lock:
+            if self._lifecycle_state is _LifecycleState.CLOSED:
+                run_now = True
+            else:
+                self._on_close_callbacks.append(f)
+                run_now = False
+        if run_now:
+            error = self._run_close_callbacks([f])
+            if error is not None:
+                raise error
+
+        context_ref = weakref.ref(self)
+
+        def unregister():
+            context = context_ref()
+            if context is None:
+                return
+            with context._lifecycle_lock:
+                for index, callback in enumerate(context._on_close_callbacks):
+                    if callback is f:
+                        del context._on_close_callbacks[index]
+                        break
+
+        return unregister
+
+    def track_generation_store(self, store: Any, cleanup: Optional[Callable[[Any], None]] = None, *, owned: bool = True) -> None:
+        store_id = id(store)
+        with self._lifecycle_lock:
+            existing = self._generation_stores.get(store_id)
+            if existing is not None:
+                if owned and not existing[3]:
+                    self._generation_stores[store_id] = (existing[0], existing[1], cleanup, True)
+                return
+            context_ref = weakref.ref(self)
+
+            def release(_ref):
+                context = context_ref()
+                if context is not None:
+                    context.release_generation_store(store_id)
+
+            self._generation_stores[store_id] = (weakref.ref(store, release), store.storage_key, cleanup, owned)
+
+    def release_generation_store(self, store_id: int) -> None:
+        with self._lifecycle_lock:
+            entry = self._generation_stores.pop(store_id, None)
+            if entry is None:
+                return
+            _, key, cleanup, _ = entry
+            if any(other_key == key for _, other_key, _, _ in self._generation_stores.values()):
+                return
+            value = self.user_dicts.pop(key, None)
+        if cleanup is not None and value is not None:
+            cleanup(value)
+
+    def _clear_generation_stores(self) -> None:
+        with self._lifecycle_lock:
+            owned_keys = {key for _, key, _, owned in self._generation_stores.values() if owned}
+            persistent_keys = {key for _, key, _, owned in self._generation_stores.values() if not owned}
+            keys = owned_keys - persistent_keys
+            values = [self.user_dicts.pop(key, None) for key in keys]
+        values.clear()
+
+    def _run_close_callbacks(self, callbacks: List[Callable[[], None]]):
+        fatal: Optional[BaseException] = None
+        with self:
+            for callback in reversed(callbacks):
+                try:
+                    callback()
+                except (KeyboardInterrupt, SystemExit) as error:
+                    if fatal is None:
+                        fatal = error
+                except BaseException:
+                    logger.exception("Kernel close callback failed for %s", self.id)
+        return fatal
+
+    def is_closing(self) -> bool:
+        with self._lifecycle_lock:
+            return self._lifecycle_state in (_LifecycleState.CLOSING, _LifecycleState.CLOSED)
 
     async def __aenter__(self):
         stack = async_stack.get()
@@ -218,72 +328,102 @@ class VirtualKernelContext:
             logger.exception("state persistence teardown failed for kernel %s", self.id)
 
     def close(self, reason: str = "unknown"):
-        # persistence teardown MUST happen before we acquire self.lock (backend I/O; §5.3 deadlock
-        # contract). Run it exactly once across concurrent closers, under a dedicated lock so a
-        # loser does not fall through and re-flush; the first closer wins the reason.
+        with self._lifecycle_lock:
+            if self._lifecycle_state in (_LifecycleState.CLOSING, _LifecycleState.CLOSED):
+                return
+            restart_owns_close = self._lifecycle_state is _LifecycleState.RESTARTING
+            self._lifecycle_state = _LifecycleState.CLOSING
+            self.close_reason = reason
+        if restart_owns_close:
+            return
+        self._finish_close()
+
+    def _finish_close(self):
+        fatal: Optional[BaseException] = None
         run_teardown = False
         with self._teardown_lock:
             if not self._teardown_done:
                 self._teardown_done = True
-                self.close_reason = reason
                 run_teardown = True
         if run_teardown:
-            self._teardown_persistence(reason)
-        with self, self.lock:
-            for key in self.page_status:
-                self.page_status[key] = PageStatus.CLOSED
-            if self._last_kernel_cull_task:
-                self._last_kernel_cull_task.cancel()
-                # drop our reference: a cancelled task keeps its CancelledError whose
-                # traceback holds the kernel_cull frame, whose closure holds `self` -
-                # keeping the reference would turn that into a reference cycle through
-                # the whole context, which refcounting cannot free
-                self._last_kernel_cull_task = None
-            if self._last_kernel_cull_future:
-                self._last_kernel_cull_future.cancel()
-                self._last_kernel_cull_future = None
-            if self.closed_event.is_set():
-                logger.error("Tried to close a kernel context that is already closed: %s", self.id)
-                return
+            try:
+                self._teardown_persistence(self.close_reason)
+            except (KeyboardInterrupt, SystemExit) as error:
+                fatal = error
+            except BaseException:
+                logger.exception("State persistence teardown was cancelled for kernel %s", self.id)
+
+        with self:
+            with self.lock:
+                for key in self.page_status:
+                    self.page_status[key] = PageStatus.CLOSED
+                if self._last_kernel_cull_task:
+                    self._last_kernel_cull_task.cancel()
+                    self._last_kernel_cull_task = None
+                if self._last_kernel_cull_future:
+                    self._last_kernel_cull_future.cancel()
+                    self._last_kernel_cull_future = None
+                had_app = self.app_object is not None
+                app_object = self.app_object
+                kernel_to_close = self.kernel
+
             logger.info("Shut down virtual kernel: %s", self.id)
-            for f in reversed(self._on_close_callbacks):
-                f()
-            had_app = self.app_object is not None
-            if self.app_object is not None:
-                if isinstance(self.app_object, reacton.core._RenderContext):
-                    try:
-                        self.app_object.close()
-                    except Exception as e:
-                        logger.exception("Could not close render context: %s", e)
-                        # we want to continue, so we at least close all widgets
-                # drop the reference: anything that still (indirectly) references this
-                # closed context should not keep the whole render tree alive with it
-                self.app_object = None
-            widgets.Widget.close_all()
-            # what if we reference each other
-            # import gc
-            # gc.collect()
-            self.kernel.close()
-            self.kernel = None  # type: ignore
-            # Only remove our OWN slot: a reconnect that raced this close (it treats a closing
-            # context as absent, see initialize_virtual_kernel) may have already installed a fresh
-            # context under this id. Deleting unconditionally would drop the replacement.
-            if contexts.get(self.id) is self:
-                del contexts[self.id]
-            del current_context[get_current_thread_key()]
-            # We saw in memleak_test that there are sometimes other entries in current_context
-            # In which _DummyThread's reference this context, so we remove those references too
-            # TODO: Think about what to do with those Threads
-            _contexts = current_context.copy()
-            for key, _ctx in _contexts.items():
-                if _ctx is self:
-                    del current_context[key]
-            self.closed_event.set()
+            while True:
+                with self._lifecycle_lock:
+                    if not self._on_close_callbacks:
+                        break
+                    callbacks = self._on_close_callbacks
+                    self._on_close_callbacks = []
+                callback_fatal = self._run_close_callbacks(callbacks)
+                if fatal is None:
+                    fatal = callback_fatal
+            self._clear_generation_stores()
+
+            with self.lock:
+                if self.app_object is app_object:
+                    self.app_object = None
+            cleanup_steps = [("widgets", widgets.Widget.close_all), ("kernel", kernel_to_close.close)]
+            if isinstance(app_object, reacton.core._RenderContext):
+                cleanup_steps.insert(0, ("render context", app_object.close))
+            for label, cleanup in cleanup_steps:
+                try:
+                    cleanup()
+                except (KeyboardInterrupt, SystemExit) as error:
+                    if fatal is None:
+                        fatal = error
+                except BaseException:
+                    logger.exception("Could not close %s", label)
+            with self.lock:
+                self.kernel = None  # type: ignore
+
+        if contexts.get(self.id) is self:
+            with _init_lock:
+                if contexts.get(self.id) is self:
+                    del contexts[self.id]
+        for key, context in list(current_context.items()):
+            if context is self:
+                del current_context[key]
+
+        while True:
+            with self._lifecycle_lock:
+                if self._on_close_callbacks:
+                    callbacks = self._on_close_callbacks
+                    self._on_close_callbacks = []
+                else:
+                    self._lifecycle_state = _LifecycleState.CLOSED
+                    self.closed_event.set()
+                    break
+            callback_fatal = self._run_close_callbacks(callbacks)
+            if fatal is None:
+                fatal = callback_fatal
+
         # only when the kernel rendered an app: a bare context holds nothing worth a full
         # collection, and a gc storm from many short-lived contexts (e.g. the unit test
         # suite closes one per test) pauses all threads, breaking timing-sensitive code
         if had_app and solara.server.settings.kernel.gc_after_close:
             _schedule_gc_after_kernel_close()
+        if fatal is not None:
+            raise fatal
 
     def _state_reset(self):
         state_directory = Path(".") / "states"
@@ -309,11 +449,11 @@ class VirtualKernelContext:
                 pickle.dump(state, f)
 
     def page_connect(self, page_id: str):
-        if self.closed_event.is_set():
+        if self.is_closing():
             raise RuntimeError("Cannot connect a page to a closed kernel")
         logger.info("Connect page %s for kernel %s", page_id, self.id)
         with self.lock:
-            if self.closed_event.is_set():
+            if self.is_closing():
                 raise RuntimeError("Cannot connect a page to a closed kernel")
             if page_id in self.page_status and self.page_status.get(page_id) == PageStatus.CLOSED:
                 raise RuntimeError("Cannot connect a page that is already closed")
@@ -831,10 +971,10 @@ def initialize_virtual_kernel(session_id: str, kernel_id: str, websocket: websoc
         # client reconnects on the SAME kernel id (the socket dropped); it needs a FRESH context
         # that restores from the backend, not the doomed one - reusing it would race close() and
         # raise "Cannot connect a page to a closed kernel" in page_connect once closed_event is
-        # set. _teardown_done flips at the very start of close(), before the socket drop that
-        # triggers the reconnect, so it reliably flags the doomed context here. close() guards its
-        # own `del contexts` by identity, so overwriting the slot below is safe.
-        if context is not None and (context._teardown_done or context.closed_event.is_set()):
+        # set. is_closing() also covers close delegated to an in-progress restart, before teardown
+        # begins. close() guards its own `del contexts` by identity, so overwriting the slot below
+        # is safe.
+        if context is not None and (context.is_closing() or context._teardown_done or context.closed_event.is_set()):
             context = None
         mismatch = context is not None and context.session_id != session_id
         newly_created = False

--- a/solara/toestand.py
+++ b/solara/toestand.py
@@ -21,6 +21,7 @@ from typing import (
     ContextManager,
     Dict,
     Generic,
+    List,
     Optional,
     Set,
     Tuple,
@@ -76,14 +77,40 @@ def _managed_subscription():
 class _SubscriptionLeakCheck:
     site: str
     store_name: str
+    kernel_id: str
     resolved: bool = False
+
+
+class _ListenerEntry(Generic[T]):
+    __slots__ = ("listener", "context")
+
+    def __init__(self, listener: Callable, context: "Context"):
+        self.listener = listener
+        self.context = context
 
 
 # per kernel context id: subscriptions to check for leaks when it closes
 # (popped by the on_close report; VirtualKernelContext itself is unhashable)
 _pending_subscription_checks: Dict[str, list] = {}
+_pending_subscription_callbacks: Dict[str, Callable[[], None]] = {}
 _warned_sites: Set[str] = set()
 _internal_packages_paths = None
+
+
+def _resolve_subscription(check: _SubscriptionLeakCheck) -> None:
+    check.resolved = True
+    checks = _pending_subscription_checks.get(check.kernel_id)
+    if checks is None:
+        return
+    try:
+        checks.remove(check)
+    except ValueError:
+        return
+    if not checks:
+        _pending_subscription_checks.pop(check.kernel_id, None)
+        unregister = _pending_subscription_callbacks.pop(check.kernel_id, None)
+        if unregister is not None:
+            unregister()
 
 
 def _warn_once(site: str, message: str):
@@ -161,8 +188,9 @@ class ValueBase(Generic[T]):
     def __init__(self, merge: Callable = merge_state, equals=equals_extra):
         self.merge = merge
         self.equals = equals
-        self.listeners: Dict[str, Set[Tuple[Callable[[T], None], Optional[ContextManager]]]] = defaultdict(set)
-        self.listeners2: Dict[str, Set[Tuple[Callable[[T, T], None], Optional[ContextManager]]]] = defaultdict(set)
+        self.listeners: Dict[str, Set[_ListenerEntry[T]]] = defaultdict(set)
+        self.listeners2: Dict[str, Set[_ListenerEntry[T]]] = defaultdict(set)
+        self._listeners_lock = threading.Lock()
 
     # make sure all boolean operations give type errors
     if not solara.settings.main.allow_reactive_boolean:
@@ -241,19 +269,20 @@ class ValueBase(Generic[T]):
             kernel = nullcontext()
         context = Context(rc, kernel)
 
-        self.listeners[scope_id].add((listener, context))
+        entry: _ListenerEntry[T] = _ListenerEntry(listener, context)
+        with self._listeners_lock:
+            self.listeners[scope_id].add(entry)
         leak_check = self._track_subscription()
 
         def cleanup():
             if leak_check is not None:
-                leak_check.resolved = True
-            entries = self.listeners.get(scope_id)
-            if entries is not None:
-                entries.discard((listener, context))
-                # prune the scope entry itself: unsubscribing must leave no residue,
-                # or every kernel that ever subscribed leaves an empty set behind
-                if not entries:
-                    del self.listeners[scope_id]
+                _resolve_subscription(leak_check)
+            with self._listeners_lock:
+                entries = self.listeners.get(scope_id)
+                if entries is not None:
+                    entries.discard(entry)
+                    if not entries:
+                        self.listeners.pop(scope_id, None)
 
         return cleanup
 
@@ -270,17 +299,20 @@ class ValueBase(Generic[T]):
         else:
             kernel = nullcontext()
         context = Context(rc, kernel)
-        self.listeners2[scope_id].add((listener, context))
+        entry: _ListenerEntry[T] = _ListenerEntry(listener, context)
+        with self._listeners_lock:
+            self.listeners2[scope_id].add(entry)
         leak_check = self._track_subscription()
 
         def cleanup():
             if leak_check is not None:
-                leak_check.resolved = True
-            entries = self.listeners2.get(scope_id)
-            if entries is not None:
-                entries.discard((listener, context))
-                if not entries:
-                    del self.listeners2[scope_id]
+                _resolve_subscription(leak_check)
+            with self._listeners_lock:
+                entries = self.listeners2.get(scope_id)
+                if entries is not None:
+                    entries.discard(entry)
+                    if not entries:
+                        self.listeners2.pop(scope_id, None)
 
         return cleanup
 
@@ -314,13 +346,14 @@ class ValueBase(Generic[T]):
         site = _app_call_site()
         if site is None:
             return None
-        leak_check = _SubscriptionLeakCheck(site, repr(self))
+        leak_check = _SubscriptionLeakCheck(site, repr(self), kernel_context.id)
         checks = _pending_subscription_checks.setdefault(kernel_context.id, [])
         checks.append(leak_check)
         if len(checks) == 1:
             kernel_id = kernel_context.id
 
             def report():
+                _pending_subscription_callbacks.pop(kernel_id, None)
                 for check in _pending_subscription_checks.pop(kernel_id, []):
                     if not check.resolved:
                         _warn_once(
@@ -331,7 +364,11 @@ class ValueBase(Generic[T]):
                             "otherwise the listener and everything it captures leak for the lifetime of the process.",
                         )
 
-            kernel_context.on_close(report)
+            unregister = kernel_context.on_close(report)
+            if kernel_id in _pending_subscription_checks:
+                _pending_subscription_callbacks[kernel_id] = unregister
+            else:
+                unregister()
         return leak_check
 
     def fire(self, new: T, old: T):
@@ -340,20 +377,20 @@ class ValueBase(Generic[T]):
         # .get instead of indexing: these are defaultdicts, and indexing would
         # permanently materialize an empty set for every kernel that ever fires,
         # growing the dicts by one entry per kernel for the process lifetime
-        contexts = set()
-        for listener, context in tuple(self.listeners.get(scope_id, ())):
-            contexts.add(context)
-        for listener2, context in tuple(self.listeners2.get(scope_id, ())):
-            contexts.add(context)
+        with self._listeners_lock:
+            listeners = tuple(self.listeners.get(scope_id, ()))
+            listeners2 = tuple(self.listeners2.get(scope_id, ()))
+        contexts = {entry.context for entry in listeners}
+        contexts.update(entry.context for entry in listeners2)
         if contexts:
             for context in contexts:
                 with context or nullcontext():
-                    for listener, context_listener in tuple(self.listeners.get(scope_id, ())):
-                        if context == context_listener:
-                            listener(new)
-                    for listener2, context_listener in tuple(self.listeners2.get(scope_id, ())):
-                        if context == context_listener:
-                            listener2(new, old)
+                    for entry in listeners:
+                        if context == entry.context:
+                            entry.listener(new)
+                    for entry in listeners2:
+                        if context == entry.context:
+                            entry.listener(new, old)
 
     def update(self, _f=None, **kwargs):
         if _f is not None:
@@ -450,6 +487,9 @@ class KernelStore(ValueBase[S], ABC):
             else:
                 scope_dict = cast(Dict[str, S], context.user_dicts)
                 scope_id = context.id
+                # Persistent module stores can share an explicit key with a transient
+                # store; track them so the transient owner cannot clear their value.
+                context.track_generation_store(self, owned=False)
         return cast(Dict[str, S], scope_dict), scope_id, context
 
     def peek(self):
@@ -866,38 +906,40 @@ class Reactive(ValueBase[S]):
         return Computed(func, key=f.__qualname__)
 
 
-def _on_kernel_start_scoped_to_creator(f: Callable[[], Optional[Callable[[], None]]]) -> Callable[[], None]:
-    """on_kernel_start, but scoped to the creating kernel when there is one.
+def _on_kernel_start_scoped_to_creator(
+    store: KernelStore,
+    f: Callable[[], Optional[Callable[[], None]]],
+    cleanup_value: Optional[Callable[[Any], None]] = None,
+) -> Callable[[], None]:
+    """Reset process-lifetime stores globally and kernel-created stores per generation.
 
     Module-level Singleton/Computed instances register at import time (no kernel
     context) and live for the process — a process-global registration is right.
-    Instances created inside a kernel (a Computed in a component body, use_task's
-    Singleton) must not outlive it: unregister when that kernel closes. The
-    lifecycle cleanup is idempotent, so an earlier unmount cleanup (use_task) and
-    the kernel-close unregistration can both run.
+    Stores created inside a real kernel are held weakly by that context and cleared
+    on every restart/close, so discarded instances are not pinned by a registry.
 
     The app script itself runs inside the short-lived "dummy" kernel context
     (solara.server.app), so module-level instances of an app ARE created inside
     a kernel — scoping to the dummy context would unregister every module-level
-    reset the moment startup finishes (and break hot reload). Skip it.
+    reset the moment startup finishes (and break hot reload), so treat it as global.
     """
     import solara.lifecycle
 
-    cleanup = solara.lifecycle.on_kernel_start(f)
     if _using_solara_server():
         import solara.server.kernel_context
 
         if solara.server.kernel_context.has_current_context():
             context = solara.server.kernel_context.get_current_context()
             if context.id != "dummy":
-                context.on_close(cleanup)
-    return cleanup
+                context.track_generation_store(store, cleanup_value)
+                return store.clear
+    return solara.lifecycle.on_kernel_start(f)
 
 
 class Singleton(Reactive[S]):
     _storage: KernelStore[S]
 
-    def __init__(self, factory: Callable[[], S], key=None):
+    def __init__(self, factory: Callable[[], S], key=None, _cleanup_value: Optional[Callable[[S], None]] = None):
         super().__init__(KernelStoreFactory(factory, key=key))
 
         # reset on kernel restart (e.g. hot reload)
@@ -907,13 +949,9 @@ class Singleton(Reactive[S]):
 
             return cleanup
 
-        # the registration appends to a process-global list, pinning self (and, through the
-        # kernel store, the per-kernel values) forever. Fine for module-level singletons -
-        # the module pins them anyway - but per-component-instance singletons (use_task)
-        # must call this cleanup on unmount or every mount leaks until process exit.
-        # Instances created INSIDE a kernel additionally unregister at kernel close
-        # (unmount cleanups don't run when the whole kernel goes away).
-        self._on_kernel_start_cleanup = _on_kernel_start_scoped_to_creator(reset)
+        # Module-level instances use the process-global lifecycle registry. Kernel-created
+        # instances are tracked weakly by their context instead.
+        self._on_kernel_start_cleanup = _on_kernel_start_scoped_to_creator(self._storage, reset, _cleanup_value)
 
     def __set__(self, obj, value):
         raise AttributeError("Can't set a singleton")
@@ -934,13 +972,20 @@ class Computed(Reactive[S]):
                 )
         self.f = f
 
+        self_ref = weakref.ref(self)
+
         def on_change(*ignore):
-            with self._auto_subscriber.value:
-                self.set(f())
+            computed = self_ref()
+            if computed is not None:
+                with computed._auto_subscriber.value:
+                    computed.set(f())
 
         import functools
 
-        self._auto_subscriber = Singleton(functools.wraps(AutoSubscribeContextManager)(lambda: AutoSubscribeContextManager(on_change)))
+        self._auto_subscriber = Singleton(
+            functools.wraps(AutoSubscribeContextManager)(lambda: AutoSubscribeContextManager(on_change)),
+            _cleanup_value=lambda manager: manager.unsubscribe_all(),
+        )
 
         @functools.wraps(f)
         def factory():
@@ -960,7 +1005,7 @@ class Computed(Reactive[S]):
 
             return cleanup
 
-        self._on_kernel_start_cleanup = _on_kernel_start_scoped_to_creator(reset)
+        self._on_kernel_start_cleanup = _on_kernel_start_scoped_to_creator(self._storage, reset)
 
     def __repr__(self):
         value = super().__repr__()
@@ -1208,79 +1253,117 @@ class FieldItem(FieldBase):
                 self._parent.set(parent_value)
 
 
+@dataclasses.dataclass(eq=False)
+class _AutoSubscribeRun:
+    subscriptions: Dict[ValueBase, Callable]
+    reactive_used: Set[ValueBase]
+    reactive_used_before: Optional[Set[ValueBase]]
+    reactive_watch_before: Optional[Callable[[ValueBase], None]]
+
+
 class AutoSubscribeContextManagerBase:
-    # a render loop might trigger a new render loop of a differtent render context
-    # so we want to save, and restore the current reactive_used
-    reactive_used: Optional[Set[ValueBase]] = None
     subscribed: Dict[ValueBase, Callable]
-    subscribed_previous_run: Dict[ValueBase, Callable]
+    reactive_used: Optional[Set[ValueBase]]
     on_change: Callable[[], None]
-    previous_reactive_watch: Optional[Callable[["ValueBase"], None]] = None
 
     def __init__(self):
         self.subscribed = {}
-        self.subscribed_previous_run = {}
+        self.reactive_used = None
         self.on_change = lambda: None
+        self._subscription_lock = threading.Lock()
+        self._active_runs: List[_AutoSubscribeRun] = []
+        self._run_local = threading.local()
+        self._closed = False
 
-    def unsubscribe_previous(self):
-        removed = set(self.subscribed_previous_run or set()) - set(self.subscribed)
-        if removed:
-            for reactive in removed:
-                unsubscribe = self.subscribed_previous_run[reactive]
+    @staticmethod
+    def _cleanup(unsubscribes):
+        fatal = None
+        for unsubscribe in unsubscribes:
+            try:
                 unsubscribe()
-                del self.subscribed_previous_run[reactive]
+            except (KeyboardInterrupt, SystemExit) as error:
+                if fatal is None:
+                    fatal = error
+            except BaseException:
+                logger.exception("Reactive subscription cleanup failed")
+        if fatal is not None:
+            raise fatal
 
     def unsubscribe_all(self):
         """Unsubscribe everything: the owner's end-of-life cleanup (unmount or kernel close)."""
-        seen: Set[int] = set()
-        for subscriptions in (self.subscribed, self.subscribed_previous_run):
-            for unsubscribe in subscriptions.values():
-                # the same unsubscribe closure can sit in both dicts
-                if id(unsubscribe) not in seen:
-                    seen.add(id(unsubscribe))
-                    unsubscribe()
-            subscriptions.clear()
+        with self._subscription_lock:
+            self._closed = True
+            unsubscribes = list(self.subscribed.values())
+            self.subscribed = {}
+            self.reactive_used = None
+            for run in self._active_runs:
+                unsubscribes.extend(run.subscriptions.values())
+                run.subscriptions = {}
+            self._active_runs = []
+        self._cleanup(unsubscribes)
 
     def add(self, reactive: ValueBase):
+        stack = getattr(self._run_local, "stack", ())
+        if not stack:
+            return
+        run = stack[-1]
         relevant_reactive = reactive
         if isinstance(reactive, ValueSubField):
             root = reactive._root
-            if root in self.subscribed or root in self.subscribed_previous_run:
+            if root in run.subscriptions:
                 # we already subscribed to this reactive's root
                 return
-            else:
-                # we are subscribing to this reactive's root
-                pass
 
         # TODO: we could see if we are the root of any of the subscribed fields,
         # and remove that field.
-        if relevant_reactive not in self.subscribed:
-            if relevant_reactive not in self.subscribed_previous_run:
-                with _managed_subscription():
-                    unsubscribe = relevant_reactive.subscribe_change(lambda *args: self.on_change())
-                self.subscribed[relevant_reactive] = unsubscribe
+        if relevant_reactive in run.subscriptions:
+            return
+        with self._subscription_lock:
+            if self._closed or run not in self._active_runs:
+                return
+        with _managed_subscription():
+            unsubscribe = relevant_reactive.subscribe_change(lambda *args: self.on_change())
+        with self._subscription_lock:
+            if self._closed or run not in self._active_runs:
+                keep = False
             else:
-                self.subscribed[relevant_reactive] = self.subscribed_previous_run[relevant_reactive]
+                run.subscriptions[relevant_reactive] = unsubscribe
+                keep = True
+        if not keep:
+            self._cleanup([unsubscribe])
 
     def __enter__(self):
-        self.subscribed = {}
-        self.reactive_used_before = thread_local.reactive_used
-        self.previous_reactive_watch = thread_local.reactive_watch
+        self._bind_to_current_kernel()
+        run = _AutoSubscribeRun({}, set(), thread_local.reactive_used, thread_local.reactive_watch)
+        with self._subscription_lock:
+            if not self._closed:
+                self._active_runs.append(run)
+        stack = getattr(self._run_local, "stack", None)
+        if stack is None:
+            stack = self._run_local.stack = []
+        stack.append(run)
         thread_local.reactive_watch = self.add
-        self.reactive_used = thread_local.reactive_used = set()
+        thread_local.reactive_used = run.reactive_used
+        return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        thread_local.reactive_used = self.reactive_used_before
-        thread_local.reactive_watch = self.previous_reactive_watch
-        self.unsubscribe_previous()
-        self.subscribed_previous_run = self.subscribed.copy()
-        # Clear saved references to avoid preventing garbage collection.
-        # Without this, a Computed's AutoSubscribeContextManager retains
-        # previous_reactive_watch (a bound method from the component's
-        # AutoSubscribeContextManagerReacton), which transitively keeps
-        # the _RenderContext alive through closure cells.
-        self.previous_reactive_watch = None
-        self.reactive_used_before = None
+        run = self._run_local.stack.pop()
+        thread_local.reactive_used = run.reactive_used_before
+        thread_local.reactive_watch = run.reactive_watch_before
+        with self._subscription_lock:
+            if run in self._active_runs:
+                self._active_runs.remove(run)
+            if self._closed or exc_type is not None:
+                unsubscribes = list(run.subscriptions.values())
+                run.subscriptions = {}
+            else:
+                unsubscribes = list(self.subscribed.values())
+                self.subscribed = run.subscriptions
+                self.reactive_used = run.reactive_used
+        self._cleanup(unsubscribes)
+
+    def _bind_to_current_kernel(self):
+        pass
 
 
 class Context:
@@ -1397,6 +1480,10 @@ class AutoSubscribeContextManager(AutoSubscribeContextManagerBase):
     def __init__(self, on_change: Callable[[], None]):
         super().__init__()
         self.on_change = on_change
+        self._context_ref: Optional[weakref.ReferenceType] = None
+        self._bind_to_current_kernel()
+
+    def _bind_to_current_kernel(self):
         # This instance owns its subscriptions, and (for Computed) is created once
         # per kernel: unsubscribe when that kernel closes, or every kernel leaves
         # its subscriptions — pinning the on_change closure and everything it
@@ -1406,7 +1493,20 @@ class AutoSubscribeContextManager(AutoSubscribeContextManagerBase):
             import solara.server.kernel_context
 
             if solara.server.kernel_context.has_current_context():
-                solara.server.kernel_context.get_current_context().on_close(self.unsubscribe_all)
+                context = solara.server.kernel_context.get_current_context()
+                with self._subscription_lock:
+                    if self._closed or self._context_ref is not None:
+                        return
+                    self._context_ref = weakref.ref(context)
+                manager_ref = weakref.ref(self)
+
+                def close_manager():
+                    manager = manager_ref()
+                    if manager is not None:
+                        manager.unsubscribe_all()
+
+                unregister = context.on_close(close_manager)
+                weakref.finalize(self, unregister)
 
 
 # alias for compatibility

--- a/tests/unit/kernel_test.py
+++ b/tests/unit/kernel_test.py
@@ -1,9 +1,13 @@
 import json
+import logging
+import threading
 from datetime import datetime
 from unittest.mock import Mock
 
-from solara.server.kernel import SessionWebsocket
 import numpy as np
+import pytest
+
+from solara.server.kernel import SessionWebsocket
 
 
 def test_session_datetime():
@@ -55,6 +59,282 @@ def test_comm_close_after_kernel_closed(kernel_context, no_kernel_context):
     # outside the context now: get_comm_manager() resolves to the global manager,
     # which never saw this comm
     c.close()
+
+
+def test_on_close_registration_during_and_after_close(no_kernel_context):
+    from solara.server import kernel as kernel_mod
+    from solara.server.kernel_context import VirtualKernelContext
+
+    context = VirtualKernelContext(id="onclose-nested", kernel=kernel_mod.Kernel(), session_id="session")
+    ran = []
+    nested_resources = []
+    app = object()
+    context.app_object = app
+
+    def nested():
+        nested_resources.append((context.kernel is not None, context.app_object is app))
+        ran.append("nested")
+
+    def outer():
+        context.on_close(nested)
+        ran.append("outer")
+
+    context.on_close(outer)
+    context.close()
+    assert ran == ["outer", "nested"]
+    assert nested_resources == [(True, True)]
+
+    context.on_close(lambda: ran.append("late"))
+    assert ran[-1] == "late"
+
+
+def test_on_close_registration_racing_close_runs(no_kernel_context):
+    from solara.server import kernel as kernel_mod
+    from solara.server.kernel_context import VirtualKernelContext
+
+    context = VirtualKernelContext(id="onclose-race", kernel=kernel_mod.Kernel(), session_id="session")
+    append_started = threading.Event()
+    release_append = threading.Event()
+
+    class BlockingAppendList(list):
+        armed = True
+
+        def append(self, item):
+            if self.armed:
+                self.armed = False
+                append_started.set()
+                assert release_append.wait(timeout=5)
+            super().append(item)
+
+    context._on_close_callbacks = BlockingAppendList(context._on_close_callbacks)
+    ran = []
+    register = threading.Thread(target=lambda: context.on_close(lambda: ran.append("raced")))
+    closer = threading.Thread(target=context.close)
+
+    register.start()
+    assert append_started.wait(timeout=5)
+    closer.start()
+    release_append.set()
+    register.join(timeout=5)
+    closer.join(timeout=5)
+
+    assert not register.is_alive()
+    assert not closer.is_alive()
+    assert ran == ["raced"]
+
+
+def test_restart_registration_belongs_to_next_generation(no_kernel_context):
+    from solara.server import kernel as kernel_mod
+    from solara.server.kernel_context import VirtualKernelContext
+
+    context = VirtualKernelContext(id="restart-epoch", kernel=kernel_mod.Kernel(), session_id="session")
+    ran = []
+
+    def cleanup():
+        ran.append("old")
+        context.on_close(lambda: ran.append("next"))
+
+    context.on_close(cleanup)
+    context.restart()
+    assert ran == ["old"]
+    context.restart()
+    assert ran == ["old", "next"]
+    context.close()
+
+
+def test_restart_callback_can_request_close_from_worker(no_kernel_context):
+    from solara.server import kernel as kernel_mod
+    from solara.server.kernel_context import VirtualKernelContext
+
+    context = VirtualKernelContext(id="restart-close", kernel=kernel_mod.Kernel(), session_id="session")
+    requested = threading.Event()
+
+    def cleanup():
+        if requested.is_set():
+            return
+        requested.set()
+        closer = threading.Thread(target=context.close)
+        closer.start()
+        closer.join(timeout=5)
+        assert not closer.is_alive()
+
+    context.on_close(cleanup)
+    context.restart()
+    assert context.closed_event.wait(timeout=5)
+
+    context.__post_init__ = Mock()  # type: ignore
+    context.restart()
+    context.__post_init__.assert_not_called()  # type: ignore
+
+
+def test_reconnect_replaces_context_closing_during_restart(no_kernel_context):
+    from solara.server import kernel as kernel_mod
+    from solara.server import kernel_context
+
+    context = kernel_context.VirtualKernelContext(id="restart-reconnect", kernel=kernel_mod.Kernel(), session_id="session")
+    kernel_context.contexts[context.id] = context
+    cleanup_started = threading.Event()
+    release_cleanup = threading.Event()
+
+    def cleanup():
+        cleanup_started.set()
+        assert release_cleanup.wait(timeout=5)
+
+    context.on_close(cleanup)
+    restart = threading.Thread(target=context.restart)
+    restart.start()
+    assert cleanup_started.wait(timeout=5)
+    context.close()
+    try:
+        replacement = kernel_context.initialize_virtual_kernel(context.session_id, context.id, Mock())
+        assert replacement is not context
+        replacement.page_connect("reconnected")
+    finally:
+        release_cleanup.set()
+        restart.join(timeout=5)
+        assert not restart.is_alive()
+        for live_context in list(kernel_context.contexts.values()):
+            live_context.close()
+
+
+def test_close_is_reentrant_and_cleanup_runs_once(no_kernel_context):
+    from solara.server import kernel as kernel_mod
+    from solara.server.kernel_context import VirtualKernelContext
+
+    context = VirtualKernelContext(id="close-reentrant", kernel=kernel_mod.Kernel(), session_id="session")
+    ran = []
+
+    def cleanup():
+        ran.append("cleanup")
+        context.close()
+
+    context.on_close(cleanup)
+    context.close()
+    context.close()
+
+    assert ran == ["cleanup"]
+    assert context.closed_event.is_set()
+
+
+def test_close_callbacks_are_unlocked_and_failure_isolated(no_kernel_context, caplog):
+    from solara.server import kernel as kernel_mod
+    from solara.server.kernel_context import VirtualKernelContext
+
+    context = VirtualKernelContext(id="close-callbacks", kernel=kernel_mod.Kernel(), session_id="session")
+    acquired = threading.Event()
+
+    def acquire_context_lock():
+        with context.lock:
+            acquired.set()
+
+    def callback():
+        thread = threading.Thread(target=acquire_context_lock)
+        thread.start()
+        thread.join(timeout=5)
+        assert not thread.is_alive()
+
+    def fail():
+        raise RuntimeError("cleanup failed")
+
+    context.on_close(callback)
+    context.on_close(fail)
+    with caplog.at_level(logging.ERROR):
+        context.close()
+
+    assert acquired.is_set()
+    assert context.closed_event.is_set()
+    assert "cleanup failed" in caplog.text
+
+
+def test_page_connect_is_rejected_once_close_starts(no_kernel_context):
+    from solara.server import kernel as kernel_mod
+    from solara.server.kernel_context import VirtualKernelContext
+
+    context = VirtualKernelContext(id="closing-page", kernel=kernel_mod.Kernel(), session_id="session")
+    started = threading.Event()
+    release = threading.Event()
+    context.state_flush_worker = Mock()
+
+    def teardown(reason):
+        started.set()
+        assert release.wait(timeout=5)
+
+    context._teardown_persistence = teardown  # type: ignore
+    closer = threading.Thread(target=context.close)
+    closer.start()
+    assert started.wait(timeout=5)
+    with pytest.raises(RuntimeError, match="closed kernel"):
+        context.page_connect("late")
+    release.set()
+    closer.join(timeout=5)
+    assert not closer.is_alive()
+
+
+def test_restart_cleanup_failure_does_not_skip_cleanup_or_reinit(no_kernel_context, caplog):
+    from solara.server import kernel as kernel_mod
+    from solara.server.kernel_context import VirtualKernelContext
+
+    context = VirtualKernelContext(id="restart-error", kernel=kernel_mod.Kernel(), session_id="session")
+    context._on_close_callbacks = []
+    ran = []
+    context.__post_init__ = lambda: ran.append("started")  # type: ignore
+    context.on_close(lambda: ran.append("older"))
+
+    def fail():
+        raise RuntimeError("cleanup failed")
+
+    context.on_close(fail)
+    context.on_close(lambda: ran.append("newer"))
+    with caplog.at_level(logging.ERROR):
+        context.restart()
+
+    assert ran == ["newer", "older", "started"]
+    context.close()
+
+
+def test_restart_initialization_error_does_not_wedge_close(no_kernel_context):
+    from solara.server import kernel as kernel_mod
+    from solara.server.kernel_context import VirtualKernelContext
+
+    context = VirtualKernelContext(id="restart-init-error", kernel=kernel_mod.Kernel(), session_id="session")
+
+    def fail():
+        raise RuntimeError("restart initialization failed")
+
+    context.__post_init__ = fail  # type: ignore
+    with pytest.raises(RuntimeError, match="restart initialization failed"):
+        context.restart()
+
+    context.close()
+    assert context.closed_event.wait(timeout=5)
+
+
+def test_generation_value_destructor_runs_outside_lifecycle_lock(no_kernel_context):
+    from solara.server import kernel as kernel_mod
+    from solara.server.kernel_context import VirtualKernelContext
+
+    context = VirtualKernelContext(id="generation-del", kernel=kernel_mod.Kernel(), session_id="session")
+    destroyed = threading.Event()
+
+    class Value:
+        def __del__(self):
+            context.on_close(lambda: None)
+            destroyed.set()
+
+    class Store:
+        storage_key = "owned"
+
+    store = Store()
+    context.track_generation_store(store)
+    context.user_dicts["owned"] = Value()  # type: ignore[assignment]
+    thread = threading.Thread(target=context.restart)
+    thread.start()
+    thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert destroyed.is_set()
+    del store
+    context.close()
 
 
 def test_comm_info_request_filters_on_target_name():

--- a/tests/unit/lifecycle_test.py
+++ b/tests/unit/lifecycle_test.py
@@ -1,5 +1,6 @@
 import asyncio
 import sys
+import threading
 import time
 from unittest.mock import Mock
 
@@ -117,29 +118,39 @@ async def test_kernel_lifecycle_close_single(close_first, short_cull_timeout):
 
 @pytest.mark.skipif(on_windows, reason="This test is flaky on Windows")
 @pytest.mark.parametrize("close_first", [True, False])
-async def test_kernel_lifecycle_close_while_disconnected(close_first, short_cull_timeout):
+async def test_kernel_lifecycle_close_while_disconnected(close_first, monkeypatch):
+    real_sleep = asyncio.sleep
+    cull_started = threading.Event()
+    release_cull = threading.Event()
+
+    async def controlled_cull_sleep(delay):
+        cull_started.set()
+        while not release_cull.is_set():
+            await real_sleep(0.01)
+
+    monkeypatch.setattr(asyncio, "sleep", controlled_cull_sleep)
     # a reconnect should be possible within the reconnect window
     websocket = Mock()
     context = kernel_context.initialize_virtual_kernel(f"session-id-1-{close_first}", f"kernel-id-1-{close_first}", websocket)
     context.page_connect("page-id-1")
     cull_task_1 = context.page_disconnect("page-id-1")
-    await asyncio.sleep(0.1)
-    # after 0.1 we connect again, but close it directly
+    assert cull_started.wait(timeout=5)
     context.page_connect("page-id-2")
+    with pytest.raises(asyncio.CancelledError):
+        await cull_task_1
+    cull_started.clear()
     if close_first:
         cull_task_2 = context.page_close("page-id-2")
-        await asyncio.sleep(0.01)
+        assert cull_started.wait(timeout=5)
         context.page_disconnect("page-id-2")
     else:
         context.page_disconnect("page-id-2")
-        await asyncio.sleep(0.01)
+        assert cull_started.wait(timeout=5)
+        cull_started.clear()
         cull_task_2 = context.page_close("page-id-2")
+        assert cull_started.wait(timeout=5)
     assert cull_task_2 is not None
     assert not context.closed_event.is_set()
-    await asyncio.sleep(0.15)
-    # but even though we closed, the first page is still in the disconnected state
-    with pytest.raises(asyncio.CancelledError):
-        await cull_task_1
-    assert not context.closed_event.is_set()
+    release_cull.set()
     await cull_task_2
     assert context.closed_event.is_set()

--- a/tests/unit/toestand_test.py
+++ b/tests/unit/toestand_test.py
@@ -1,8 +1,10 @@
 import dataclasses
+import gc
 import logging
 import threading
 import time
 import unittest.mock
+import weakref
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Set, TypeVar, cast
 
@@ -228,8 +230,8 @@ def test_kernel_close_purges_subscription_residue(no_kernel_context):
     # Computed's auto-subscribe machinery) must not outlive the kernel: the
     # (listener, Context) tuples on process-lifetime stores pin the listener
     # closures and everything they capture (memory-usage-inspection.md, case
-    # study 4). Same for the process-global on_kernel_start registrations that
-    # Singleton/Computed instances create.
+    # study 4). Kernel-created Singleton/Computed instances must also stay out
+    # of the process-global on_kernel_start registry.
     import solara.lifecycle
 
     registry_before = len(solara.lifecycle._on_kernel_start_callbacks)
@@ -256,7 +258,7 @@ def test_kernel_close_purges_subscription_residue(no_kernel_context):
         assert computed.value == "hello!"
         assert context.id in listener_scopes(store)
 
-    assert len(solara.lifecycle._on_kernel_start_callbacks) > registry_before
+    assert len(solara.lifecycle._on_kernel_start_callbacks) == registry_before
     context.close()
 
     # the closed kernel's scope is gone from the store (the Computed's
@@ -264,6 +266,449 @@ def test_kernel_close_purges_subscription_residue(no_kernel_context):
     assert context.id not in listener_scopes(store)
     # ...and the kernel-start registry is back at its previous size
     assert len(solara.lifecycle._on_kernel_start_callbacks) == registry_before
+
+
+def _listener_count(value_base, scope_id: str) -> int:
+    count = 0
+    current = value_base
+    while isinstance(current, toestand.ValueBase):
+        count += len(current.listeners.get(scope_id, ()))
+        count += len(current.listeners2.get(scope_id, ()))
+        current = getattr(current, "_storage", None)
+    return count
+
+
+def test_auto_subscribe_overlapping_runs_do_not_orphan_cleanup(no_kernel_context, monkeypatch):
+    monkeypatch.setattr(toestand, "_using_solara_server", lambda: True)
+    dependency = Reactive("old")
+    fresh = Reactive("fresh")
+    context = kernel_context.VirtualKernelContext(id="overlap", kernel=kernel.Kernel(), session_id="session")
+
+    with context:
+        manager = toestand.AutoSubscribeContextManager(lambda: None)
+        with manager:
+            assert dependency.value == "old"
+
+    first_entered = threading.Event()
+    release_first = threading.Event()
+    second_finished = threading.Event()
+    errors = []
+
+    def recompute(first: bool):
+        try:
+            with context, manager:
+                assert fresh.value == "fresh"
+                if first:
+                    first_entered.set()
+                    assert release_first.wait(timeout=5)
+        except BaseException as error:
+            errors.append(error)
+        finally:
+            if not first:
+                second_finished.set()
+
+    first = threading.Thread(target=recompute, args=(True,))
+    second = threading.Thread(target=recompute, args=(False,))
+    first.start()
+    assert first_entered.wait(timeout=5)
+    second.start()
+    assert second_finished.wait(timeout=5)
+    release_first.set()
+    first.join(timeout=5)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    if errors:
+        raise errors[0]
+    assert _listener_count(fresh, context.id) == 1
+
+    context.close()
+    assert _listener_count(dependency, context.id) == 0
+    assert _listener_count(fresh, context.id) == 0
+
+
+@pytest.mark.parametrize("read_before_close", [False, True])
+def test_auto_subscribe_close_cleans_active_run(no_kernel_context, monkeypatch, read_before_close):
+    monkeypatch.setattr(toestand, "_using_solara_server", lambda: True)
+    store = Reactive("value")
+    context = kernel_context.VirtualKernelContext(id=f"active-{read_before_close}", kernel=kernel.Kernel(), session_id="session")
+    with context:
+        manager = toestand.AutoSubscribeContextManager(lambda: None)
+
+    entered = threading.Event()
+    release = threading.Event()
+    errors = []
+
+    def run():
+        try:
+            with context, manager:
+                if read_before_close:
+                    assert store.value == "value"
+                entered.set()
+                assert release.wait(timeout=5)
+                if not read_before_close:
+                    assert store.value == "value"
+        except BaseException as error:
+            errors.append(error)
+
+    thread = threading.Thread(target=run)
+    thread.start()
+    assert entered.wait(timeout=5)
+    context.close()
+    assert _listener_count(store, context.id) == 0
+
+    release.set()
+    thread.join(timeout=5)
+    assert not thread.is_alive()
+    if errors:
+        raise errors[0]
+    assert _listener_count(store, context.id) == 0
+
+
+def test_auto_subscribe_cleanup_is_unlocked_and_failure_isolated(caplog):
+    manager = toestand.AutoSubscribeContextManager(lambda: None)
+    acquired = threading.Event()
+    errors = []
+
+    def acquire_manager_lock():
+        def acquire():
+            try:
+                manager._subscription_lock.acquire()
+                acquired.set()
+            except BaseException as error:
+                errors.append(error)
+
+        thread = threading.Thread(target=acquire)
+        thread.start()
+        thread.join(timeout=5)
+        if acquired.is_set():
+            manager._subscription_lock.release()
+        assert not thread.is_alive()
+        if errors:
+            raise errors[0]
+
+    def fail():
+        raise RuntimeError("unsubscribe failed")
+
+    manager.subscribed = {
+        cast(toestand.ValueBase, object()): acquire_manager_lock,
+        cast(toestand.ValueBase, object()): fail,
+    }
+    with caplog.at_level(logging.ERROR):
+        manager.unsubscribe_all()
+
+    assert acquired.is_set()
+    assert "unsubscribe failed" in caplog.text
+
+
+def test_listener_prune_is_atomic_with_subscribe(no_kernel_context, monkeypatch):
+    from collections import defaultdict
+
+    monkeypatch.setattr(toestand, "_using_solara_server", lambda: True)
+    store = Reactive("value")
+    context = kernel_context.VirtualKernelContext(id="listener-prune", kernel=kernel.Kernel(), session_id="session")
+    holder = cast(toestand.ValueBase, getattr(store._storage, "_storage", store._storage))
+    pruning = threading.Event()
+    proceed = threading.Event()
+    added = threading.Event()
+    cleanups = []
+    errors = []
+
+    class PausingDict(defaultdict):
+        def pop(self, *args, **kwargs):
+            pruning.set()
+            assert proceed.wait(timeout=5)
+            return super().pop(*args, **kwargs)
+
+        def __delitem__(self, key):
+            pruning.set()
+            assert proceed.wait(timeout=5)
+            return super().__delitem__(key)
+
+    holder.listeners2 = PausingDict(set)
+    with context:
+        unsubscribe = holder.subscribe_change(lambda old, new: None)
+
+    cleanup_thread = threading.Thread(target=lambda: unsubscribe())
+
+    def subscribe():
+        try:
+            with context:
+                cleanups.append(holder.subscribe_change(lambda old, new: None))
+            added.set()
+        except BaseException as error:
+            errors.append(error)
+
+    subscribe_thread = threading.Thread(target=subscribe)
+    cleanup_thread.start()
+    assert pruning.wait(timeout=5)
+    subscribe_thread.start()
+    assert not added.wait(timeout=0.2)
+    proceed.set()
+    cleanup_thread.join(timeout=5)
+    subscribe_thread.join(timeout=5)
+
+    assert not cleanup_thread.is_alive()
+    assert not subscribe_thread.is_alive()
+    if errors:
+        raise errors[0]
+    assert len(holder.listeners2.get(context.id, ())) == 1
+    cleanups[0]()
+    context.close()
+
+
+def test_listener_user_code_runs_outside_listener_lock():
+    store = Reactive("value")
+    completed = threading.Event()
+
+    class Listener:
+        def __call__(self, value):
+            def subscribe_and_cleanup():
+                cleanup = store.subscribe(lambda value: None)
+                cleanup()
+                completed.set()
+
+            thread = threading.Thread(target=subscribe_and_cleanup)
+            thread.start()
+            thread.join(timeout=5)
+            assert not thread.is_alive()
+
+        def __hash__(self):
+            raise RuntimeError("listener hash must not be used")
+
+    cleanup = store.subscribe(Listener())
+    store.value = "changed"
+    cleanup()
+    assert completed.is_set()
+
+
+def test_post_close_computed_access_leaves_no_residue(no_kernel_context, monkeypatch):
+    monkeypatch.setattr(toestand, "_using_solara_server", lambda: True)
+    store = Reactive("hello")
+    context = kernel_context.VirtualKernelContext(id="computed-closed", kernel=kernel.Kernel(), session_id="session")
+    with context:
+        computed = toestand.Computed(lambda: store.value + "!", key="computed-closed")
+
+    context.close()
+    with context:
+        assert computed.value == "hello!"
+    assert _listener_count(store, context.id) == 0
+
+
+def test_kernel_created_computed_survives_repeated_restart(no_kernel_context, monkeypatch):
+    monkeypatch.setattr(toestand, "_using_solara_server", lambda: True)
+    dependency = Reactive("a")
+    context = kernel_context.VirtualKernelContext(id="computed-restart", kernel=kernel.Kernel(), session_id="session")
+
+    with context:
+        computed = toestand.Computed(lambda: dependency.value + "!", key="computed-restart")
+        assert computed.value == "a!"
+    for value in ["b", "c"]:
+        context.restart()
+        with context:
+            dependency.value = value
+            assert computed.value == value + "!"
+        assert _listener_count(dependency, context.id) == 1
+    context.close()
+
+
+def test_restart_releases_transient_computed_payload(no_kernel_context, monkeypatch):
+    monkeypatch.setattr(toestand, "_using_solara_server", lambda: True)
+    store = Reactive("value")
+    context = kernel_context.VirtualKernelContext(id="generation-release", kernel=kernel.Kernel(), session_id="session")
+    with context:
+        assert store.value == "value"
+    baseline = len(context.user_dicts)
+
+    class Payload(list):
+        pass
+
+    payload = Payload(range(1000))
+
+    def read(payload: Payload = payload):
+        return (payload, store.value)[1]
+
+    with context:
+        computed = toestand.Computed(read, key="generation-release")
+        assert computed.value == "value"
+    computed_ref = weakref.ref(computed)
+    payload_ref = weakref.ref(payload)
+
+    context.restart()
+    del computed, payload, read
+    gc.collect()
+
+    assert computed_ref() is None
+    assert payload_ref() is None
+    assert len(context.user_dicts) == baseline
+    context.close()
+
+
+def test_unread_kernel_computed_is_not_rooted(no_kernel_context, monkeypatch):
+    monkeypatch.setattr(toestand, "_using_solara_server", lambda: True)
+    context = kernel_context.VirtualKernelContext(id="computed-unread", kernel=kernel.Kernel(), session_id="session")
+
+    class Payload(list):
+        pass
+
+    payload = Payload(range(1000))
+
+    def read(payload: Payload = payload):
+        return payload
+
+    with context:
+        computed = toestand.Computed(read, key="computed-unread")
+    computed_ref = weakref.ref(computed)
+    payload_ref = weakref.ref(payload)
+    del computed, payload, read
+    gc.collect()
+
+    assert computed_ref() is None
+    assert payload_ref() is None
+    context.close()
+
+
+def test_read_transient_computed_is_released_before_restart(no_kernel_context, monkeypatch):
+    monkeypatch.setattr(toestand, "_using_solara_server", lambda: True)
+    dependency = Reactive("value")
+    context = kernel_context.VirtualKernelContext(id="computed-transient", kernel=kernel.Kernel(), session_id="session")
+    with context:
+        assert dependency.value == "value"
+    baseline = len(context.user_dicts)
+    callbacks_before = len(context._on_close_callbacks)
+
+    class Payload(list):
+        pass
+
+    payload = Payload(range(1000))
+
+    def read(payload: Payload = payload):
+        return (payload, dependency.value)[1]
+
+    with context:
+        computed = toestand.Computed(read, key="computed-transient")
+        assert computed.value == "value"
+    computed_ref = weakref.ref(computed)
+    payload_ref = weakref.ref(payload)
+    del computed, payload, read
+    gc.collect()
+
+    assert computed_ref() is None
+    assert payload_ref() is None
+    assert _listener_count(dependency, context.id) == 0
+    assert len(context.user_dicts) == baseline
+    assert len(context._on_close_callbacks) == callbacks_before
+    context.close()
+
+
+def test_discarded_singleton_releases_kernel_value(no_kernel_context, monkeypatch):
+    monkeypatch.setattr(toestand, "_using_solara_server", lambda: True)
+    context = kernel_context.VirtualKernelContext(id="singleton-transient", kernel=kernel.Kernel(), session_id="session")
+    baseline = len(context.user_dicts)
+
+    class Payload(list):
+        pass
+
+    payload = Payload(range(1000))
+
+    def create(payload: Payload = payload):
+        return payload
+
+    with context:
+        singleton = toestand.Singleton(create, key="singleton-transient")
+        assert singleton.value is payload
+    payload_ref = weakref.ref(payload)
+    del singleton, payload, create
+    gc.collect()
+
+    assert payload_ref() is None
+    assert len(context.user_dicts) == baseline
+    context.close()
+
+
+def test_discarded_reactive_releases_kernel_value(no_kernel_context, monkeypatch):
+    monkeypatch.setattr(toestand, "_using_solara_server", lambda: True)
+    context = kernel_context.VirtualKernelContext(id="reactive-transient", kernel=kernel.Kernel(), session_id="session")
+
+    class Payload(list):
+        pass
+
+    payload = Payload(range(1000))
+    with context:
+        reactive = Reactive(payload, key="reactive-transient")
+        stored_payload = reactive.value
+    payload_ref = weakref.ref(payload)
+    stored_payload_ref = weakref.ref(stored_payload)
+    del reactive, payload, stored_payload
+    gc.collect()
+
+    assert payload_ref() is None
+    assert stored_payload_ref() is None
+    assert not context.user_dicts
+    context.close()
+
+
+def test_discarded_singleton_preserves_shared_explicit_key(no_kernel_context, monkeypatch):
+    monkeypatch.setattr(toestand, "_using_solara_server", lambda: True)
+    calls = 0
+
+    def create():
+        nonlocal calls
+        calls += 1
+        return object()
+
+    permanent = toestand.Singleton(create, key="shared-explicit-key")
+    context = kernel_context.VirtualKernelContext(id="shared-key", kernel=kernel.Kernel(), session_id="session")
+    with context:
+        value = permanent.value
+        transient = toestand.Singleton(create, key="shared-explicit-key")
+        assert transient.value is value
+    del transient
+    gc.collect()
+    with context:
+        assert permanent.value is value
+    assert calls == 1
+    context.close()
+
+
+def test_manager_created_outside_kernel_binds_on_first_use(no_kernel_context, monkeypatch):
+    monkeypatch.setattr(toestand, "_using_solara_server", lambda: True)
+    store = Reactive("value")
+    manager = toestand.AutoSubscribeContextManager(lambda: None)
+    context = kernel_context.VirtualKernelContext(id="manager-first-use", kernel=kernel.Kernel(), session_id="session")
+
+    with context, manager:
+        assert store.value == "value"
+    context.close()
+
+    assert manager._closed
+    assert _listener_count(store, context.id) == 0
+
+
+def test_failed_run_keeps_last_valid_dependencies(no_kernel_context, monkeypatch):
+    monkeypatch.setattr(toestand, "_using_solara_server", lambda: True)
+    valid = Reactive(1)
+    partial = Reactive(10)
+    fail = False
+    context = kernel_context.VirtualKernelContext(id="computed-failure", kernel=kernel.Kernel(), session_id="session")
+
+    def calculate():
+        if fail:
+            partial.value
+            raise RuntimeError("calculation failed")
+        return valid.value
+
+    with context:
+        computed = toestand.Computed(calculate, key="computed-failure")
+        assert computed.value == 1
+        manager = computed._auto_subscriber.value
+        fail = True
+        with pytest.raises(RuntimeError, match="calculation failed"):
+            valid.value = 2
+
+    assert valid in manager.subscribed
+    assert partial not in manager.subscribed
+    context.close()
 
 
 def test_computed_created_during_render_warns(no_kernel_context):
@@ -296,9 +741,13 @@ def test_unreleased_subscription_warns_at_kernel_close(no_kernel_context):
     # clean usage: cleanup called before close -> no warning
     toestand._warned_sites.clear()
     context2 = kernel_context.VirtualKernelContext(id="toestand-warn-3", kernel=kernel.Kernel(), session_id="session-1")
+    callbacks_before = len(context2._on_close_callbacks)
     with context2:
-        unsubscribe = store.subscribe(lambda value: None)
-        unsubscribe()
+        for _ in range(10):
+            unsubscribe = store.subscribe(lambda value: None)
+            unsubscribe()
+    assert len(context2._on_close_callbacks) == callbacks_before
+    assert context2.id not in toestand._pending_subscription_checks
     import warnings as warnings_module
 
     with warnings_module.catch_warnings(record=True) as records:


### PR DESCRIPTION
## Summary

Fix reactive subscription and virtual-kernel lifecycle leaks without introducing callback/lock deadlocks.

This replaces #1190 with a clean implementation built from the strongest regression tests collected across the earlier branches.

## Root cause

Subscriptions, automatic dependency tracking, and kernel restart/close cleanup had overlapping ownership:

- transient Reactive, Singleton, and Computed state could remain in kernel storage;
- automatic subscriptions could survive their owner or resubscribe after terminal close;
- listener and leak-check bookkeeping could accumulate empty entries or callbacks;
- restart and close callbacks ran with lifecycle state and locks that allowed races or re-entrant deadlocks.

## Changes

- make kernel restart/close state transitions explicit and run user cleanup outside lifecycle locks;
- make on-close registration safe during and after close;
- weakly track kernel store ownership while preserving module state and shared explicit keys across hot reload;
- make automatic subscriptions per-run, terminally closeable, and safe for overlapping or failed runs;
- prune listener and leak-check bookkeeping when cleanup completes;
- add focused regression coverage for leaks, repeated restart, close races, callback failures, explicit-key collisions, and destructor re-entry.

## Validation

- 454 unit tests passed, 23 skipped;
- 4 server/browser memory-leak integration tests passed;
- 21 lifecycle, reconnect, and ESM integration tests passed, 5 skipped;
- pre-commit, Ruff, formatting, mypy, and codespell passed;
- independent memory, deadlock/race, and simplicity reviews all returned GO;
- concurrency stress passed 30 iterations.
