### PR TITLE
fix: deadlocks between kernel close, the event loop and reactive updates

### DIFF
--- a/docs/deadlock-rules.md
+++ b/docs/deadlock-rules.md
@@ -1,0 +1,100 @@
+# Deadlock rules for solara server
+
+This document lists the locks in the solara server, the rules that keep them from forming a cycle, and how to test for and diagnose a hang.
+Every rule below came from a real deadlock.
+Read this before touching kernel lifecycle, reactive variables, or anything that runs on an event loop thread.
+
+## The locks
+
+| Lock | Where | Held for |
+|------|-------|----------|
+| `context.lock` (RLock) | `solara/server/server.py`, `app_loop` | the whole processing of one websocket message: the event handler, every render it triggers, every widget update it sends |
+| reacton render lock (`_RenderContext.thread_lock`, non-reentrant) | reacton `core.py`, `render()` and `close()` | one full render pass, including the reconsolidation and effects phase |
+| store lock (`KernelStore._lock`, `SharedStore._lock`, RLock) | `solara/toestand.py`, `solara/_stores.py` | one read-modify-write in `update()` or a field set, and the `_ensure_public_exists` read with mutation detection |
+| init lock (`context.init_locks[key]`, RLock) | `KernelStore.get()` | the lazy `initial_value()` of one reactive in one kernel |
+| `_listeners_lock` | `ValueBase` | taking a snapshot of the listeners, never while calling them |
+| the keep-alive event loop | `solara/server/kernel_context.py` | shared by every kernel's cull timer in the process |
+| the uvicorn event loop | `solara/server/starlette.py` | every `portal.call` from a kernel thread waits for it |
+
+## Rule 1: never call `context.close()` on an event loop thread
+
+In threaded mode the kernel's message thread holds `context.lock` for the whole event handler.
+Each widget update in that handler is a `portal.call` that needs the uvicorn event loop to run.
+`context.close()` blocks on `context.lock`.
+Calling it from a coroutine therefore deadlocks whenever a handler is busy: the loop waits for the lock, the handler waits for the loop.
+
+This was reproduced live for the HTTP evict route (permanent hang) and for the lifespan shutdown with uvicorn's `timeout_graceful_shutdown` (the loop is dead until the handler returns, so health checks fail).
+Both now run the close off the loop, see `_off_loop` in `starlette.py`.
+Off the loop, `close()` still waits for `context.lock`, so a busy handler delays the close for as long as it runs.
+At shutdown that wait is bounded: `_close_all_contexts` closes every kernel in parallel under one deadline (`SOLARA_SERVER_SHUTDOWN_CLOSE_TIMEOUT`, default 10 seconds) and logs the kernels that did not make it.
+
+The same rule holds for the keep-alive loop.
+A cull used to run `close()` inline on it.
+One kernel wedged in an event handler then blocked the cull of every other kernel in the process, which is a process-wide memory leak.
+The cull now runs `close()` on its own thread (`_run_in_thread` in `kernel_context.py`) and only awaits the result.
+
+## Rule 2: never fire listeners while holding a store lock
+
+`update()` and field sets (`Ref(state.fields.x).value = ...`) take the store lock for their read-modify-write.
+A listener runs arbitrary code, typically a render, which takes the render lock.
+The render thread may set the same reactive from an effect, or with mutation detection on, even read it, which takes the store lock.
+Firing under the lock is an ABBA deadlock between a background thread (a task writing progress) and the render thread.
+
+The stores therefore split storing from firing: `_set_deferred()` stores under the lock and returns the `fire` call, and the caller runs it after releasing the lock.
+`set()` still fires inline, because `set()` does not take the lock.
+The price is ordering: two threads writing the same reactive at the same time may notify in the other order than they stored.
+Plain `.value = x` never ordered its notifications either, and every listener solara installs (render, computed, persistence dirty-mark) re-reads the store.
+A listener that must see the latest value reads it instead of using its argument.
+The one solara listener that uses its argument is the external-change hook of the text inputs (`use_reactive` forwarding to `on_external_value_change` in `components/input.py`): two threads writing that reactive at the same time can leave the field showing the older text until the next render.
+Any new store must implement `_set_deferred()` the same way.
+`tests/unit/deadlock_test.py` pins this down with a deterministic two-thread cycle.
+
+## Rule 3: never do blocking I/O under a lock
+
+The state-persistence code (`solara/state`) does backend I/O.
+It runs its final flush before `close()` takes `context.lock`, and the flush worker snapshots under the store lock but writes outside every lock.
+`KernelStore.get()` holds an init lock while `initial_value()` runs, so an initial value that does I/O or takes another lock must not depend on anything that waits for this kernel.
+The init lock logs every thread's stack after `SOLARA_STORAGE_INIT_LOCK_TIMEOUT` seconds instead of hanging silently.
+
+## Rule 4: an `on_close` callback must not wait for the kernel to be closed
+
+`closed_event` is set at the very end of `close()`.
+A close callback (an `on_kernel_start` cleanup, a `use_effect` cleanup) that joins a thread waiting on `solara.kernel_closed_event()` waits for itself.
+Signal such a thread with your own event, or let it poll `closed_event.is_set()` without joining it.
+
+## Rule 5: the patched thread bootstrap must never raise before the thread is started
+
+`patch.py` binds a new thread to its kernel context before `Thread._bootstrap` marks it as started.
+An exception there kills the thread before `_started` is set, and the caller of `Thread.start()` waits forever.
+The bootstrap therefore falls back to running without a context on any error, for example when the kernel closed between `Thread()` and `start()`.
+
+## Rule 6: `close()` must always reach `closed_event.set()`
+
+Everybody waiting on `closed_event` (tests, user threads, persistence) hangs if `close()` raises halfway.
+Use tolerant operations in the close path (`dict.pop(key, None)`, not `del`), and catch and log per-step failures.
+The close path also runs on plain threads (cull, evict, shutdown), which in non-threaded mode have no context id set: `get_current_thread_key` falls back to a thread key there instead of raising.
+
+## Testing for deadlocks
+
+Model the cycle with two threads and `threading.Event`s so the interleaving is deterministic.
+Give each thread a `join(timeout)` and assert that no thread is alive afterwards.
+Mark the test with `@pytest.mark.timeout`, so a hang becomes a failure with thread stacks.
+See `tests/unit/deadlock_test.py` for the pattern.
+
+For live reproduction, run the server with `PYTHONFAULTHANDLER=1`.
+When it hangs, send `SIGABRT`: faulthandler dumps every thread's stack to stderr, which shows both sides of the cycle.
+Drive the browser with playwright and keep an event handler busy (a loop with a `time.sleep` and a reactive write per iteration) while triggering the suspect path.
+
+## Model checking (TLA+)
+
+`docs/tla/` holds a PlusCal model of the lock table above (`SolaraLocks.tla`) and of the kernel lifecycle (`SolaraLifecycle.tla`), with a README on how to run TLC.
+The lock model re-finds the three cycles under the old rules and passes under the new ones.
+The lifecycle model found the cull-versus-reconnect race (a page marked connected on a kernel that is already closing) and validated the fix: mark the kernel as closing under the same `context.lock` hold as the decision (`_begin_close`).
+Use the models as a design aid when adding a lock or a new close path, not as a CI gate: they are a hand transcription of the code and drift silently.
+
+## Diagnosing a hang in production
+
+Deploy with a way to get thread stacks without killing the process.
+The cheapest is `faulthandler.register(signal.SIGUSR1, all_threads=True)` at startup, then `kill -USR1 <pid>`.
+Do not use `SIGUSR1` under gunicorn, which reserves it for log reopening; pick `SIGUSR2`.
+A blocked event loop shows as a failing `/readyz` while the process is alive.

--- a/docs/design-redis-state-persistence.md
+++ b/docs/design-redis-state-persistence.md
@@ -51,7 +51,7 @@ state is lost.
 | Dev hot-reload re-runs the app in the **same** kernel over **live** comms — its machinery does not transfer to a fresh-kernel remount, but proves remount-without-reload is supported | `app.py:491-504` |
 | Clean close vs connection loss are already distinguished: `page_close` (beacon `POST /_solara/api/close/{kernel_id}`) vs `page_disconnect` + cull timer (`kernel.cull_timeout`, default 24h) | `kernel_context.py:219-359`, `starlette.py:769` |
 | Redis precedent and core/enterprise split: `cache_type_map` keeps `memory` in core, `redis` in `solara_enterprise.cache.redis`, imported lazily | `cache.py:265-292` |
-| Documented deadlock precedent: never do blocking I/O under a store lock | `docs/reactive-initialization-lock-deadlock.md` |
+| Documented deadlock precedent: never do blocking I/O under a store lock | `docs/deadlock-rules.md` |
 
 ## 3. Design overview
 

--- a/docs/memory-leak-detection.md
+++ b/docs/memory-leak-detection.md
@@ -320,6 +320,11 @@ Manual BFS/DFS over `gc.get_referrers()` produces overwhelming output — lists 
   - `count(typename)` — count live instances of a type
 - **`sys.getrefcount()`** (stdlib) — check how many references exist to an object (note: the call itself adds one)
 
+## Related
+
+- `docs/deadlock-rules.md`: the lock inventory and the rules that keep kernel close, culling and reactive updates from deadlocking. A wedged kernel is also a leak: it can never be culled.
+- `docs/memory-usage-inspection.md`: the measurement handbook (process-level numbers, the cycle protocol, case studies).
+
 ## Configuration
 
 - `SOLARA_KERNEL_CULL_TIMEOUT` — how long to wait before cleaning up a disconnected kernel (default: 24h, set to near-zero in tests)

--- a/docs/tla/LifeFix.cfg
+++ b/docs/tla/LifeFix.cfg
@@ -1,0 +1,5 @@
+\* Candidate fix: mark CLOSING under the same self.lock hold as the decision.
+SPECIFICATION Spec
+CONSTANT FixLifecycle = TRUE
+INVARIANT NoStrandedPage
+PROPERTIES AllDone

--- a/docs/tla/LifeRace.cfg
+++ b/docs/tla/LifeRace.cfg
@@ -1,0 +1,5 @@
+\* The code as it is today: the CLOSING mark is not under the cull's lock hold.
+SPECIFICATION Spec
+CONSTANT FixLifecycle = FALSE
+INVARIANT NoStrandedPage
+PROPERTIES AllDone

--- a/docs/tla/New.cfg
+++ b/docs/tla/New.cfg
@@ -1,0 +1,10 @@
+\* NEW rules: close() off the event loop, listeners fired outside the store lock.
+SPECIFICATION Spec
+CONSTANTS
+    HandlerSteps = 2
+    NewCloseRules = TRUE
+    NewStoreRules = TRUE
+    EvictOn = TRUE
+    WedgeK1 = FALSE
+INVARIANT TypeOK
+PROPERTIES AllDone AllCullsDone

--- a/docs/tla/NewCull.cfg
+++ b/docs/tla/NewCull.cfg
@@ -1,0 +1,10 @@
+\* Same wedged kernel, but the cull runs close() off the keep-alive loop.
+SPECIFICATION Spec
+CONSTANTS
+    HandlerSteps = 2
+    NewCloseRules = TRUE
+    NewStoreRules = TRUE
+    EvictOn = FALSE
+    WedgeK1 = TRUE
+INVARIANT TypeOK
+PROPERTIES Cull2Done

--- a/docs/tla/NewWF.cfg
+++ b/docs/tla/NewWF.cfg
@@ -1,0 +1,10 @@
+\* The New configuration under weak fairness (see SpecWF in the module).
+SPECIFICATION SpecWF
+CONSTANTS
+    HandlerSteps = 2
+    NewCloseRules = TRUE
+    NewStoreRules = TRUE
+    EvictOn = TRUE
+    WedgeK1 = FALSE
+INVARIANT TypeOK
+PROPERTIES AllDone AllCullsDone

