### PR TITLE
fix: type-guard get_ipython in NotebookExecute

### DIFF
--- a/solara/website/components/notebook.py
+++ b/solara/website/components/notebook.py
@@ -70,7 +70,9 @@ def execute_notebook(path: Path):
 def NotebookExecute(notebook_path: Path, show_last_expressions=False, auto_show_page=False):
     import IPython.core.pylabtools as pylabtools
 
-    shell = IPython.get_ipython().kernel.shell
+    ipython = IPython.get_ipython()
+    assert ipython is not None, "NotebookExecute needs to run in a kernel"
+    shell = ipython.kernel.shell  # type: ignore[attr-defined]
 
     # TODO: there is a change the cleanup will not be called
     pylabtools.select_figure_formats(shell, ["png"])


### PR DESCRIPTION
`code-quality` is red on master (both the ipyvuetify 1 and ipyvuetify 3 mypy runs):

```
solara/website/components/notebook.py:73: error: Item "InteractiveShell" of "InteractiveShell | None" has no attribute "kernel"  [union-attr]
solara/website/components/notebook.py:73: error: Item "None" of "InteractiveShell | None" has no attribute "kernel"  [union-attr]
```

IPython types `get_ipython()` as `InteractiveShell | None`, and `.kernel` only exists on the kernel subclass. Assert the shell exists (this component only runs inside a kernel) and ignore the `kernel` attribute, matching the `if ip:` guard `solara/server/patch.py:367` already uses.

Unrelated to any feature work — just gets master's code quality job green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)