### PR TITLE
ci: ipyreact 0.6.1 in the integration locks

### DIFF
--- a/.ci-package-locks/integration/osubuntu-python3.9-ipywidgets7.txt
+++ b/.ci-package-locks/integration/osubuntu-python3.9-ipywidgets7.txt
@@ -72,7 +72,7 @@ ipydatawidgets==4.3.5
 ipykernel==6.29.5
 ipyleaflet==0.20.0
 ipympl==0.10.0
-ipyreact==0.6.0
+ipyreact==0.6.1
 ipython==8.18.1
 ipython-genutils==0.2.0
 ipyvolume==0.6.3

--- a/.ci-package-locks/integration/osubuntu-python3.9-ipywidgets8.txt
+++ b/.ci-package-locks/integration/osubuntu-python3.9-ipywidgets8.txt
@@ -71,7 +71,7 @@ ipydatawidgets==4.3.5
 ipykernel==6.31.0
 ipyleaflet==0.20.0
 ipympl==0.10.0
-ipyreact==0.6.0
+ipyreact==0.6.1
 ipython==8.18.1
 ipython-genutils==0.2.0
 ipyvolume==0.6.3

--- a/.ci-package-locks/integration/oswindows-python3.9-ipywidgets7.txt
+++ b/.ci-package-locks/integration/oswindows-python3.9-ipywidgets7.txt
@@ -73,7 +73,7 @@ ipydatawidgets==4.3.5
 ipykernel==6.29.5
 ipyleaflet==0.20.0
 ipympl==0.10.0
-ipyreact==0.6.0
+ipyreact==0.6.1
 ipython==8.18.1
 ipython-genutils==0.2.0
 ipyvolume==0.6.3

--- a/.ci-package-locks/integration/oswindows-python3.9-ipywidgets8.txt
+++ b/.ci-package-locks/integration/oswindows-python3.9-ipywidgets8.txt
@@ -72,7 +72,7 @@ ipydatawidgets==4.3.5
 ipykernel==6.31.0
 ipyleaflet==0.20.0
 ipympl==0.10.0
-ipyreact==0.6.0
+ipyreact==0.6.1
 ipython==8.18.1
 ipython-genutils==0.2.0
 ipyvolume==0.6.3


### PR DESCRIPTION
Bumps `ipyreact` from 0.6.0 to 0.6.1 in the four integration lock files.

0.6.1 (widgetti/ipyreact#82) invalidates the page-global module registry when a **replacement** model is created. A hot reload replaces the per-kernel `Module` model rather than updating its `code` trait (an update on a closed widget never reaches the browser), so before 0.6.1 a consumer rendered alongside the replacement could resolve the previous module and keep rendering it — the update was lost permanently, not merely delayed. `tests/integration/esm_test.py::test_ipyreact_module_hot_reload` therefore depended on winning that race, which loaded runners lose.

Verified: with 0.6.1 the test runs first-try green (both server flavors, no retries) in repeated CI runs, and in a 1-CPU container it goes from 2–3 of 3 runs stuck on the old version (150s budget exhausted) to 3/3 correct in ~6s.

Scheduled runs install unlocked and already pick up 0.6.1; this makes PR runs use it too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)