### PR TITLE
test: make ESM hot-reload integration tests immune to lost file-watch events

### DIFF
--- a/tests/integration/esm_test.py
+++ b/tests/integration/esm_test.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import time
 import uuid
 
 import ipyreact
@@ -97,5 +98,18 @@ def test_ipyreact_module_hot_reload(
     with extra_include_path(str(tmp_path)), solara_app(f"{app_name}:Page"):
         page_session.goto(solara_server.base_url)
         page_session.locator(".hot-widget >> text=version 1").wait_for()
-        module_file.write_text(hot_module_code % 2)
-        page_session.locator(".hot-widget >> text=version 2").wait_for()
+        # a single rewrite can race the watcher being armed, and watch events can
+        # be lost or coalesced on loaded CI runners. Keep writing fresh versions
+        # until one propagates: still fails if hot reload is genuinely broken
+        # (no rewrite ever reaches the browser), but immune to one lost event.
+        deadline = time.monotonic() + 30
+        version = 1
+        while True:
+            version += 1
+            module_file.write_text(hot_module_code % version)
+            try:
+                page_session.locator(f".hot-widget >> text=version {version}").wait_for(timeout=3000)
+                break
+            except playwright.sync_api.TimeoutError:
+                if time.monotonic() > deadline:
+                    raise

--- a/tests/integration/esm_test.py
+++ b/tests/integration/esm_test.py
@@ -97,7 +97,7 @@ def test_ipyreact_module_hot_reload(
     (tmp_path / f"{app_name}.py").write_text(hot_app_code)
     with extra_include_path(str(tmp_path)), solara_app(f"{app_name}:Page"):
         page_session.goto(solara_server.base_url)
-        page_session.locator(".hot-widget >> text=version 1").wait_for()
+        page_session.locator('.hot-widget >> text="version 1"').wait_for()
         # a single rewrite can race the watcher being armed, and watch events can
         # be lost or coalesced on loaded CI runners. Keep writing fresh versions
         # until one propagates: still fails if hot reload is genuinely broken
@@ -108,7 +108,10 @@ def test_ipyreact_module_hot_reload(
             version += 1
             module_file.write_text(hot_module_code % version)
             try:
-                page_session.locator(f".hot-widget >> text=version {version}").wait_for(timeout=3000)
+                # exact match (text= is substring: "version 2" would also match
+                # "version 20"); generous window so a slow - not lost - reload
+                # on a loaded runner still counts before we move the target
+                page_session.locator(f'.hot-widget >> text="version {version}"').wait_for(timeout=6000)
                 break
             except playwright.sync_api.TimeoutError:
                 if time.monotonic() > deadline:


### PR DESCRIPTION
## Why

`test_ipyreact_module_hot_reload[flask-chromium]` has been failing on the scheduled master runs of `integration-test (ubuntu, 3.9, 8)` since 2026-07-22, while code, resolved dependency versions (solara 1.60.3, ipyreact 0.6.0, playwright 1.50.0, watchdog 6.0.0, ...) and the runner image were all identical to the last green run. The same commit both passed and failed on different days, so this is a timing flake, not a regression.

The retained CI video of a failing run shows the page rendering "version 1" and staying there for the entire wait: the rewrite of the watched bundle never produced a reload. The test does a single write of "version 2" and then waits 30s, which makes it sensitive to two races:

- the write can land before the file watch is fully armed
- watch events can be lost or coalesced on loaded runners

Because pytest-retry reruns in the same process, one missed event failed all 4 attempts the same way.

## What

Instead of one write + 30s wait, the test now writes a fresh "version {n}" every ~3s and waits briefly for it to appear, with an overall 30s deadline. A single lost event no longer matters, but the test still fails hard when hot reload is genuinely broken (no rewrite ever reaches the browser).

Verified locally by delaying the `watcher.add_file` arming by 5s so the first write's event is dropped: the old single-shot pattern times out, the retry loop recovers on a later write. `tests/integration/esm_test.py` (flask + starlette) passes 3/3 runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)