--- a/docs/tla/Old.cfg
+++ b/docs/tla/Old.cfg
@@ -1,0 +1,10 @@
+\* OLD rules: the code before the deadlock fixes. Everything on.
+SPECIFICATION Spec
+CONSTANTS
+    HandlerSteps = 2
+    NewCloseRules = FALSE
+    NewStoreRules = FALSE
+    EvictOn = TRUE
+    WedgeK1 = FALSE
+INVARIANT TypeOK
+PROPERTIES AllDone AllCullsDone

--- a/docs/tla/OldCull.cfg
+++ b/docs/tla/OldCull.cfg
@@ -1,0 +1,12 @@
+\* Isolates counterexample (c): kernel 1's handler is wedged, culls run ON the
+\* shared keep-alive loop. Kernel 1's own cull can never finish (close waits for
+\* context.lock), so only kernel 2's cull is checked.
+SPECIFICATION Spec
+CONSTANTS
+    HandlerSteps = 2
+    NewCloseRules = FALSE
+    NewStoreRules = TRUE
+    EvictOn = FALSE
+    WedgeK1 = TRUE
+INVARIANT TypeOK
+PROPERTIES Cull2Done

--- a/docs/tla/OldEvict.cfg
+++ b/docs/tla/OldEvict.cfg
@@ -1,0 +1,10 @@
+\* Isolates counterexample (a): only rule 1 is broken, the store rule is fixed.
+SPECIFICATION Spec
+CONSTANTS
+    HandlerSteps = 2
+    NewCloseRules = FALSE
+    NewStoreRules = TRUE
+    EvictOn = TRUE
+    WedgeK1 = FALSE
+INVARIANT TypeOK
+PROPERTIES AllDone AllCullsDone

--- a/docs/tla/OldStore.cfg
+++ b/docs/tla/OldStore.cfg
@@ -1,0 +1,10 @@
+\* Isolates counterexample (b): only rule 2 is broken, evict is off.
+SPECIFICATION Spec
+CONSTANTS
+    HandlerSteps = 2
+    NewCloseRules = TRUE
+    NewStoreRules = FALSE
+    EvictOn = FALSE
+    WedgeK1 = FALSE
+INVARIANT TypeOK
+PROPERTIES AllDone AllCullsDone

--- a/docs/tla/README.md
+++ b/docs/tla/README.md
@@ -1,0 +1,45 @@
+# TLA+ models of the solara server locks
+
+`SolaraLocks.tla` models the locks in [../deadlock-rules.md](../deadlock-rules.md).
+`SolaraLifecycle.tla` models the cull/reconnect race; `LifeFix.cfg` is the fix now in `kernel_context.py` (`_begin_close` under the decision lock).
+Both event loops are modelled as mutexes: a coroutine that blocks holds its loop for that time.
+
+## Run
+
+Get `tla2tools.jar` from https://github.com/tlaplus/tlaplus/releases, then:
+
+```
+java -cp tla2tools.jar pcal.trans docs/tla/SolaraLocks.tla
+java -XX:+UseParallelGC -cp tla2tools.jar tlc2.TLC -config docs/tla/New.cfg -workers auto docs/tla/SolaraLocks.tla
+```
+
+Re-run `pcal.trans` after every edit to the PlusCal block, or TLC checks the old translation.
+
+## Configurations
+
+| cfg | what it is |
+|-----|------------|
+| `New.cfg` | the current code. No deadlock, everything terminates. |
+| `Old.cfg` | the code before the fixes. Both rules broken. |
+| `OldEvict.cfg` | only rule 1 broken: evict closes on the uvicorn loop. |
+| `OldStore.cfg` | only rule 2 broken: listeners fire under the store lock. |
+| `OldCull.cfg` | one wedged handler, culls close on the shared keep-alive loop. |
+| `NewCull.cfg` | the same wedged handler with the cull off the loop. |
+| `NewWF.cfg` | `New.cfg` under weak fairness (`SpecWF`), which finishes in the time budget. |
+| `LifeRace.cfg` / `LifeFix.cfg` | the lifecycle race, without and with the candidate fix (`SolaraLifecycle.tla`). |
+
+## Fairness
+
+Every process is `fair+` (strong fairness).
+A thread blocked on a real mutex eventually gets it.
+With plain weak fairness TLC reports a starvation lasso that is an artefact:
+one thread takes the store lock briefly on every loop iteration, so a second thread waiting
+for that lock is never *continuously* enabled and weak fairness never forces it to run.
+Strong fairness costs time: the liveness pass dominates the run.
+`New.cfg` under strong fairness did not finish inside 10 minutes, so use `NewWF.cfg`.
+That is not a weaker result: weak fairness allows every behaviour strong fairness allows
+and more, so a property that holds for `SpecWF` also holds for `Spec`.
+
+TLC's built-in deadlock check is used as-is.
+The PlusCal translator adds a `Terminating` stuttering step, so the all-Done state is not
+reported as a deadlock; any other state with no enabled action is a real lock cycle.

--- a/docs/tla/SolaraLifecycle.tla
+++ b/docs/tla/SolaraLifecycle.tla
@@ -1,0 +1,194 @@
+------------------------- MODULE SolaraLifecycle -------------------------
+(***************************************************************************)
+(* The kernel lifecycle race between a cull and a reconnect.                *)
+(*                                                                          *)
+(* This is NOT one of the fixed deadlocks.  It is a race we suspect in       *)
+(* solara/server/kernel_context.py and did not fix.                          *)
+(*                                                                          *)
+(* The cull decides "no connected pages" under self.lock, RELEASES the lock, *)
+(* and only then calls close() (kernel_context.py:530-541, the comment there *)
+(* says close() must run outside self.lock because its persistence teardown  *)
+(* does backend I/O).  close() then marks the kernel CLOSING under a         *)
+(* DIFFERENT lock, self._lifecycle_lock (kernel_context.py:361-365).         *)
+(*                                                                          *)
+(* page_connect (kernel_context.py:484-493) checks is_closing() twice, once  *)
+(* outside self.lock and once inside it, and then sets the page CONNECTED.   *)
+(* Because the cull's decision and the CLOSING mark are not under the same   *)
+(* hold of self.lock, a reconnect can slip in between them.                  *)
+(*                                                                          *)
+(* page_connect also cancels the pending cull task, but that only helps      *)
+(* while the cull still sleeps.  Once the cull has passed its decision, the  *)
+(* close runs on its own thread and the cancel does nothing.  That is        *)
+(* exactly the window modelled here, so the cancel needs no extra variable.  *)
+(*                                                                          *)
+(* FixLifecycle = TRUE is the candidate fix: mark CLOSING under the same     *)
+(* self.lock hold as the decision.                                          *)
+(***************************************************************************)
+EXTENDS Naturals, TLC
+
+CONSTANT FixLifecycle
+
+NoProc == "none"
+
+(*--algorithm SolaraLifecycle
+
+variables
+    ctxOwner  = NoProc,          \* context.lock (self.lock)
+    lifecycle = "open",          \* _lifecycle_state: open / closing / closed
+    page      = "disconnected";  \* page_status of the one page
+
+fair+ process Cull = "cull"
+begin
+CU_Lock:
+    await ctxOwner = NoProc;
+    ctxOwner := "cull";
+CU_Decide:
+    \* "with self.lock: if PageStatus.CONNECTED in self.page_status.values(): return False"
+    if page = "connected" then
+        ctxOwner := NoProc;
+        goto Done;               \* a page reconnected in time, keep the kernel
+    elsif FixLifecycle then
+        lifecycle := "closing";  \* CANDIDATE FIX: mark under the same lock hold
+    end if;
+CU_Unlock:
+    ctxOwner := NoProc;          \* close() runs OUTSIDE self.lock
+CU_Closing:
+    lifecycle := "closing";      \* close(): under _lifecycle_lock, not self.lock
+CU_Lock2:
+    await ctxOwner = NoProc;
+    ctxOwner := "cull";
+CU_Finish:
+    \* _finish_close: "for key in self.page_status: self.page_status[key] = CLOSED"
+    page := "closed";
+    lifecycle := "closed";
+    ctxOwner := NoProc;
+end process;
+
+fair+ process Reconnect = "recon"
+begin
+RE_FastCheck:
+    if lifecycle /= "open" then
+        goto Done;               \* page_connect:485, the check outside the lock
+    end if;
+RE_Lock:
+    await ctxOwner = NoProc;
+    ctxOwner := "recon";
+RE_Check:
+    if lifecycle /= "open" then  \* page_connect:489, the check inside the lock
+        ctxOwner := NoProc;
+        goto Done;               \* RuntimeError: cannot connect to a closed kernel
+    end if;
+RE_Connect:
+    page := "connected";         \* page_status[page_id] = CONNECTED
+    ctxOwner := NoProc;
+end process;
+
+end algorithm; *)
+
+\* BEGIN TRANSLATION
+VARIABLES ctxOwner, lifecycle, page, pc
+
+vars == << ctxOwner, lifecycle, page, pc >>
+
+ProcSet == {"cull"} \cup {"recon"}
+
+Init == (* Global variables *)
+        /\ ctxOwner = NoProc
+        /\ lifecycle = "open"
+        /\ page = "disconnected"
+        /\ pc = [self \in ProcSet |-> CASE self = "cull" -> "CU_Lock"
+                                        [] self = "recon" -> "RE_FastCheck"]
+
+CU_Lock == /\ pc["cull"] = "CU_Lock"
+           /\ ctxOwner = NoProc
+           /\ ctxOwner' = "cull"
+           /\ pc' = [pc EXCEPT !["cull"] = "CU_Decide"]
+           /\ UNCHANGED << lifecycle, page >>
+
+CU_Decide == /\ pc["cull"] = "CU_Decide"
+             /\ IF page = "connected"
+                   THEN /\ ctxOwner' = NoProc
+                        /\ pc' = [pc EXCEPT !["cull"] = "Done"]
+                        /\ UNCHANGED lifecycle
+                   ELSE /\ IF FixLifecycle
+                              THEN /\ lifecycle' = "closing"
+                              ELSE /\ TRUE
+                                   /\ UNCHANGED lifecycle
+                        /\ pc' = [pc EXCEPT !["cull"] = "CU_Unlock"]
+                        /\ UNCHANGED ctxOwner
+             /\ page' = page
+
+CU_Unlock == /\ pc["cull"] = "CU_Unlock"
+             /\ ctxOwner' = NoProc
+             /\ pc' = [pc EXCEPT !["cull"] = "CU_Closing"]
+             /\ UNCHANGED << lifecycle, page >>
+
+CU_Closing == /\ pc["cull"] = "CU_Closing"
+              /\ lifecycle' = "closing"
+              /\ pc' = [pc EXCEPT !["cull"] = "CU_Lock2"]
+              /\ UNCHANGED << ctxOwner, page >>
+
+CU_Lock2 == /\ pc["cull"] = "CU_Lock2"
+            /\ ctxOwner = NoProc
+            /\ ctxOwner' = "cull"
+            /\ pc' = [pc EXCEPT !["cull"] = "CU_Finish"]
+            /\ UNCHANGED << lifecycle, page >>
+
+CU_Finish == /\ pc["cull"] = "CU_Finish"
+             /\ page' = "closed"
+             /\ lifecycle' = "closed"
+             /\ ctxOwner' = NoProc
+             /\ pc' = [pc EXCEPT !["cull"] = "Done"]
+
+Cull == CU_Lock \/ CU_Decide \/ CU_Unlock \/ CU_Closing \/ CU_Lock2
+           \/ CU_Finish
+
+RE_FastCheck == /\ pc["recon"] = "RE_FastCheck"
+                /\ IF lifecycle /= "open"
+                      THEN /\ pc' = [pc EXCEPT !["recon"] = "Done"]
+                      ELSE /\ pc' = [pc EXCEPT !["recon"] = "RE_Lock"]
+                /\ UNCHANGED << ctxOwner, lifecycle, page >>
+
+RE_Lock == /\ pc["recon"] = "RE_Lock"
+           /\ ctxOwner = NoProc
+           /\ ctxOwner' = "recon"
+           /\ pc' = [pc EXCEPT !["recon"] = "RE_Check"]
+           /\ UNCHANGED << lifecycle, page >>
+
+RE_Check == /\ pc["recon"] = "RE_Check"
+            /\ IF lifecycle /= "open"
+                  THEN /\ ctxOwner' = NoProc
+                       /\ pc' = [pc EXCEPT !["recon"] = "Done"]
+                  ELSE /\ pc' = [pc EXCEPT !["recon"] = "RE_Connect"]
+                       /\ UNCHANGED ctxOwner
+            /\ UNCHANGED << lifecycle, page >>
+
+RE_Connect == /\ pc["recon"] = "RE_Connect"
+              /\ page' = "connected"
+              /\ ctxOwner' = NoProc
+              /\ pc' = [pc EXCEPT !["recon"] = "Done"]
+              /\ UNCHANGED lifecycle
+
+Reconnect == RE_FastCheck \/ RE_Lock \/ RE_Check \/ RE_Connect
+
+(* Allow infinite stuttering to prevent deadlock on termination. *)
+Terminating == /\ \A self \in ProcSet: pc[self] = "Done"
+               /\ UNCHANGED vars
+
+Next == Cull \/ Reconnect
+           \/ Terminating
+
+Spec == /\ Init /\ [][Next]_vars
+        /\ SF_vars(Cull)
+        /\ SF_vars(Reconnect)
+
+Termination == <>(\A self \in ProcSet: pc[self] = "Done")
+
+\* END TRANSLATION
+
+-----------------------------------------------------------------------------
+\* A page is never CONNECTED on a kernel that is closing or closed.
+NoStrandedPage == (page = "connected") => (lifecycle = "open")
+
+AllDone == <>(\A p \in ProcSet : pc[p] = "Done")
+=============================================================================

--- a/docs/tla/SolaraLocks.tla
+++ b/docs/tla/SolaraLocks.tla
@@ -1,0 +1,461 @@
+-------------------------- MODULE SolaraLocks --------------------------
+(***************************************************************************)
+(* A model of the lock structure of the solara server, used to check the    *)
+(* rules in docs/deadlock-rules.md.                                         *)
+(*                                                                          *)
+(* Every resource is a mutex owned by at most one process.  Two event loops *)
+(* are modelled as mutexes too: a coroutine that blocks while it runs holds  *)
+(* its loop for that whole time, which is exactly what makes them behave     *)
+(* like locks.                                                              *)
+(*                                                                          *)
+(* Resources (with the code they come from):                                *)
+(*                                                                          *)
+(*  ctx[k]   context.lock of kernel k, an RLock.  Held by the message thread *)
+(*           for the WHOLE handling of one websocket message                 *)
+(*           (solara/server/server.py:178 "with context.lock:").  Also taken *)
+(*           by close(), see _finish_close in                                *)
+(*           solara/server/kernel_context.py:387 "with self.lock:".          *)
+(*                                                                          *)
+(*  rlock[k] the reacton render lock (_RenderContext.thread_lock),           *)
+(*           NON-reentrant, held for one whole render pass including the     *)
+(*           effects phase (reacton/core.py render() ~1599, close() ~1328).  *)
+(*           A thread that is already rendering never renders again          *)
+(*           (_is_rendering / _possible_rerender), so the owner never        *)
+(*           re-requests it.                                                 *)
+(*                                                                          *)
+(*  store    one reactive variable's RLock (KernelStore._lock,               *)
+(*           solara/toestand.py).  OLD: update() fires listeners while       *)
+(*           holding it.  NEW: _set_deferred() stores under the lock,        *)
+(*           releases, then fires.  With mutation detection on, a READ takes *)
+(*           it briefly (solara/_stores.py _ensure_public_exists).           *)
+(*                                                                          *)
+(*  uv       the uvicorn event loop, ONE per process.  Every portal.call     *)
+(*           from a kernel thread waits for it                               *)
+(*           (solara/server/starlette.py:223 send_text -> portal.call).      *)
+(*                                                                          *)
+(*  kal      the keep-alive event loop, ONE per process, shared by every     *)
+(*           kernel's cull task (kernel_context.py keep_alive_event_loop).   *)
+(*                                                                          *)
+(* Processes: MessageThread[k], TaskThread[k], Cull[k] for k in Kernels,     *)
+(* plus one Evict for kernel 1.                                             *)
+(*                                                                          *)
+(* Every process is "fair+" (STRONG fairness), not "fair".  A thread blocked *)
+(* on a real mutex eventually gets it.  With only weak fairness TLC reports  *)
+(* a spurious starvation lasso: one thread takes the store lock briefly on   *)
+(* every loop iteration, so a second thread waiting for that lock is not     *)
+(* CONTINUOUSLY enabled, and weak fairness never forces it to run.  That     *)
+(* counterexample is an artefact of the fairness choice, not a solara bug.   *)
+(***************************************************************************)
+EXTENDS Naturals, Sequences, TLC
+
+CONSTANTS
+    HandlerSteps,    \* how many render passes one event handler does (2 is enough)
+    NewCloseRules,   \* rule 1: close() never runs ON an event loop thread
+    NewStoreRules,   \* rule 2: never fire listeners while holding a store lock
+    EvictOn,         \* run the HTTP evict route at all (used to isolate counterexamples)
+    WedgeK1          \* kernel 1's event handler never returns (a busy handler)
+
+Kernels == {1, 2}
+
+NoProc == <<"none", 0>>   \* the "no owner" value; a tuple so it is comparable with the process ids
+
+MsgIds   == {<<"msg",   k>> : k \in Kernels}
+TaskIds  == {<<"task",  k>> : k \in Kernels}
+CullIds  == {<<"cull",  k>> : k \in Kernels}
+EvictId  == <<"evict", 1>>
+
+\* Reentrant (RLock) acquire/release.  The owner may re-enter; others wait.
+AcqR(l, p) == [owner |-> p, count |-> l.count + 1]
+RelR(l)    == IF l.count = 1 THEN [owner |-> NoProc, count |-> 0]
+                             ELSE [owner |-> l.owner, count |-> l.count - 1]
+FreeR      == [owner |-> NoProc, count |-> 0]
+
+(*--algorithm SolaraLocks
+
+variables
+    ctx   = [k \in Kernels |-> FreeR],   \* context.lock per kernel (RLock)
+    rlock = [k \in Kernels |-> NoProc],  \* reacton render lock per kernel (non-reentrant)
+    store = FreeR,                       \* one reactive's KernelStore._lock (RLock)
+    uv    = NoProc,                      \* the uvicorn event loop
+    kal   = NoProc;                      \* the keep-alive event loop
+
+(*************************************************************************)
+(* The message thread of kernel k.  server.py holds context.lock for the  *)
+(* whole handler.  The handler writes a reactive HandlerSteps times, and  *)
+(* each write renders.  A render sends one widget update (portal.call ->  *)
+(* uv) and does one reactive read (mutation detection -> store).          *)
+(*************************************************************************)
+fair+ process Msg \in MsgIds
+variable i = 0;
+begin
+M_Ctx:
+    await ctx[self[2]].owner \in {NoProc, self};
+    ctx[self[2]] := AcqR(ctx[self[2]], self);
+M_Loop:
+    while i < HandlerSteps do
+    M_RenderAcq:
+        await rlock[self[2]] = NoProc;
+        rlock[self[2]] := self;
+    M_Send:
+        \* portal.call: needs the uvicorn loop to run one step
+        await uv = NoProc;
+        uv := self;
+    M_SendDone:
+        uv := NoProc;
+    M_Read:
+        \* mutation detection reads the reactive, which takes the store lock
+        await store.owner \in {NoProc, self};
+        store := AcqR(store, self);
+    M_ReadDone:
+        store := RelR(store);
+    M_RenderRel:
+        rlock[self[2]] := NoProc;
+        \* a wedged handler (WedgeK1) never finishes its loop
+        i := IF WedgeK1 /\ self[2] = 1 THEN 0 ELSE i + 1;
+    end while;
+M_CtxRel:
+    ctx[self[2]] := RelR(ctx[self[2]]);
+end process;
+
+(*************************************************************************)
+(* A background task that writes the same reactive once via update().     *)
+(* OLD: fire the listeners (a render) while still holding the store lock. *)
+(* NEW: _set_deferred stores under the lock, releases, then fires.        *)
+(*************************************************************************)
+fair+ process Task \in TaskIds
+begin
+T_StoreAcq:
+    await store.owner \in {NoProc, self};
+    store := AcqR(store, self);
+T_Store:
+    \* read-modify-write of the value happens here (no data modelled)
+    if NewStoreRules then
+        store := RelR(store);
+    end if;
+T_FireAcq:
+    \* firing a listener means a render, which takes the render lock
+    await rlock[self[2]] = NoProc;
+    rlock[self[2]] := self;
+T_FireRel:
+    rlock[self[2]] := NoProc;
+T_Rel:
+    if ~NewStoreRules then
+        store := RelR(store);
+    end if;
+end process;
+
+(*************************************************************************)
+(* The HTTP evict route (starlette.py:451 evict).                         *)
+(* OLD: the coroutine called context.close() itself, so it held the       *)
+(* uvicorn loop for the whole close.                                      *)
+(* NEW: _off_loop hands the close to a thread; the loop is free again.    *)
+(*************************************************************************)
+fair+ process Evict = EvictId
+begin
+E_Start:
+    if ~EvictOn then
+        goto Done;
+    end if;
+E_Uv:
+    await uv = NoProc;
+    uv := EvictId;
+E_HandOff:
+    if NewCloseRules then
+        uv := NoProc;          \* _off_loop: run the close on a thread
+    end if;
+E_Ctx:
+    await ctx[1].owner \in {NoProc, EvictId};
+    ctx[1] := AcqR(ctx[1], EvictId);
+E_Render:
+    await rlock[1] = NoProc;   \* close() closes the render context
+    rlock[1] := EvictId;
+E_Rel:
+    rlock[1] := NoProc;
+    ctx[1] := RelR(ctx[1]);
+E_UvRel:
+    if ~NewCloseRules then
+        uv := NoProc;
+    end if;
+end process;
+
+(*************************************************************************)
+(* The cull task of kernel k (kernel_context.py _bump_kernel_cull).       *)
+(* OLD: close() ran inline on the shared keep-alive loop.                 *)
+(* NEW: _run_in_thread runs the close off that loop and only awaits it.   *)
+(*************************************************************************)
+fair+ process Cull \in CullIds
+begin
+C_Kal:
+    await kal = NoProc;
+    kal := self;
+C_HandOff:
+    if NewCloseRules then
+        kal := NoProc;         \* _run_in_thread
+    end if;
+C_Ctx:
+    await ctx[self[2]].owner \in {NoProc, self};
+    ctx[self[2]] := AcqR(ctx[self[2]], self);
+C_Render:
+    await rlock[self[2]] = NoProc;
+    rlock[self[2]] := self;
+C_Rel:
+    rlock[self[2]] := NoProc;
+    ctx[self[2]] := RelR(ctx[self[2]]);
+C_KalRel:
+    if ~NewCloseRules then
+        kal := NoProc;
+    end if;
+end process;
+
+end algorithm; *)
+
+\* BEGIN TRANSLATION
+VARIABLES ctx, rlock, store, uv, kal, pc, i
+
+vars == << ctx, rlock, store, uv, kal, pc, i >>
+
+ProcSet == (MsgIds) \cup (TaskIds) \cup {EvictId} \cup (CullIds)
+
+Init == (* Global variables *)
+        /\ ctx = [k \in Kernels |-> FreeR]
+        /\ rlock = [k \in Kernels |-> NoProc]
+        /\ store = FreeR
+        /\ uv = NoProc
+        /\ kal = NoProc
+        (* Process Msg *)
+        /\ i = [self \in MsgIds |-> 0]
+        /\ pc = [self \in ProcSet |-> CASE self \in MsgIds -> "M_Ctx"
+                                        [] self \in TaskIds -> "T_StoreAcq"
+                                        [] self = EvictId -> "E_Start"
+                                        [] self \in CullIds -> "C_Kal"]
+
+M_Ctx(self) == /\ pc[self] = "M_Ctx"
+               /\ ctx[self[2]].owner \in {NoProc, self}
+               /\ ctx' = [ctx EXCEPT ![self[2]] = AcqR(ctx[self[2]], self)]
+               /\ pc' = [pc EXCEPT ![self] = "M_Loop"]
+               /\ UNCHANGED << rlock, store, uv, kal, i >>
+
+M_Loop(self) == /\ pc[self] = "M_Loop"
+                /\ IF i[self] < HandlerSteps
+                      THEN /\ pc' = [pc EXCEPT ![self] = "M_RenderAcq"]
+                      ELSE /\ pc' = [pc EXCEPT ![self] = "M_CtxRel"]
+                /\ UNCHANGED << ctx, rlock, store, uv, kal, i >>
+
+M_RenderAcq(self) == /\ pc[self] = "M_RenderAcq"
+                     /\ rlock[self[2]] = NoProc
+                     /\ rlock' = [rlock EXCEPT ![self[2]] = self]
+                     /\ pc' = [pc EXCEPT ![self] = "M_Send"]
+                     /\ UNCHANGED << ctx, store, uv, kal, i >>
+
+M_Send(self) == /\ pc[self] = "M_Send"
+                /\ uv = NoProc
+                /\ uv' = self
+                /\ pc' = [pc EXCEPT ![self] = "M_SendDone"]
+                /\ UNCHANGED << ctx, rlock, store, kal, i >>
+
+M_SendDone(self) == /\ pc[self] = "M_SendDone"
+                    /\ uv' = NoProc
+                    /\ pc' = [pc EXCEPT ![self] = "M_Read"]
+                    /\ UNCHANGED << ctx, rlock, store, kal, i >>
+
+M_Read(self) == /\ pc[self] = "M_Read"
+                /\ store.owner \in {NoProc, self}
+                /\ store' = AcqR(store, self)
+                /\ pc' = [pc EXCEPT ![self] = "M_ReadDone"]
+                /\ UNCHANGED << ctx, rlock, uv, kal, i >>
+
+M_ReadDone(self) == /\ pc[self] = "M_ReadDone"
+                    /\ store' = RelR(store)
+                    /\ pc' = [pc EXCEPT ![self] = "M_RenderRel"]
+                    /\ UNCHANGED << ctx, rlock, uv, kal, i >>
+
+M_RenderRel(self) == /\ pc[self] = "M_RenderRel"
+                     /\ rlock' = [rlock EXCEPT ![self[2]] = NoProc]
+                     /\ i' = [i EXCEPT ![self] = IF WedgeK1 /\ self[2] = 1 THEN 0 ELSE i[self] + 1]
+                     /\ pc' = [pc EXCEPT ![self] = "M_Loop"]
+                     /\ UNCHANGED << ctx, store, uv, kal >>
+
+M_CtxRel(self) == /\ pc[self] = "M_CtxRel"
+                  /\ ctx' = [ctx EXCEPT ![self[2]] = RelR(ctx[self[2]])]
+                  /\ pc' = [pc EXCEPT ![self] = "Done"]
+                  /\ UNCHANGED << rlock, store, uv, kal, i >>
+
+Msg(self) == M_Ctx(self) \/ M_Loop(self) \/ M_RenderAcq(self)
+                \/ M_Send(self) \/ M_SendDone(self) \/ M_Read(self)
+                \/ M_ReadDone(self) \/ M_RenderRel(self) \/ M_CtxRel(self)
+
+T_StoreAcq(self) == /\ pc[self] = "T_StoreAcq"
+                    /\ store.owner \in {NoProc, self}
+                    /\ store' = AcqR(store, self)
+                    /\ pc' = [pc EXCEPT ![self] = "T_Store"]
+                    /\ UNCHANGED << ctx, rlock, uv, kal, i >>
+
+T_Store(self) == /\ pc[self] = "T_Store"
+                 /\ IF NewStoreRules
+                       THEN /\ store' = RelR(store)
+                       ELSE /\ TRUE
+                            /\ store' = store
+                 /\ pc' = [pc EXCEPT ![self] = "T_FireAcq"]
+                 /\ UNCHANGED << ctx, rlock, uv, kal, i >>
+
+T_FireAcq(self) == /\ pc[self] = "T_FireAcq"
+                   /\ rlock[self[2]] = NoProc
+                   /\ rlock' = [rlock EXCEPT ![self[2]] = self]
+                   /\ pc' = [pc EXCEPT ![self] = "T_FireRel"]
+                   /\ UNCHANGED << ctx, store, uv, kal, i >>
+
+T_FireRel(self) == /\ pc[self] = "T_FireRel"
+                   /\ rlock' = [rlock EXCEPT ![self[2]] = NoProc]
+                   /\ pc' = [pc EXCEPT ![self] = "T_Rel"]
+                   /\ UNCHANGED << ctx, store, uv, kal, i >>
+
+T_Rel(self) == /\ pc[self] = "T_Rel"
+               /\ IF ~NewStoreRules
+                     THEN /\ store' = RelR(store)
+                     ELSE /\ TRUE
+                          /\ store' = store
+               /\ pc' = [pc EXCEPT ![self] = "Done"]
+               /\ UNCHANGED << ctx, rlock, uv, kal, i >>
+
+Task(self) == T_StoreAcq(self) \/ T_Store(self) \/ T_FireAcq(self)
+                 \/ T_FireRel(self) \/ T_Rel(self)
+
+E_Start == /\ pc[EvictId] = "E_Start"
+           /\ IF ~EvictOn
+                 THEN /\ pc' = [pc EXCEPT ![EvictId] = "Done"]
+                 ELSE /\ pc' = [pc EXCEPT ![EvictId] = "E_Uv"]
+           /\ UNCHANGED << ctx, rlock, store, uv, kal, i >>
+
+E_Uv == /\ pc[EvictId] = "E_Uv"
+        /\ uv = NoProc
+        /\ uv' = EvictId
+        /\ pc' = [pc EXCEPT ![EvictId] = "E_HandOff"]
+        /\ UNCHANGED << ctx, rlock, store, kal, i >>
+
+E_HandOff == /\ pc[EvictId] = "E_HandOff"
+             /\ IF NewCloseRules
+                   THEN /\ uv' = NoProc
+                   ELSE /\ TRUE
+                        /\ uv' = uv
+             /\ pc' = [pc EXCEPT ![EvictId] = "E_Ctx"]
+             /\ UNCHANGED << ctx, rlock, store, kal, i >>
+
+E_Ctx == /\ pc[EvictId] = "E_Ctx"
+         /\ ctx[1].owner \in {NoProc, EvictId}
+         /\ ctx' = [ctx EXCEPT ![1] = AcqR(ctx[1], EvictId)]
+         /\ pc' = [pc EXCEPT ![EvictId] = "E_Render"]
+         /\ UNCHANGED << rlock, store, uv, kal, i >>
+
+E_Render == /\ pc[EvictId] = "E_Render"
+            /\ rlock[1] = NoProc
+            /\ rlock' = [rlock EXCEPT ![1] = EvictId]
+            /\ pc' = [pc EXCEPT ![EvictId] = "E_Rel"]
+            /\ UNCHANGED << ctx, store, uv, kal, i >>
+
+E_Rel == /\ pc[EvictId] = "E_Rel"
+         /\ rlock' = [rlock EXCEPT ![1] = NoProc]
+         /\ ctx' = [ctx EXCEPT ![1] = RelR(ctx[1])]
+         /\ pc' = [pc EXCEPT ![EvictId] = "E_UvRel"]
+         /\ UNCHANGED << store, uv, kal, i >>
+
+E_UvRel == /\ pc[EvictId] = "E_UvRel"
+           /\ IF ~NewCloseRules
+                 THEN /\ uv' = NoProc
+                 ELSE /\ TRUE
+                      /\ uv' = uv
+           /\ pc' = [pc EXCEPT ![EvictId] = "Done"]
+           /\ UNCHANGED << ctx, rlock, store, kal, i >>
+
+Evict == E_Start \/ E_Uv \/ E_HandOff \/ E_Ctx \/ E_Render \/ E_Rel
+            \/ E_UvRel
+
+C_Kal(self) == /\ pc[self] = "C_Kal"
+               /\ kal = NoProc
+               /\ kal' = self
+               /\ pc' = [pc EXCEPT ![self] = "C_HandOff"]
+               /\ UNCHANGED << ctx, rlock, store, uv, i >>
+
+C_HandOff(self) == /\ pc[self] = "C_HandOff"
+                   /\ IF NewCloseRules
+                         THEN /\ kal' = NoProc
+                         ELSE /\ TRUE
+                              /\ kal' = kal
+                   /\ pc' = [pc EXCEPT ![self] = "C_Ctx"]
+                   /\ UNCHANGED << ctx, rlock, store, uv, i >>
+
+C_Ctx(self) == /\ pc[self] = "C_Ctx"
+               /\ ctx[self[2]].owner \in {NoProc, self}
+               /\ ctx' = [ctx EXCEPT ![self[2]] = AcqR(ctx[self[2]], self)]
+               /\ pc' = [pc EXCEPT ![self] = "C_Render"]
+               /\ UNCHANGED << rlock, store, uv, kal, i >>
+
+C_Render(self) == /\ pc[self] = "C_Render"
+                  /\ rlock[self[2]] = NoProc
+                  /\ rlock' = [rlock EXCEPT ![self[2]] = self]
+                  /\ pc' = [pc EXCEPT ![self] = "C_Rel"]
+                  /\ UNCHANGED << ctx, store, uv, kal, i >>
+
+C_Rel(self) == /\ pc[self] = "C_Rel"
+               /\ rlock' = [rlock EXCEPT ![self[2]] = NoProc]
+               /\ ctx' = [ctx EXCEPT ![self[2]] = RelR(ctx[self[2]])]
+               /\ pc' = [pc EXCEPT ![self] = "C_KalRel"]
+               /\ UNCHANGED << store, uv, kal, i >>
+
+C_KalRel(self) == /\ pc[self] = "C_KalRel"
+                  /\ IF ~NewCloseRules
+                        THEN /\ kal' = NoProc
+                        ELSE /\ TRUE
+                             /\ kal' = kal
+                  /\ pc' = [pc EXCEPT ![self] = "Done"]
+                  /\ UNCHANGED << ctx, rlock, store, uv, i >>
+
+Cull(self) == C_Kal(self) \/ C_HandOff(self) \/ C_Ctx(self)
+                 \/ C_Render(self) \/ C_Rel(self) \/ C_KalRel(self)
+
+(* Allow infinite stuttering to prevent deadlock on termination. *)
+Terminating == /\ \A self \in ProcSet: pc[self] = "Done"
+               /\ UNCHANGED vars
+
+Next == Evict
+           \/ (\E self \in MsgIds: Msg(self))
+           \/ (\E self \in TaskIds: Task(self))
+           \/ (\E self \in CullIds: Cull(self))
+           \/ Terminating
+
+Spec == /\ Init /\ [][Next]_vars
+        /\ \A self \in MsgIds : SF_vars(Msg(self))
+        /\ \A self \in TaskIds : SF_vars(Task(self))
+        /\ SF_vars(Evict)
+        /\ \A self \in CullIds : SF_vars(Cull(self))
+
+Termination == <>(\A self \in ProcSet: pc[self] = "Done")
+
+\* END TRANSLATION
+
+-----------------------------------------------------------------------------
+\* The same spec with WEAK fairness.  Every behaviour allowed by Spec (strong
+\* fairness) is also allowed by SpecWF, so a property that holds for SpecWF
+\* holds for Spec as well.  It is used for the New configuration, whose strong
+\* fairness liveness pass does not fit the time budget (see README.md).
+SpecWF == /\ Init /\ [][Next]_vars
+          /\ \A self \in MsgIds : WF_vars(Msg(self))
+          /\ \A self \in TaskIds : WF_vars(Task(self))
+          /\ WF_vars(Evict)
+          /\ \A self \in CullIds : WF_vars(Cull(self))
+
+-----------------------------------------------------------------------------
+\* Safety: the non-reentrant render lock is never taken by its own owner, and
+\* the reentrant locks keep a consistent owner/count.
+TypeOK ==
+    /\ \A k \in Kernels : rlock[k] \in ({NoProc} \cup MsgIds \cup TaskIds \cup CullIds \cup {EvictId})
+    /\ \A k \in Kernels : (ctx[k].owner = NoProc) <=> (ctx[k].count = 0)
+    /\ (store.owner = NoProc) <=> (store.count = 0)
+
+\* Liveness.  All-Done is reached by the Terminating stuttering step the
+\* PlusCal translator adds, so all-Done is NOT reported as a deadlock; every
+\* other state with no enabled action is a real lock cycle.
+AllDone      == <>(\A p \in ProcSet : pc[p] = "Done")
+AllCullsDone == <>(\A k \in Kernels : pc[<<"cull", k>>] = "Done")
+\* One wedged kernel must not stall the cull of the other kernel.
+Cull2Done    == <>(pc[<<"cull", 2>>] = "Done")
+=============================================================================

--- a/solara/_stores.py
+++ b/solara/_stores.py
@@ -3,6 +3,7 @@ import dataclasses
 import inspect
 import sys
 import threading
+import functools
 from typing import Callable, ContextManager, Generic, Optional, Union, cast, Any
 import warnings
 
@@ -62,6 +63,11 @@ class MutateDetectorStore(ValueBase[S]):
         self._storage.clear()
 
     def set(self, value: S):
+        fire = self._set_deferred(value)
+        if fire is not None:
+            fire()
+
+    def _set_deferred(self, value: S) -> Optional[Callable[[], None]]:
         self.check_mutations()
         self._ensure_public_exists()
         private = copy.deepcopy(value)
@@ -72,7 +78,7 @@ class MutateDetectorStore(ValueBase[S]):
         else:
             frame_info = None
         store_value = StoreValue(private=private, public=_PublicValueNotSet(), get_traceback=None, set_value=value, set_traceback=frame_info)
-        self._storage.set(store_value)
+        return self._storage._set_deferred(store_value)
 
     def check_mutations(self):
         self._storage._check_mutation()
@@ -284,10 +290,15 @@ reactive_df = solara.reactive(df, equals=solara.util.equals_pickle)
         return "GLOBAL"
 
     def set(self, value: S):
+        fire = self._set_deferred(value)
+        if fire is not None:
+            fire()
+
+    def _set_deferred(self, value: S) -> Optional[Callable[[], None]]:
         self._check_mutation()
         old = self.get()
         if self.equals(old, value):
-            return
+            return None
         self._value = value
 
         if _DEBUG:
@@ -298,4 +309,4 @@ reactive_df = solara.reactive(df, equals=solara.util.equals_pickle)
             print("change old", old)  # noqa
             print("change new", value)  # noqa
 
-        self.fire(value, old)
+        return functools.partial(self.fire, value, old)

--- a/solara/server/kernel_context.py
+++ b/solara/server/kernel_context.py
@@ -63,6 +63,36 @@ class _LifecycleState(enum.Enum):
     CLOSED = "closed"
 
 
+async def _run_in_thread(func: Callable[[], Any], name: str) -> Any:
+    """Run ``func`` on a fresh (unbounded) daemon thread and await its result.
+
+    Not an executor: a pool would let a handful of wedged kernels exhaust it and stall
+    the rest again. The thread runs without a kernel context (the loop thread has none).
+    """
+    loop = asyncio.get_running_loop()
+    future: "asyncio.Future[Any]" = loop.create_future()
+
+    def deliver(setter: Callable[[], None]) -> None:
+        try:
+            loop.call_soon_threadsafe(lambda: None if future.done() else setter())
+        except RuntimeError:
+            pass  # loop closed (testing)
+
+    def run() -> None:
+        try:
+            result = func()
+        except BaseException as error:  # noqa
+            exception = error  # `error` is unbound once the except block exits
+            deliver(lambda: future.set_exception(exception))
+        else:
+            deliver(lambda: future.set_result(result))
+
+    thread = threading.Thread(target=run, name=name, daemon=True)
+    thread.current_context = None  # type: ignore  # see patch.WidgetContextAwareThread__init__
+    thread.start()
+    return await future
+
+
 def _get_or_create_event_loop() -> asyncio.AbstractEventLoop:
     # On Python 3.12+, asyncio.get_event_loop() raises RuntimeError when called
     # from the main thread after asyncio.run() has cleaned up the loop.
@@ -288,7 +318,7 @@ class VirtualKernelContext:
 
         MUST run BEFORE ``close()`` acquires ``self.lock``: the worker's final flush does backend
         I/O and the delete is a backend call - doing either under ``context.lock`` is the documented
-        deadlock (docs/reactive-initialization-lock-deadlock.md). Wrapped so a persistence failure
+        deadlock (docs/deadlock-rules.md). Wrapped so a persistence failure
         never breaks close(). Idempotent (the worker's own close() and manager detach guard reruns).
         """
         worker = self.state_flush_worker
@@ -328,15 +358,25 @@ class VirtualKernelContext:
             logger.exception("state persistence teardown failed for kernel %s", self.id)
 
     def close(self, reason: str = "unknown"):
+        if self._begin_close(reason):
+            self._finish_close()
+
+    def _begin_close(self, reason: str) -> bool:
+        """Mark the kernel as closing; True when the caller must run ``_finish_close``.
+
+        Split from close() so the decision to close and the CLOSING mark can happen under
+        the same ``self.lock`` hold: page_connect checks ``is_closing()`` under ``self.lock``,
+        so a decision made under the lock and a mark set after releasing it leave a window in
+        which a reconnect marks a page CONNECTED on a kernel that is about to die
+        (docs/tla/SolaraLifecycle.tla shows the interleaving). Cheap: no I/O, no other lock.
+        """
         with self._lifecycle_lock:
             if self._lifecycle_state in (_LifecycleState.CLOSING, _LifecycleState.CLOSED):
-                return
+                return False
             restart_owns_close = self._lifecycle_state is _LifecycleState.RESTARTING
             self._lifecycle_state = _LifecycleState.CLOSING
             self.close_reason = reason
-        if restart_owns_close:
-            return
-        self._finish_close()
+        return not restart_owns_close
 
     def _finish_close(self):
         fatal: Optional[BaseException] = None
@@ -402,7 +442,10 @@ class VirtualKernelContext:
                     del contexts[self.id]
         for key, context in list(current_context.items()):
             if context is self:
-                del current_context[key]
+                # pop, not del: a thread exiting right now removes its own key
+                # (clear_context_for_thread), and a KeyError here would abort the
+                # close before closed_event is set, hanging everyone waiting on it
+                current_context.pop(key, None)
 
         while True:
             with self._lifecycle_lock:
@@ -486,14 +529,44 @@ class VirtualKernelContext:
                 logger.info("Scheduling kernel cull, will wait for max %s before shutting down the virtual kernel %s", cull_timeout_sleep_seconds, self.id)
                 await asyncio.sleep(cull_timeout_sleep_seconds)
                 logger.info("Timeout reached, checking if we should be shutting down virtual kernel %s", self.id)
-                with self.lock:
-                    has_connected_pages = PageStatus.CONNECTED in self.page_status.values()
-                if has_connected_pages:
-                    logger.info("We have (re)connected pages, keeping the virtual kernel %s alive", self.id)
+                this_task = asyncio.current_task()
+
+                def cull() -> bool:
+                    # Runs on its own thread, OFF keep_alive_event_loop: that loop is shared by
+                    # every kernel's cull task, and both the self.lock below and close() (self.lock,
+                    # close callbacks, the render lock) can block for as long as an event handler
+                    # runs. One kernel wedged in a handler would stall the cull of every other
+                    # kernel in the process, which is a process-wide leak (docs/deadlock-rules.md).
+                    with self.lock:
+                        if PageStatus.CONNECTED in self.page_status.values():
+                            return False
+                        if self._last_kernel_cull_task is this_task:
+                            # we are that task (and that future): nothing for close() to cancel.
+                            # Cancelling ourselves while we await the close would cancel the
+                            # future the caller of page_disconnect is awaiting.
+                            self._last_kernel_cull_task = None
+                            self._last_kernel_cull_future = None
+                        # mark CLOSING under the same lock hold as the decision, so a reconnect
+                        # racing us sees is_closing() and gets a fresh kernel (see _begin_close)
+                        owns_close = self._begin_close("cull")
+                    # the rest OUTSIDE self.lock: its persistence teardown does backend I/O (§5.3)
+                    if owns_close:
+                        self._finish_close()
+                    return True
+
+                try:
+                    closed = await _run_in_thread(cull, name=f"solara-kernel-cull-{self.id}")
+                except asyncio.CancelledError:
+                    raise
+                except BaseException:  # noqa
+                    # a failing close must still resolve the future the page_disconnect caller
+                    # awaits (below), or that caller waits forever
+                    logger.exception("Error while culling virtual kernel %s", self.id)
                 else:
-                    logger.info("No connected pages, and timeout reached, shutting down virtual kernel %s", self.id)
-                    # close() OUTSIDE self.lock: its persistence teardown does backend I/O (§5.3)
-                    self.close(reason="cull")
+                    if closed:
+                        logger.info("No connected pages, and timeout reached, shut down virtual kernel %s", self.id)
+                    else:
+                        logger.info("We have (re)connected pages, keeping the virtual kernel %s alive", self.id)
                 if current_event_loop is not None and future is not None:
                     try:
                         current_event_loop.call_soon_threadsafe(future.set_result, None)
@@ -509,12 +582,6 @@ class VirtualKernelContext:
                     except RuntimeError:
                         pass  # event loop already closed, happens during testing
                 raise
-
-        async def create_task():
-            task = asyncio.create_task(kernel_cull())
-            # create a reference to the task so we can cancel it later
-            self._last_kernel_cull_task = task
-            await task
 
         with self.lock:
             future: "Optional[asyncio.Future[None]]" = None
@@ -606,14 +673,15 @@ class VirtualKernelContext:
             if has_disconnected_pages:
                 future = self._bump_kernel_cull()
             if not (has_connected_pages or has_disconnected_pages):
-                should_close = True
+                # a genuine tab close, reason="page-close" so the fenced delete removes the
+                # hash (§5.4). Mark CLOSING here, under the lock of the decision (see
+                # _begin_close); the teardown itself runs OUTSIDE self.lock (backend I/O, §5.3)
+                should_close = self._begin_close("page-close")
             else:
                 logger.info("Still have connected or disconnected pages, keeping virtual kernel %s alive", self.id)
         if should_close:
-            # a genuine tab close: close() OUTSIDE self.lock (persistence teardown does backend
-            # I/O, §5.3) with reason="page-close" so the fenced delete removes the hash (§5.4)
             logger.info("No connected or disconnected pages, shutting down virtual kernel %s", self.id)
-            self.close(reason="page-close")
+            self._finish_close()
         return future
 
 
@@ -696,16 +764,31 @@ else:
     async_context_id = None
 
 
+def _async_context_key() -> Optional[str]:
+    """The non-threaded-mode context key, or None on a thread where it was never set.
+
+    The ContextVar is set per websocket task (starlette.py) and once on the importing
+    thread ("default"). A plain thread starts with an empty contextvars context, so on the
+    threads that close kernels (cull, evict, shutdown) it is unset: raising there would
+    abort close() before closed_event is set (docs/deadlock-rules.md, rule 6). Fall back
+    to a thread-based key instead; a shared default would let two closing threads clobber
+    each other's entry in current_context and pin a closed context.
+    """
+    if async_context_id is None:
+        raise RuntimeError("No threading support, and no contextvars support (Python 3.6 is not supported for this)")
+    try:
+        return async_context_id.get()
+    except LookupError:
+        return None
+
+
 def get_current_thread_key() -> str:
     # consider renaming this to get_current_context_key
     if not solara.server.settings.kernel.threaded:
-        if async_context_id is not None:
-            try:
-                key = async_context_id.get()
-            except LookupError:
-                raise RuntimeError("no kernel context set")
-        else:
-            raise RuntimeError("No threading support, and no contextvars support (Python 3.6 is not supported for this)")
+        key = _async_context_key()
+        if key is None:
+            thread = threading.current_thread()
+            key = thread._name + str(thread._ident)  # type: ignore
     else:
         thread = threading.current_thread()
         key = get_thread_key(thread)
@@ -721,8 +804,9 @@ def get_current_thread_key() -> str:
 
 def get_thread_key(thread: threading.Thread) -> str:
     if not solara.server.settings.kernel.threaded:
-        if async_context_id is not None:
-            return async_context_id.get()
+        key = _async_context_key()
+        if key is not None:
+            return key
     thread_key = thread._name + str(thread._ident)  # type: ignore
     return thread_key
 

--- a/solara/server/patch.py
+++ b/solara/server/patch.py
@@ -329,13 +329,25 @@ def _WidgetContextAwareThread__bootstrap(self):
         # we need to call this manually, because set_context_for_thread
         # uses this, and the original _bootstrap calls it too late for us
         self._set_ident()
-        if kernel_context.async_context_id is not None:
-            kernel_context.async_context_id.set(self.current_context.id)
-        kernel_context.set_context_for_thread(self.current_context, self)
-        shell = self.current_context.kernel.shell
-        display_pub = shell.display_pub
-        display_in_reacton_hook = shell.display_in_reacton_hook
-        display_pub.register_hook(display_in_reacton_hook)
+        try:
+            if kernel_context.async_context_id is not None:
+                kernel_context.async_context_id.set(self.current_context.id)
+            kernel_context.set_context_for_thread(self.current_context, self)
+            shell = self.current_context.kernel.shell
+            display_pub = shell.display_pub
+            display_in_reacton_hook = shell.display_in_reacton_hook
+            display_pub.register_hook(display_in_reacton_hook)
+        except BaseException:  # noqa
+            # same hang as above, but the close is half way (kernel.close() already tore
+            # down the shell, kernel is not None yet): anything raised here happens before
+            # Thread._bootstrap marks the thread as started, so the start() caller would
+            # wait forever. Log, and run without a kernel context.
+            logger.exception("Could not bind thread %s to its kernel context, running without one", self._name)
+            self.current_context = None
+            try:
+                kernel_context.clear_context_for_thread(self)
+            except BaseException:  # noqa - must not raise either, same hang
+                pass
     try:
         context = self.current_context or solara.util.nullcontext()
         with pdb_guard(), context:

--- a/solara/server/settings.py
+++ b/solara/server/settings.py
@@ -226,6 +226,10 @@ class Server(BaseSettings):
     # Requires uvicorn's websockets implementation; falls back to the default
     # path (with a log message) when unavailable. See starlette.py.
     sync_ws_write: bool = False
+    # at shutdown every kernel is closed in parallel; a kernel whose event handler still
+    # runs holds its lock and cannot be closed, so wait at most this many seconds
+    # (SOLARA_SERVER_SHUTDOWN_CLOSE_TIMEOUT) before letting the process exit take it
+    shutdown_close_timeout: float = 10.0
 
     class Config:
         env_prefix = "solara_server_"

--- a/solara/server/starlette.py
+++ b/solara/server/starlette.py
@@ -1,4 +1,5 @@
 import asyncio
+import functools
 import concurrent.futures
 from contextlib import asynccontextmanager
 import hashlib
@@ -8,6 +9,7 @@ import json
 import logging
 import math
 import os
+import queue
 import secrets
 from pathlib import Path
 import sys
@@ -246,8 +248,8 @@ await to_thread.run_sync(my_update)
                     task = self.event_loop.create_task(self._send_bytes_exc(data))
                     self.tasks.add(task)
                     task.add_done_callback(self.tasks.discard)
-
-                self.portal.call(self._send_bytes_exc, data)
+                else:
+                    self.portal.call(self._send_bytes_exc, data)
 
     async def receive(self):
         if self.portal is None:
@@ -468,8 +470,21 @@ async def evict(request: Request):
     session_id = request.cookies.get(server.COOKIE_KEY_SESSION_ID)
     if not session_id or session_id != context.session_id:
         return Response(status_code=403)
-    context.close(reason="evicted")
+    # never close a kernel ON the event loop thread, see _off_loop
+    await _off_loop(functools.partial(context.close, reason="evicted"))
     return Response(status_code=200)
+
+
+async def _off_loop(func):
+    """Run blocking kernel teardown on a worker thread, never on the event loop.
+
+    In threaded mode the kernel's message thread holds ``context.lock`` for the whole
+    duration of an event handler (server.py, app_loop), and every widget update it makes
+    is a ``portal.call`` that needs this event loop to run. ``context.close()`` blocks on
+    that same lock. Calling close() from a coroutine therefore deadlocks whenever a
+    handler is busy: the loop waits for the lock, the handler waits for the loop.
+    """
+    return await asyncio.get_running_loop().run_in_executor(None, func)
 
 
 async def root(request: Request, fullpath: str = ""):
@@ -794,12 +809,62 @@ def on_shutdown():
     except Exception:  # noqa
         logger.exception("error draining state workers on shutdown")
     # shutdown all kernels
-    for context in list(kernel_context.contexts.values()):
-        try:
-            context.close(reason="server-shutdown")
-        except:  # noqa
-            logger.exception("error closing kernel on shutdown")
+    _close_all_contexts()
     telemetry.server_stop()
+
+
+def _close_all_contexts(deadline_seconds: Optional[float] = None) -> None:
+    """Close every kernel at shutdown, in parallel and under one deadline.
+
+    close() waits for ``context.lock``, which an event handler holds for as long as it
+    runs. Closing serially would let one kernel with a long handler push the whole
+    shutdown past the orchestrator's grace period (then the process is SIGKILLed with
+    nothing else cleaned up). So close all kernels at once, wait at most the deadline
+    (settings.server.shutdown_close_timeout), and log the ones that did not make it:
+    their handler thread was going to die with the process anyway. The state-persistence
+    flush already ran in _drain_state_workers, so an unfinished close loses no state.
+
+    Daemon threads, not a ThreadPoolExecutor: the interpreter joins executor workers at
+    exit (even after shutdown(wait=False)), so a close still blocked on a handler's lock
+    would hold the process until SIGKILL, defeating the deadline. Daemon threads are
+    abandoned at exit. A bounded number of workers pull from a queue, so a process with
+    thousands of kernels does not create thousands of threads.
+    """
+    if deadline_seconds is None:
+        deadline_seconds = settings.server.shutdown_close_timeout
+    contexts = list(kernel_context.contexts.values())
+    if not contexts:
+        return
+    deadline = time.monotonic() + deadline_seconds
+    todo: "queue.SimpleQueue[kernel_context.VirtualKernelContext]" = queue.SimpleQueue()
+    for context in contexts:
+        todo.put(context)
+    closed: Set[str] = set()
+    closed_lock = threading.Lock()
+    all_done = threading.Event()
+
+    def worker():
+        while True:
+            try:
+                context = todo.get_nowait()
+            except queue.Empty:
+                return
+            try:
+                context.close(reason="server-shutdown")
+            except BaseException:  # noqa - a close failure must not take the other closes down
+                logger.exception("error closing kernel %s on shutdown", context.id)
+            with closed_lock:
+                closed.add(context.id)
+                if len(closed) == len(contexts):
+                    all_done.set()
+
+    for index in range(min(32, len(contexts))):
+        threading.Thread(target=worker, name=f"solara-shutdown-close-{index}", daemon=True).start()
+    all_done.wait(max(0.0, deadline - time.monotonic()))
+    with closed_lock:
+        left = [context.id for context in contexts if context.id not in closed]
+    for kernel_id in left:
+        logger.warning("kernel %s did not close within the shutdown deadline (%.0fs), leaving it to the process exit", kernel_id, deadline_seconds)
 
 
 @asynccontextmanager
@@ -807,7 +872,10 @@ async def lifespan(app):
     """Lifespan context manager for Starlette (replaces on_startup/on_shutdown)."""
     on_startup()
     yield
-    on_shutdown()
+    # off the loop: with uvicorn's timeout_graceful_shutdown a kernel can still be inside an
+    # event handler here (its thread outlives the cancelled websocket task), and closing it
+    # from this thread would deadlock the shutdown, see _off_loop
+    await _off_loop(on_shutdown)
 
 
 def readyz(request: Request):

--- a/solara/state/worker.py
+++ b/solara/state/worker.py
@@ -140,7 +140,7 @@ class KernelFlushWorker:
         CONTRACT: **call this OUTSIDE ``context.lock``.** :meth:`flush_now` snapshots under the
         reactive lock (never ``context.lock``) and writes to the backend outside every lock,
         so holding ``context.lock`` here would risk the documented I/O-under-lock deadlock
-        (docs/reactive-initialization-lock-deadlock.md). The server wires this single call as
+        (docs/deadlock-rules.md). The server wires this single call as
         the context's ``on_close`` for a persistence-enabled kernel.
         """
         if self._closed:

--- a/solara/toestand.py
+++ b/solara/toestand.py
@@ -5,6 +5,7 @@ import logging
 import os
 import sys
 import threading
+import functools
 import time
 import traceback
 import weakref
@@ -392,15 +393,39 @@ class ValueBase(Generic[T]):
                         if context == entry.context:
                             entry.listener(new, old)
 
+    def _set_deferred(self, value: T) -> Optional[Callable[[], None]]:
+        """Store ``value`` without firing listeners.
+
+        Returns the deferred ``fire`` call when the value changed, else None. This is
+        the primitive for callers that hold ``self.lock`` for a read-modify-write
+        (``update``, field sets): listeners must fire AFTER the lock is released. A
+        listener runs arbitrary code, typically a render, which takes reacton's
+        render lock; a rendering thread that sets (or, with mutation detection,
+        even reads) the same reactive needs our lock: firing under the lock is an
+        ABBA deadlock between a background thread and the render thread.
+
+        Ordering: two threads writing the same reactive at once may notify in the
+        other order than they stored (the second writer can fire first). Plain
+        ``.value = x`` never ordered its notifications either, and every listener
+        solara itself installs re-reads the store instead of using the argument.
+        Listeners that must see the latest value should read it, not the argument.
+
+        The default keeps third-party stores working: set and fire inline.
+        """
+        self.set(value)
+        return None
+
     def update(self, _f=None, **kwargs):
-        if _f is not None:
-            assert not kwargs
-            with self.lock:
-                kwargs = _f(self.get())
         with self.lock:
             # important to have this part thread-safe
+            if _f is not None:
+                assert not kwargs
+                kwargs = _f(self.get())
             new = self.merge(self.get(), **kwargs)
-            self.set(new)
+            fire = self._set_deferred(new)
+        # listeners fire outside the lock, see _set_deferred
+        if fire is not None:
+            fire()
 
     def use_value(self) -> T:
         # .use with the default argument doesn't give good type inference
@@ -573,7 +598,7 @@ class KernelStore(ValueBase[S], ABC):
         if self.storage_key in scope_dict:
             del scope_dict[self.storage_key]
 
-    def set(self, value: S):
+    def _set_deferred(self, value: S) -> Optional[Callable[[], None]]:
         scope_dict, scope_id, context = self._get_dict()
         if not solara.settings.main.allow_global_context and scope_id == "global":
             raise RuntimeError(
@@ -581,7 +606,7 @@ class KernelStore(ValueBase[S], ABC):
             )
         old = self.get()
         if self.equals(old, value):
-            return
+            return None
         scope_dict[self.storage_key] = value
 
         if _DEBUG:
@@ -592,7 +617,12 @@ class KernelStore(ValueBase[S], ABC):
             print("change old", old)  # noqa
             print("change new", value)  # noqa
 
-        self.fire(value, old)
+        return functools.partial(self.fire, value, old)
+
+    def set(self, value: S):
+        fire = self._set_deferred(value)
+        if fire is not None:
+            fire()
 
     @abstractmethod
     def initial_value(self) -> S:
@@ -879,6 +909,11 @@ class Reactive(ValueBase[S]):
             raise ValueError("Can't set a reactive to itself")
         self._storage.set(value)
 
+    def _set_deferred(self, value: S) -> Optional[Callable[[], None]]:
+        if value is self:
+            raise ValueError("Can't set a reactive to itself")
+        return self._storage._set_deferred(value)
+
     def get(self, add_watch=None) -> S:
         if add_watch is not None:
             warnings.warn("add_watch is deprecated, use .peek()", DeprecationWarning)
@@ -1143,6 +1178,9 @@ class ReactiveField(Reactive[T]):
     def set(self, value: T):
         self._field.set(value)
 
+    def _set_deferred(self, value: T) -> Optional[Callable[[], None]]:
+        return self._field._set_deferred(value)
+
     def update(self, *args, **kwargs):
         ValueBase.update(cast(ValueBase, self), *args, **kwargs)
 
@@ -1167,6 +1205,14 @@ class FieldBase:
         raise NotImplementedError
 
     def set(self, value):
+        # the read-modify-write up the field chain happens under the root's lock, but
+        # the listeners fire after it is released (see ValueBase._set_deferred)
+        with self._lock:
+            fire = self._set_deferred(value)
+        if fire is not None:
+            fire()
+
+    def _set_deferred(self, value) -> Optional[Callable[[], None]]:
         raise NotImplementedError
 
 
@@ -1189,8 +1235,8 @@ class Fields(FieldBase):
             return obj
         return self._parent.peek()
 
-    def set(self, value):
-        self._parent.set(value)
+    def _set_deferred(self, value) -> Optional[Callable[[], None]]:
+        return self._parent._set_deferred(value)
 
     def __repr__(self):
         return repr(self._parent)
@@ -1210,14 +1256,13 @@ class FieldAttr(FieldBase):
         obj = self._parent.peek(obj)
         return getattr(obj, self.key)
 
-    def set(self, value):
-        with self._lock:
-            parent_value = self._parent.peek()
-            if isinstance(self.key, str):
-                parent_value = merge_state(parent_value, **{self.key: value})
-                self._parent.set(parent_value)
-            else:
-                raise TypeError(f"Type of key {self.key!r} is not supported")
+    def _set_deferred(self, value) -> Optional[Callable[[], None]]:
+        parent_value = self._parent.peek()
+        if isinstance(self.key, str):
+            parent_value = merge_state(parent_value, **{self.key: value})
+            return self._parent._set_deferred(parent_value)
+        else:
+            raise TypeError(f"Type of key {self.key!r} is not supported")
 
     def __str__(self):
         return f".{self.key}"
@@ -1240,17 +1285,16 @@ class FieldItem(FieldBase):
         obj = self._parent.peek(obj)
         return getitem(obj, self.key)
 
-    def set(self, value):
-        with self._lock:
-            parent_value = self._parent.peek()
-            if isinstance(self.key, int) and isinstance(parent_value, (list, tuple)):
-                parent_type = type(parent_value)
-                parent_value = parent_value.copy()  # type: ignore
-                parent_value[self.key] = value
-                self._parent.set(parent_type(parent_value))
-            else:
-                parent_value = merge_state(parent_value, **{self.key: value})
-                self._parent.set(parent_value)
+    def _set_deferred(self, value) -> Optional[Callable[[], None]]:
+        parent_value = self._parent.peek()
+        if isinstance(self.key, int) and isinstance(parent_value, (list, tuple)):
+            parent_type = type(parent_value)
+            parent_value = parent_value.copy()  # type: ignore
+            parent_value[self.key] = value
+            return self._parent._set_deferred(parent_type(parent_value))
+        else:
+            parent_value = merge_state(parent_value, **{self.key: value})
+            return self._parent._set_deferred(parent_value)
 
 
 @dataclasses.dataclass(eq=False)

--- a/tests/integration/deadlock_test.py
+++ b/tests/integration/deadlock_test.py
@@ -1,0 +1,82 @@
+import time
+from pathlib import Path
+
+import playwright.sync_api
+import pytest
+import requests
+
+import solara
+import solara.server.kernel_context
+import solara.server.settings
+from solara.server import kernel_context, server
+from solara.server.starlette import ServerStarlette
+
+HERE = Path(__file__).parent
+
+progress = solara.reactive(0)
+
+
+@solara.component
+def BusyApp():
+    """Button whose handler stays busy for ~10s while pushing widget updates."""
+
+    def start():
+        for i in range(40):
+            progress.value = i
+            time.sleep(0.25)
+
+    solara.Button(label="start", on_click=start)
+    solara.Text(f"progress {progress.value}")
+
+
+@pytest.fixture
+def eviction_enabled(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(solara.server.settings.state, "test_eviction", True)
+    if solara.server.settings.main.mode == "production":
+        monkeypatch.setattr(solara.server.settings.main, "mode", "development")
+    yield
+
+
+def test_evict_while_handler_busy_does_not_deadlock(
+    browser: playwright.sync_api.Browser,
+    page_session: playwright.sync_api.Page,
+    solara_server,
+    solara_app,
+    extra_include_path,
+    eviction_enabled,
+):
+    """Regression test: closing a kernel must never happen on the event loop thread.
+
+    A busy event handler holds ``context.lock`` and pushes widget updates through
+    ``portal.call``, which needs the event loop. If the evict route calls
+    ``context.close()`` inline, the loop blocks on the lock while the handler blocks on
+    the loop, and the whole server stops answering (even ``/readyz``).
+    """
+    if not isinstance(solara_server, ServerStarlette):
+        pytest.skip("the eviction route and the off-loop close are starlette-only")
+
+    with extra_include_path(HERE), solara_app("deadlock_test:BusyApp"):
+        kernel_context.contexts.clear()
+        page_session.goto(solara_server.base_url)
+        page_session.locator("text=progress 0").wait_for()
+        page_session.locator("button:has-text('start')").click()
+        # the handler is now running and sending widget updates
+        page_session.locator("text=progress 2").wait_for()
+
+        kernel_ids = [id for id in kernel_context.contexts if id != "dummy"]
+        assert len(kernel_ids) == 1, f"expected 1 kernel, got {kernel_ids}"
+        kernel_id = kernel_ids[0]
+        context = kernel_context.contexts[kernel_id]
+
+        cookies = page_session.context.cookies()
+        session_ids = [c["value"] for c in cookies if c["name"] == server.COOKIE_KEY_SESSION_ID]
+        assert session_ids, f"no {server.COOKIE_KEY_SESSION_ID} cookie: {cookies}"
+
+        url = f"{solara_server.base_url}/_solara/api/evict/{kernel_id}"
+        response = requests.post(url, cookies={server.COOKIE_KEY_SESSION_ID: session_ids[0]}, timeout=15)
+        assert response.status_code == 200, response.text
+
+        # the server must still serve other requests (it would not if the loop deadlocked)
+        assert requests.get(f"{solara_server.base_url}/readyz", timeout=5).status_code == 200
+
+        assert context.closed_event.wait(30)

--- a/tests/unit/deadlock_test.py
+++ b/tests/unit/deadlock_test.py
@@ -1,0 +1,317 @@
+"""Regression tests for lock-ordering deadlocks.
+
+Every test here models a real lock cycle with two threads and events, so the
+interleaving is deterministic: no sleeps, no luck. A failing test hangs, which
+pytest-timeout turns into a failure with the thread stacks.
+"""
+
+import asyncio
+import logging
+import threading
+import time
+
+import pytest
+
+import solara
+import solara.server.app  # installs the Thread patch
+from solara.server import kernel_context
+import solara.server.starlette as starlette_server
+from solara.toestand import Ref
+
+DEADLOCK_TIMEOUT = 5.0
+
+
+def _cross_locks(state, set_a, set_b):
+    """The reactive/render lock cycle.
+
+    Thread 1 sets a reactive: the store's lock is taken for the read-modify-write
+    and the listeners fire. The listener needs another lock (in solara this is
+    reacton's render lock, held for a whole render pass, effects included).
+
+    Thread 2 holds that other lock (it is "rendering") and sets the same
+    reactive, which needs the store's lock.
+
+    Firing listeners while holding the store's lock makes this an ABBA deadlock;
+    firing after releasing the lock does not.
+    """
+    # reacton's render lock is re-entered by the render thread's own listeners (it checks
+    # _is_rendering before rendering again), so model it with an RLock
+    render_lock = threading.RLock()
+    render_lock_held = threading.Event()
+    listener_entered = threading.Event()
+    listener_finished = threading.Event()
+
+    def listener(*_ignore):
+        listener_entered.set()
+        with render_lock:
+            pass
+        listener_finished.set()
+
+    def thread1():
+        assert render_lock_held.wait(DEADLOCK_TIMEOUT)
+        set_a()
+
+    def thread2():
+        with render_lock:
+            render_lock_held.set()
+            assert listener_entered.wait(DEADLOCK_TIMEOUT)
+            set_b()
+
+    unsubscribe = state.subscribe_change(listener)
+    try:
+        threads = [threading.Thread(target=thread1, daemon=True), threading.Thread(target=thread2, daemon=True)]
+        for thread in threads:
+            thread.start()
+        deadline = time.monotonic() + DEADLOCK_TIMEOUT
+        for thread in threads:
+            thread.join(max(0.0, deadline - time.monotonic()))
+        stuck = [thread for thread in threads if thread.is_alive()]
+        assert not stuck, "deadlock: listeners fired while the store lock was held"
+        assert listener_finished.is_set()
+    finally:
+        unsubscribe()
+
+
+@pytest.mark.timeout(30)
+def test_field_set_does_not_fire_listeners_under_the_store_lock():
+    state = solara.reactive({"a": 0, "b": 0})
+    a = Ref(state.fields["a"])
+    b = Ref(state.fields["b"])
+
+    def set_a():
+        a.value = 1
+
+    def set_b():
+        b.value = 2
+
+    _cross_locks(state, set_a, set_b)
+    assert state.value == {"a": 1, "b": 2}
+
+
+@pytest.mark.timeout(30)
+def test_update_does_not_fire_listeners_under_the_store_lock():
+    state = solara.reactive({"a": 0, "b": 0})
+    _cross_locks(state, lambda: state.update(a=1), lambda: state.update(b=2))
+    assert state.value == {"a": 1, "b": 2}
+
+
+@pytest.mark.timeout(30)
+def test_nested_field_set_does_not_fire_listeners_under_the_store_lock():
+    state = solara.reactive({"outer": {"a": 0, "b": 0}})
+    a = Ref(state.fields["outer"]["a"])
+    b = Ref(state.fields["outer"]["b"])
+
+    def set_a():
+        a.value = 1
+
+    def set_b():
+        b.value = 2
+
+    _cross_locks(state, set_a, set_b)
+    assert state.value == {"outer": {"a": 1, "b": 2}}
+
+
+@pytest.mark.timeout(30)
+def test_update_is_still_atomic_across_threads():
+    # firing outside the lock must not cost the read-modify-write atomicity of update()
+    counter = solara.reactive({"n": 0})
+    n_threads = 8
+    n_updates = 200
+
+    def worker():
+        for _ in range(n_updates):
+            counter.update(lambda value: {"n": value["n"] + 1})
+
+    threads = [threading.Thread(target=worker, daemon=True) for _ in range(n_threads)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(DEADLOCK_TIMEOUT)
+    assert counter.value == {"n": n_threads * n_updates}
+
+
+@pytest.mark.timeout(30)
+def test_field_set_is_still_atomic_across_threads():
+    state = solara.reactive({"inner": {"n": 0}})
+    inner = Ref(state.fields["inner"])
+    n_threads = 8
+    n_updates = 200
+
+    def worker():
+        for _ in range(n_updates):
+            inner.update(lambda value: {"n": value["n"] + 1})
+
+    threads = [threading.Thread(target=worker, daemon=True) for _ in range(n_threads)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(DEADLOCK_TIMEOUT)
+    assert state.value == {"inner": {"n": n_threads * n_updates}}
+
+
+@pytest.mark.timeout(30)
+def test_thread_start_does_not_hang_when_kernel_closes_before_bootstrap():
+    """The patched Thread bootstrap runs before Thread.start() returns.
+
+    If it raises (the kernel closed between Thread() and start(): the shell is
+    gone), the thread dies before setting the started flag and start() waits
+    forever. The bootstrap must fall back to running without a kernel context.
+    """
+    context = kernel_context.create_dummy_context()
+    with context:
+        thread = threading.Thread(target=lambda: None, daemon=True)
+    assert thread.current_context is context  # type: ignore
+    # the close tore down the kernel's shell, but did not set kernel=None yet
+    shell = context.kernel.shell
+    context.kernel.shell = None  # type: ignore
+
+    starter_done = threading.Event()
+
+    def start_it():
+        thread.start()
+        thread.join(DEADLOCK_TIMEOUT)
+        starter_done.set()
+
+    starter = threading.Thread(target=start_it, daemon=True)
+    starter.start()
+    try:
+        assert starter_done.wait(DEADLOCK_TIMEOUT), "Thread.start() hung: the patched bootstrap raised before the thread was marked started"
+    finally:
+        context.kernel.shell = shell
+        context.close()
+
+
+class _RacyDict(dict):
+    """A current_context whose items() snapshot is followed by a concurrent pop."""
+
+    def __init__(self, source, key):
+        super().__init__(source)
+        self._key = key
+
+    def items(self):
+        items = list(super().items())
+        self.pop(self._key, None)
+        return items
+
+
+@pytest.mark.timeout(30)
+def test_close_tolerates_thread_key_removed_concurrently(monkeypatch):
+    # _finish_close scans current_context for entries pointing at itself and removes them;
+    # a thread exiting at the same moment pops its own key. That must not abort the close:
+    # an aborted close never sets closed_event, and everybody waiting on it hangs.
+    context = kernel_context.create_dummy_context()
+    key = "some-thread-that-is-exiting"
+    racy = _RacyDict(kernel_context.current_context, key)
+    racy[key] = context
+    monkeypatch.setattr(kernel_context, "current_context", racy)
+    context.close()
+    assert context.closed_event.is_set()
+    assert key not in racy
+
+
+@pytest.mark.timeout(30)
+def test_run_in_thread_delivers_result_and_exception():
+    loop = asyncio.new_event_loop()
+    try:
+        assert loop.run_until_complete(kernel_context._run_in_thread(lambda: 42, name="t")) == 42
+
+        def boom():
+            raise ValueError("boom")
+
+        with pytest.raises(ValueError, match="boom"):
+            loop.run_until_complete(kernel_context._run_in_thread(boom, name="t"))
+    finally:
+        loop.close()
+
+
+@pytest.mark.timeout(30)
+def test_cull_resolves_disconnect_future_when_close_raises(monkeypatch):
+    # the caller of page_disconnect awaits the returned future; a close() that raises
+    # inside the cull must not leave it pending forever
+    monkeypatch.setattr(kernel_context.solara.server.settings.kernel, "cull_timeout", "0s")
+    context = kernel_context.create_dummy_context()
+    kernel_context.contexts[context.id] = context
+    real_close = context.close
+
+    def failing_close(reason="unknown"):
+        real_close(reason=reason)
+        raise RuntimeError("close failed")
+
+    monkeypatch.setattr(context, "close", failing_close)
+    loop = asyncio.new_event_loop()
+    try:
+
+        async def run():
+            context.page_connect("page")
+            future = context.page_disconnect("page")
+            await asyncio.wait_for(future, DEADLOCK_TIMEOUT)
+
+        loop.run_until_complete(run())
+    finally:
+        loop.close()
+    assert context.closed_event.is_set()
+
+
+@pytest.mark.timeout(30)
+def test_shutdown_close_is_bounded_by_the_deadline(caplog, monkeypatch):
+    # one kernel is stuck in an event handler (its lock is held); the other must still
+    # close, and the shutdown must return at the deadline, not when the handler ends
+    stuck = kernel_context.create_dummy_context()
+    stuck.id = "stuck"
+    free = kernel_context.create_dummy_context()
+    free.id = "free"
+    monkeypatch.setattr(kernel_context, "contexts", {"stuck": stuck, "free": free})
+    release = threading.Event()
+    acquired = threading.Event()
+
+    def handler():
+        with stuck.lock:
+            acquired.set()
+            release.wait(DEADLOCK_TIMEOUT * 2)
+
+    holder = threading.Thread(target=handler, daemon=True)
+    holder.start()
+    assert acquired.wait(DEADLOCK_TIMEOUT)
+    t0 = time.monotonic()
+    with caplog.at_level(logging.WARNING, logger="solara.server.fastapi"):
+        starlette_server._close_all_contexts(deadline_seconds=1.0)
+    elapsed = time.monotonic() - t0
+    try:
+        assert elapsed < DEADLOCK_TIMEOUT, "shutdown waited for the stuck handler"
+        assert free.closed_event.is_set()
+        assert not stuck.closed_event.is_set()
+        assert any("stuck" in record.getMessage() and "deadline" in record.getMessage() for record in caplog.records)
+    finally:
+        release.set()
+        holder.join(DEADLOCK_TIMEOUT)
+        assert stuck.closed_event.wait(DEADLOCK_TIMEOUT)
+
+
+@pytest.mark.timeout(30)
+def test_close_from_a_plain_thread_in_non_threaded_mode(monkeypatch):
+    # cull, evict and shutdown close kernels from plain threads. In non-threaded mode the
+    # context key comes from a ContextVar that such a thread never set; close() must still
+    # run to completion (and set closed_event) there.
+    monkeypatch.setattr(kernel_context.solara.server.settings.kernel, "threaded", False)
+    contexts = [kernel_context.create_dummy_context() for _ in range(2)]
+    for index, context in enumerate(contexts):
+        context.id = f"non-threaded-{index}"
+        kernel_context.contexts[context.id] = context
+    errors = []
+
+    def close(context):
+        try:
+            context.close(reason="evicted")
+        except BaseException as error:  # noqa
+            errors.append(error)
+
+    threads = [threading.Thread(target=close, args=(context,), daemon=True) for context in contexts]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(DEADLOCK_TIMEOUT)
+    assert not errors
+    for context in contexts:
+        assert context.closed_event.is_set()
+        assert context.id not in kernel_context.contexts
+        assert context not in kernel_context.current_context.values()


### PR DESCRIPTION
## Summary

Audit of releases 1.58-1.61 for deadlocks and leaks. Three lock cycles, all reproduced live before the fix:

- `context.close()` ran on the uvicorn event loop (evict route, lifespan shutdown) while the kernel's message thread holds `context.lock` for a whole handler and needs the loop for every widget update: evict hung the server permanently, shutdown with `--timeout-graceful-shutdown` left the loop dead for the handler's duration. Both now run off the loop; shutdown closes all kernels in parallel under a deadline (`SOLARA_SERVER_SHUTDOWN_CLOSE_TIMEOUT`, default 10s, daemon threads because the interpreter joins executor workers at exit).
- The cull ran `close()` inline on the shared keep-alive loop: one kernel wedged in a handler stalled the cull of every other kernel (a process-wide leak). It now closes on its own thread.
- `update()` and field sets fired listeners under the store lock; listeners render, reacton holds the render lock for the whole pass, and the render thread can need the store lock (with mutation detection even on a read). Stores now separate storing (`_set_deferred`, under the lock) from firing (after).

Found in review and also fixed: `Thread.start()` hang when the kernel closes between `Thread()` and `start()`; `close()` aborting on a KeyError before `closed_event`; `send_bytes` from the loop thread sending twice; in non-threaded mode `close()` from a plain thread raising on the unset context-id ContextVar; a reconnect marking a page connected on a kernel the cull had just decided to close (CLOSING is now set under the decision's lock hold).

Known trade-off, documented: two threads writing the same reactive at once may notify out of store order (plain `.value = x` never ordered either; every solara listener re-reads the store).

## Docs and tests

- `docs/deadlock-rules.md`: the lock inventory and six rules.
- `tests/unit/deadlock_test.py`: deterministic two-thread cycles for each rule, all red before the fix.
- `tests/integration/deadlock_test.py`: evict while a handler is busy (red with the inline close, green after).
- `docs/tla/`: PlusCal models; the lock model re-finds the three cycles under the old rules, the lifecycle model found the cull/reconnect race and validated its fix.

## Verification

Full unit suite green. Leak integration tests green; 10x10 memory harness on the kitchen-sink app shows no leak and a flat thread count. Live: evict returns while the loop keeps answering `/readyz`; SIGTERM with a 60s handler exits in 13.6s. Remaining integration failures in `server_test.py` and `test_reconnect_fail` are pre-existing on master (verified on a clean checkout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
